### PR TITLE
Enable persistent storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "gw-chain",
  "gw-common",
  "gw-config",
+ "gw-db",
  "gw-generator",
  "gw-jsonrpc-types",
  "gw-mem-pool",

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -16,6 +16,7 @@ gw-common = { path = "../common" }
 gw-config = { path = "../config" }
 gw-chain = { path = "../chain" }
 gw-types = { path = "../types" }
+gw-db = { path = "../db" }
 gw-store = { path = "../store" }
 gw-generator = { path = "../generator" }
 gw-mem-pool = { path = "../mem-pool" }

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -116,9 +116,8 @@ pub fn generate_config(
         generator_path: format!("{}/polyjuice-generator", polyjuice_binaries_dir).into(),
         validator_script_type_hash: scripts.polyjuice_validator.script_type_hash.clone(),
     });
-    let store: StoreConfig = StoreConfig {
-        path: "./store.db".into(),
-    };
+    // FIXME change to a directory path after we tested the persist storage
+    let store: StoreConfig = StoreConfig { path: "".into() };
     let genesis_committed_info = L2BlockCommittedInfo {
         block_hash,
         number,


### PR DESCRIPTION
* Enable persistent storage if `config.store.path` is not an empty path, otherwise we still using temporary storage.
* Update the `generate-config` command to generate an empty `config.store.path`. We should set the path to a directory after we fully tested the persistent storage feature.