### PR TITLE
fix chain sync interface

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -16,6 +16,7 @@ use gw_generator::{
 };
 use gw_store::{Store, WrapStore};
 use gw_types::{
+    core::Status,
     packed::{
         AccountMerkleState, BlockMerkleState, CancelChallenge, DepositionRequest, GlobalState,
         HeaderInfo, L2Block, L2BlockReader, RawL2Block, StartChallenge, StartChallengeWitness,
@@ -27,16 +28,8 @@ use gw_types::{
     },
 };
 use parking_lot::Mutex;
-use std::sync::Arc;
 use std::time::SystemTime;
-
-/// Rollup status
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[repr(u8)]
-pub enum Status {
-    Running = 0,
-    Halting = 1,
-}
+use std::{convert::TryFrom, sync::Arc};
 
 /// Produce block param
 pub struct ProduceBlockParam {
@@ -78,6 +71,7 @@ pub struct L1Action {
     /// transactions' header info
     pub header_info: HeaderInfo,
     pub context: L1ActionContext,
+    pub global_state: GlobalState,
 }
 
 pub struct ProduceBlockResult {
@@ -86,6 +80,7 @@ pub struct ProduceBlockResult {
 }
 
 /// sync method returned events
+#[derive(Debug)]
 pub enum SyncEvent {
     // success
     Success,
@@ -100,53 +95,63 @@ pub enum SyncEvent {
     WaitChallenge,
 }
 
+impl PartialEq for SyncEvent {
+    fn eq(&self, other: &SyncEvent) -> bool {
+        use SyncEvent::*;
+        match (self, other) {
+            (Success, Success) => true,
+            (BadBlock(ctx1), BadBlock(ctx2)) => ctx1 == ctx2,
+            (
+                BadChallenge {
+                    witness: witness1,
+                    tx_receipt: tx_receipt1,
+                },
+                BadChallenge {
+                    witness: witness2,
+                    tx_receipt: tx_receipt2,
+                },
+            ) => tx_receipt1 == tx_receipt2 && witness1.as_slice() == witness2.as_slice(),
+            (WaitChallenge, WaitChallenge) => true,
+            _ => false,
+        }
+    }
+}
+impl Eq for SyncEvent {}
+
 /// concrete type aliases
 pub type StateStore = sparse_merkle_tree::default_store::DefaultStore<sparse_merkle_tree::H256>;
 pub type TxPoolImpl = TxPool<WrapStore<StateStore>>;
 
-pub struct LocaLState {
+pub struct LocalState {
     tip: L2Block,
     last_synced: HeaderInfo,
-    current_bad_block: Option<StartChallenge>,
-    status: Status,
+    last_global_state: GlobalState,
 }
 
-impl LocaLState {
-    fn new(tip: L2Block, last_synced: HeaderInfo, status: Status) -> Self {
-        LocaLState {
-            tip,
-            last_synced,
-            status,
-            current_bad_block: None,
-        }
-    }
-
-    /// return rollup status
-    pub fn status(&self) -> Status {
-        self.status
-    }
-
-    pub fn set_status(&mut self, status: Status) {
-        self.status = status;
-    }
-
+impl LocalState {
     pub fn tip(&self) -> &L2Block {
         &self.tip
+    }
+
+    pub fn status(&self) -> Status {
+        let status: u8 = self.last_global_state.status().into();
+        Status::try_from(status).expect("invalid status")
     }
 
     pub fn last_synced(&self) -> &HeaderInfo {
         &self.last_synced
     }
 
-    fn set_current_bad_block(&mut self, context: Option<StartChallenge>) {
-        self.current_bad_block = context;
+    pub fn last_global_state(&self) -> &GlobalState {
+        &self.last_global_state
     }
 }
 
 pub struct Chain {
     pub rollup_type_script_hash: [u8; 32],
     pub store: Store<StateStore>,
-    pub local_state: LocaLState,
+    pub bad_block_context: Option<StartChallenge>,
+    pub local_state: LocalState,
     pub generator: Generator,
     pub tx_pool: Arc<Mutex<TxPoolImpl>>,
 }
@@ -165,10 +170,16 @@ impl Chain {
             .ok_or(anyhow!("can't find tip from store"))?;
         let last_synced = store
             .get_block_synced_header_info(&tip.hash().into())?
-            .ok_or(anyhow!("can't find HeaderInfo of tip"))?;
-        let local_state = LocaLState::new(tip, last_synced, Status::Running);
+            .ok_or(anyhow!("can't find last synced header info"))?;
+        let last_global_state = store.get_tip_global_state()?;
+        let local_state = LocalState {
+            tip,
+            last_synced,
+            last_global_state,
+        };
         Ok(Chain {
             store,
+            bad_block_context: None,
             local_state,
             generator,
             tx_pool,
@@ -177,7 +188,7 @@ impl Chain {
     }
 
     /// return local state
-    pub fn local_state(&self) -> &LocaLState {
+    pub fn local_state(&self) -> &LocalState {
         &self.local_state
     }
 
@@ -197,17 +208,24 @@ impl Chain {
                 transaction,
                 header_info,
                 context,
+                global_state,
             } = action;
-            let block_number: u64 = header_info.number().unpack();
-            assert!(
-                block_number > {
+            assert_eq!(
+                {
+                    let number: u64 = header_info.number().unpack();
+                    number
+                },
+                {
                     let number: u64 = self.local_state.last_synced.number().unpack();
                     number
                 },
                 "must greater than last synced number"
             );
-
-            match (self.local_state.status(), context) {
+            let status = {
+                let status: u8 = self.local_state.last_global_state.status().into();
+                Status::try_from(status).expect("invalid status")
+            };
+            let event = match (status, context) {
                 (
                     Status::Running,
                     L1ActionContext::SubmitTxs {
@@ -217,47 +235,55 @@ impl Chain {
                     // Submit transactions
                     // parse layer2 block
                     let l2block = parse_l2block(&transaction, &self.rollup_type_script_hash)?;
-                    if let Some(challenge_context) =
-                        self.process_block(l2block, header_info, deposition_requests)?
-                    {
+                    if let Some(challenge_context) = self.process_block(
+                        l2block.clone(),
+                        header_info.clone(),
+                        deposition_requests,
+                    )? {
                         // stop syncing and return event
-                        self.local_state
-                            .set_current_bad_block(Some(challenge_context.args.clone()));
-                        return Ok(SyncEvent::BadBlock(challenge_context));
+                        self.bad_block_context = Some(challenge_context.args.clone());
+                        SyncEvent::BadBlock(challenge_context)
+                    } else {
+                        SyncEvent::Success
                     }
                 }
                 (Status::Running, L1ActionContext::Challenge { context }) => {
                     // Challenge
-                    self.local_state.set_status(Status::Halting);
-                    if let Some(current_bad_block) = self.local_state.current_bad_block.as_ref() {
+                    let status: u8 = global_state.status().into();
+                    assert_eq!(Status::try_from(status), Ok(Status::Halting));
+                    if let Some(current_bad_block) = self.bad_block_context.as_ref() {
                         if current_bad_block.as_slice() == context.as_slice() {
                             // bad block is in challenge, just wait.
                             return Ok(SyncEvent::WaitChallenge);
                         }
-                        return Ok(SyncEvent::WaitChallenge);
+                        SyncEvent::WaitChallenge
+                    } else {
+                        // now, either we haven't found a bad block or the challenge is challenge a validate block
+                        // in both cases the challenge is bad
+                        let witness = CancelChallenge::default();
+                        let tx_receipt = unimplemented!();
+                        SyncEvent::BadChallenge {
+                            witness,
+                            tx_receipt,
+                        }
                     }
-                    // now, either we haven't found a bad block or the challenge is challenge a validate block
-                    // in both cases the challenge is bad
-                    let witness = CancelChallenge::default();
-                    let tx_receipt = unimplemented!();
-                    return Ok(SyncEvent::BadChallenge {
-                        witness,
-                        tx_receipt,
-                    });
                 }
                 (Status::Halting, L1ActionContext::CancelChallenge { context: _ }) => {
-                    self.local_state.set_status(Status::Running);
+                    // TODO update states
+                    let status: u8 = global_state.status().into();
+                    assert_eq!(Status::try_from(status), Ok(Status::Running));
+                    SyncEvent::Success
                 }
                 (Status::Halting, L1ActionContext::Revert { context }) => {
-                    self.local_state.set_status(Status::Running);
+                    // TODO revert layer2 status
+                    let status: u8 = global_state.status().into();
+                    assert_eq!(Status::try_from(status), Ok(Status::Running));
                     assert_eq!(
-                        self.local_state
-                            .current_bad_block
-                            .as_ref()
-                            .map(|b| b.as_slice()),
+                        self.bad_block_context.as_ref().map(|b| b.as_slice()),
                         Some(context.as_slice()),
                         "revert from the bad block"
                     );
+                    SyncEvent::Success
                 }
                 (status, context) => {
                     panic!(
@@ -265,6 +291,15 @@ impl Chain {
                         status, context
                     );
                 }
+            };
+
+            // update last global state
+            self.local_state.last_global_state = global_state.clone();
+            self.local_state.last_synced = header_info;
+            self.store.set_tip_global_state(global_state)?;
+            // return to caller if any event happen
+            if event != SyncEvent::Success {
+                return Ok(event);
             }
         }
         // update tx pool state
@@ -322,12 +357,11 @@ impl Chain {
                 }
             }
         };
+
+        // update chain
         self.store
             .insert_block(l2block.clone(), header_info.clone(), result.receipts)?;
         self.store.attach_block(l2block.clone())?;
-
-        // update chain
-        self.local_state.last_synced = header_info;
         self.local_state.tip = l2block;
         Ok(None)
     }

--- a/crates/jsonrpc-types/src/genesis.rs
+++ b/crates/jsonrpc-types/src/genesis.rs
@@ -5,6 +5,8 @@ use gw_types::{packed, prelude::*, H256};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::godwoken::GlobalState;
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct BranchNode {
@@ -95,6 +97,7 @@ pub struct GenesisWithSMTState {
     pub genesis: JsonBytes,
     pub branches_map: Vec<BranchMapEntry>,
     pub leaves_map: Vec<LeafMapEntry>,
+    pub global_state: GlobalState,
 }
 
 impl From<GenesisWithSMTState> for genesis::GenesisWithSMTState {
@@ -120,6 +123,7 @@ impl From<GenesisWithSMTState> for genesis::GenesisWithSMTState {
                 .expect("Build packed::L2Block from slice"),
             branches_map,
             leaves_map,
+            global_state: genesis.global_state.into(),
         }
     }
 }
@@ -128,6 +132,7 @@ impl From<genesis::GenesisWithSMTState> for GenesisWithSMTState {
     fn from(genesis: genesis::GenesisWithSMTState) -> Self {
         GenesisWithSMTState {
             genesis: JsonBytes::from_bytes(genesis.genesis.as_bytes()),
+            global_state: genesis.global_state.into(),
             branches_map: genesis
                 .branches_map
                 .into_iter()

--- a/crates/jsonrpc-types/src/parameter.rs
+++ b/crates/jsonrpc-types/src/parameter.rs
@@ -2,12 +2,12 @@ use ckb_jsonrpc_types::{JsonBytes, Script as JsonScript, Uint32, Uint64};
 use ckb_types::packed as ckb_packed;
 use ckb_types::H256;
 use gw_chain::{chain, next_block_context};
-use gw_types::{packed, prelude::*};
+use gw_types::{core, packed, prelude::*};
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::godwoken::{CancelChallenge, ChallengeContext, TxReceipt};
+use crate::godwoken::{CancelChallenge, ChallengeContext, GlobalState, TxReceipt};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Default)]
 #[serde(rename_all = "snake_case")]
@@ -41,6 +41,7 @@ pub struct L1Action {
     /// transactions' header info
     pub header_info: JsonBytes,
     pub context: L1ActionContext,
+    pub global_state: GlobalState,
 }
 
 impl From<L1Action> for chain::L1Action {
@@ -49,6 +50,7 @@ impl From<L1Action> for chain::L1Action {
             transaction,
             header_info,
             context,
+            global_state,
         } = json;
         // let transaction_slice: &[u8] = transaction.into_bytes().as_ref();
         let transaction_bytes = transaction.into_bytes();
@@ -59,6 +61,7 @@ impl From<L1Action> for chain::L1Action {
             header_info: packed::HeaderInfo::from_slice(header_info_bytes.as_ref())
                 .expect("Build packed::HeaderInfo from slice"),
             context: context.into(),
+            global_state: global_state.into(),
         }
     }
 }
@@ -249,19 +252,19 @@ impl Default for Status {
     }
 }
 
-impl From<Status> for chain::Status {
+impl From<Status> for core::Status {
     fn from(json: Status) -> Self {
         match json {
-            Status::Running => chain::Status::Running,
-            Status::Halting => chain::Status::Halting,
+            Status::Running => core::Status::Running,
+            Status::Halting => core::Status::Halting,
         }
     }
 }
-impl From<chain::Status> for Status {
-    fn from(status: chain::Status) -> Self {
+impl From<core::Status> for Status {
+    fn from(status: core::Status) -> Self {
         match status {
-            chain::Status::Running => Status::Running,
-            chain::Status::Halting => Status::Halting,
+            core::Status::Running => Status::Running,
+            core::Status::Halting => Status::Halting,
         }
     }
 }

--- a/crates/types/src/core.rs
+++ b/crates/types/src/core.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use molecule::prelude::Byte;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -15,5 +17,24 @@ impl Into<u8> for ScriptHashType {
 impl Into<Byte> for ScriptHashType {
     fn into(self) -> Byte {
         (self as u8).into()
+    }
+}
+
+/// Rollup status
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[repr(u8)]
+pub enum Status {
+    Running = 0,
+    Halting = 1,
+}
+
+impl TryFrom<u8> for Status {
+    type Error = u8;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Status::Running),
+            1 => Ok(Status::Halting),
+            n => return Err(n),
+        }
     }
 }

--- a/packages/godwoken/native/src/lib.rs
+++ b/packages/godwoken/native/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use gw_chain::{
-    chain::{Chain, ProduceBlockParam, ProduceBlockResult, Status, SyncEvent, SyncParam},
+    chain::{Chain, ProduceBlockParam, ProduceBlockResult, SyncEvent, SyncParam},
     next_block_context::NextBlockContext,
     tx_pool::TxPool,
 };
@@ -14,7 +14,7 @@ use gw_store::{
     genesis::{build_genesis, GenesisWithSMTState},
     Store,
 };
-use gw_types::{packed, prelude::*};
+use gw_types::{core::Status, packed, prelude::*};
 use neon::prelude::*;
 use parking_lot::Mutex;
 use std::sync::{Arc, RwLock};


### PR DESCRIPTION
* Add `global_state: GlobaState` field on L1Action. (The output global state of the transaction.)
* Use u8 to represent status.
* `build_genesis` function returns the global_state for initialize the rollup cell.