### PR TITLE
Update snapshot interface

### DIFF
--- a/crates/block-producer/src/block_producer.rs
+++ b/crates/block-producer/src/block_producer.rs
@@ -7,7 +7,10 @@ use gw_common::{
     h256_ext::H256Ext, merkle_utils::calculate_merkle_root, smt::Blake2bHasher, state::State, H256,
 };
 use gw_generator::{traits::StateExt, Generator};
-use gw_store::{transaction::StoreTransaction, Snapshot};
+use gw_store::{
+    snapshot::{Snapshot, SnapshotKey},
+    transaction::StoreTransaction,
+};
 use gw_types::{
     core::Status,
     packed::{
@@ -61,11 +64,8 @@ pub fn produce_block<'a>(param: ProduceBlockParam<'a>) -> Result<ProduceBlockRes
     let db = Rc::new(db);
     // create overlay storage
     let mut state = {
-        let tip_block = db.get_tip_block()?;
-        let tip_block_hash = tip_block.hash().into();
-        // the latest state
-        let account_state_root = tip_block.raw().post_account().merkle_root().unpack();
-        Snapshot::storage_at(db.clone(), tip_block_hash, account_state_root)?
+        let tip_block_hash = db.get_tip_block_hash()?;
+        Snapshot::storage_at(db.clone(), SnapshotKey::AtBlock(tip_block_hash))?
     };
     let prev_account_state_root = state.calculate_root()?;
     let prev_account_state_count = state.get_account_count()?;

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -1,8 +1,7 @@
 mod db_utils;
-mod snapshot;
+pub mod snapshot;
 mod store_impl;
 pub mod transaction;
 mod write_batch;
 
-pub use snapshot::Snapshot;
 pub use store_impl::Store;

--- a/crates/store/src/snapshot.rs
+++ b/crates/store/src/snapshot.rs
@@ -22,6 +22,16 @@ use gw_types::{
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
+/// SnapshotKey
+/// Represent a history point of the db.
+/// In the db representation we convert it to prefix key: <raw-key>-<block-number>-<tx-index>
+pub enum SnapshotKey {
+    // get snapshot of db after processed the block
+    AtBlock(H256),
+    // get snapshot of db after processed the transaction
+    AtTx { block_hash: H256, tx_index: u32 },
+}
+
 /// Represent a history point,
 /// changes on Snapshot won't affect the main chain db
 pub struct Snapshot {
@@ -36,13 +46,8 @@ impl Snapshot {
     /// Get snapshot at a history point
     ///
     /// - db, StoreTransaction that contains all main chain state
-    /// - tip_block_hash, The tip block hash of a history point
-    /// - account_state_root, Account state root of a history point
-    pub fn storage_at(
-        db: Rc<StoreTransaction>,
-        _tip_block_hash: H256,
-        _account_state_root: H256,
-    ) -> Result<Self> {
+    /// - key, Represents a history point
+    pub fn storage_at(db: Rc<StoreTransaction>, _key: SnapshotKey) -> Result<Self> {
         let root = db.get_account_smt_root()?;
         let account_count = db.get_account_count()?;
         let smt_store = OverlaySMTStore::new(db.clone());

--- a/crates/store/src/store_impl.rs
+++ b/crates/store/src/store_impl.rs
@@ -1,6 +1,6 @@
 use super::snapshot::Snapshot;
-use crate::transaction::StoreTransaction;
 use crate::write_batch::StoreWriteBatch;
+use crate::{snapshot::SnapshotKey, transaction::StoreTransaction};
 use anyhow::Result;
 use gw_common::{error::Error, smt::H256};
 use gw_db::{
@@ -69,10 +69,9 @@ impl<'a> Store {
     }
 
     /// Return a snapshot of a history point
-    /// TODO implemente the snapshot
-    pub fn storage_at(&self, tip_block_hash: H256, account_state_root: H256) -> Result<Snapshot> {
+    pub fn storage_at(&self, key: SnapshotKey) -> Result<Snapshot> {
         let db = self.begin_transaction();
-        Snapshot::storage_at(Rc::new(db), tip_block_hash, account_state_root)
+        Snapshot::storage_at(Rc::new(db), key)
     }
 
     pub fn get_chain_id(&self) -> Result<H256, Error> {


### PR DESCRIPTION
The SMT implementation can't support the previous design, so we choice a new way.