### PR TITLE
feat: Readonly mode

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -21,9 +21,9 @@ program
     "-s, --sql-connection <sqlConnection>",
     "PostgreSQL connection striong"
   )
-  .requiredOption(
+  .option(
     "-p, --private-key <privateKey>",
-    "aggregator private key to use"
+    "aggregator private key to use, when omitted, readOnly mode will be used"
   )
   .option("-l, --listen <listen>", "JSONRPC listen path", "8119");
 program.parse(argv);
@@ -57,6 +57,7 @@ function defaultLogger(level: Level, message: string) {
 const jsonrpcServer = new JsonrpcServer(
   chainService,
   program.listen,
+  !!program.privateKey,
   defaultLogger
 );
 

--- a/packages/runner/src/jsonrpc_server.ts
+++ b/packages/runner/src/jsonrpc_server.ts
@@ -20,14 +20,15 @@ export class JsonrpcServer {
   logger: Logger;
   listen: string;
 
-  constructor(chainService: ChainService, listen: string, logger: Logger) {
+  constructor(
+    chainService: ChainService,
+    listen: string,
+    readOnlyMode: boolean,
+    logger: Logger
+  ) {
     this.chainService = chainService;
-    this.server = new jayson.Server({
-      gw_submitL2Transaction: this.wrapWithLogger(this.submitL2Transaction),
+    let methods = {
       gw_executeL2Tranaction: this.wrapWithLogger(this.executeL2Transaction),
-      gw_submitWithdrawalRequest: this.wrapWithLogger(
-        this.submitWithdrawalRequest
-      ),
       gw_getBalance: this.wrapWithLogger(this.getBalance),
       gw_getStorageAt: this.wrapWithLogger(this.getStorageAt),
       gw_getAccountIdByScriptHash: this.wrapWithLogger(
@@ -38,7 +39,16 @@ export class JsonrpcServer {
       gw_getScriptHash: this.wrapWithLogger(this.getScriptHash),
       gw_getData: this.wrapWithLogger(this.getData),
       gw_getDataHash: this.wrapWithLogger(this.getDataHash),
-    });
+    };
+    if (!readOnlyMode) {
+      methods = Object.assign({}, methods, {
+        gw_submitL2Transaction: this.wrapWithLogger(this.submitL2Transaction),
+        gw_submitWithdrawalRequest: this.wrapWithLogger(
+          this.submitWithdrawalRequest
+        ),
+      });
+    }
+    this.server = new jayson.Server(methods);
     this.listen = listen;
     this.logger = logger;
   }


### PR DESCRIPTION
This change provides a new readonly mode. Readonly mode is triggered
when aggregator private key is missing. Godwoken will then start a
server which only syncs changes, but make no L2 block submissions.

For now, submitL2Transaction/submitWithdrawalRequest are also
missing. Later when we integrate a proper transaction pool, those can
be enabled as well in readonly mode.