### PR TITLE
Register secp256k1 data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ dependencies = [
  "ckb-fixed-hash",
  "ckb-hash",
  "ckb-jsonrpc-types",
+ "ckb-resource",
  "ckb-sdk",
  "ckb-types",
  "clap",

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -137,7 +137,7 @@ pub fn run(config: Config) -> Result<()> {
     // TODO: use persistent store later
     let store = Store::open_tmp().with_context(|| "init store")?;
     let secp_data: Bytes = {
-        let out_point = block_producer_config.secp_data_dep.out_point.clone();
+        let out_point = config.genesis.secp_data_dep.out_point.clone();
         block_on(rpc_client.get_transaction(out_point.tx_hash.0.into()))?
             .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?
             .raw()

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use async_jsonrpc_client::HttpClient;
-use futures::{select, FutureExt};
+use futures::{executor::block_on, select, FutureExt};
 use gw_chain::chain::Chain;
 use gw_common::H256;
 use gw_config::Config;
@@ -18,6 +18,7 @@ use gw_mem_pool::pool::MemPool;
 use gw_rpc_server::{registry::Registry, server::start_jsonrpc_server};
 use gw_store::Store;
 use gw_types::{
+    bytes::Bytes,
     packed::{NumberHash, RollupConfig, Script},
     prelude::*,
 };
@@ -107,14 +108,11 @@ async fn poll_loop(
 
 pub fn run(config: Config) -> Result<()> {
     let rollup_config: RollupConfig = config.genesis.rollup_config.clone().into();
-    // TODO: use persistent store later
-    let store = Store::open_tmp().with_context(|| "init store")?;
-    init_genesis(
-        &store,
-        &config.genesis,
-        config.chain.genesis_committed_info.clone().into(),
-    )
-    .with_context(|| "init genesis")?;
+    let block_producer_config = config
+        .block_producer
+        .clone()
+        .ok_or_else(|| anyhow!("not set block producer"))?;
+
     let rollup_context = RollupContext {
         rollup_config: rollup_config.clone(),
         rollup_script_hash: {
@@ -122,6 +120,39 @@ pub fn run(config: Config) -> Result<()> {
             rollup_script_hash.into()
         },
     };
+    let rollup_type_script: Script = config.chain.rollup_type_script.clone().into();
+    let rpc_client = {
+        let indexer_client = HttpClient::new(config.rpc_client.indexer_url)?;
+        let ckb_client = HttpClient::new(config.rpc_client.ckb_url)?;
+        let rollup_type_script =
+            ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
+        RPCClient {
+            indexer_client,
+            ckb_client,
+            rollup_context: rollup_context.clone(),
+            rollup_type_script,
+        }
+    };
+
+    // TODO: use persistent store later
+    let store = Store::open_tmp().with_context(|| "init store")?;
+    let secp_data: Bytes = {
+        let out_point = block_producer_config.secp_data_dep.out_point.clone();
+        block_on(rpc_client.get_transaction(out_point.tx_hash.0.into()))?
+            .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?
+            .raw()
+            .outputs_data()
+            .get(out_point.index.value() as usize)
+            .expect("get secp output data")
+            .raw_data()
+    };
+    init_genesis(
+        &store,
+        &config.genesis,
+        config.chain.genesis_committed_info.clone().into(),
+        secp_data,
+    )
+    .with_context(|| "init genesis")?;
 
     let rollup_config_hash = rollup_config.hash().into();
     let generator = {
@@ -155,20 +186,6 @@ pub fn run(config: Config) -> Result<()> {
         )
         .with_context(|| "create chain")?,
     ));
-
-    let rollup_type_script: Script = config.chain.rollup_type_script.into();
-    let rpc_client = {
-        let indexer_client = HttpClient::new(config.rpc_client.indexer_url)?;
-        let ckb_client = HttpClient::new(config.rpc_client.ckb_url)?;
-        let rollup_type_script =
-            ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
-        RPCClient {
-            indexer_client,
-            ckb_client,
-            rollup_context: rollup_context.clone(),
-            rollup_type_script,
-        }
-    };
 
     // RPC registry
     let rpc_registry = Registry::new(mem_pool.clone(), store.clone());
@@ -222,9 +239,7 @@ pub fn run(config: Config) -> Result<()> {
         mem_pool,
         rpc_client.clone(),
         ckb_genesis_info,
-        config
-            .block_producer
-            .ok_or_else(|| anyhow!("not set block producer"))?,
+        block_producer_config,
     )
     .with_context(|| "init block producer")?;
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -43,6 +43,8 @@ pub struct GenesisConfig {
     pub rollup_type_hash: H256,
     pub meta_contract_validator_type_hash: H256,
     pub rollup_config: RollupConfig,
+    // For load secp data and use in challenge transaction
+    pub secp_data_dep: CellDep,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
@@ -60,8 +62,6 @@ pub struct BlockProducerConfig {
     pub stake_cell_lock_dep: CellDep,
     pub poa_lock_dep: CellDep,
     pub poa_state_dep: CellDep,
-    // For load secp data and use in challenge transaction
-    pub secp_data_dep: CellDep,
     pub wallet_config: WalletConfig,
 }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -60,6 +60,8 @@ pub struct BlockProducerConfig {
     pub stake_cell_lock_dep: CellDep,
     pub poa_lock_dep: CellDep,
     pub poa_state_dep: CellDep,
+    // For load secp data and use in challenge transaction
+    pub secp_data_dep: CellDep,
     pub wallet_config: WalletConfig,
 }
 

--- a/crates/generator/src/tests/genesis.rs
+++ b/crates/generator/src/tests/genesis.rs
@@ -28,6 +28,7 @@ fn test_init_genesis() {
         meta_contract_validator_type_hash: meta_contract_code_hash.into(),
         rollup_config: RollupConfig::default().into(),
         rollup_type_hash: rollup_script_hash.into(),
+        secp_data_dep: Default::default(),
     };
     let genesis = build_genesis(&config, Bytes::default()).unwrap();
     let genesis_block_hash: [u8; 32] = genesis.genesis.hash();

--- a/crates/generator/src/tests/genesis.rs
+++ b/crates/generator/src/tests/genesis.rs
@@ -29,12 +29,12 @@ fn test_init_genesis() {
         rollup_config: RollupConfig::default().into(),
         rollup_type_hash: rollup_script_hash.into(),
     };
-    let genesis = build_genesis(&config).unwrap();
+    let genesis = build_genesis(&config, Bytes::default()).unwrap();
     let genesis_block_hash: [u8; 32] = genesis.genesis.hash();
     assert_eq!(genesis_block_hash, GENESIS_BLOCK_HASH);
     let genesis_committed_info = L2BlockCommittedInfo::default();
     let store: Store = Store::open_tmp().unwrap();
-    init_genesis(&store, &config, genesis_committed_info).unwrap();
+    init_genesis(&store, &config, genesis_committed_info, Bytes::default()).unwrap();
     let db = store.begin_transaction();
     // check init values
     assert_ne!(db.get_block_smt_root().unwrap(), H256::zero());

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -108,7 +108,13 @@ pub fn setup_chain_with_account_lock_manage(
         account_lock_manage,
         rollup_context.clone(),
     ));
-    init_genesis(&store, &genesis_config, genesis_committed_info).unwrap();
+    init_genesis(
+        &store,
+        &genesis_config,
+        genesis_committed_info,
+        Bytes::default(),
+    )
+    .unwrap();
     let mem_pool = MemPool::create(store.clone(), Arc::clone(&generator)).unwrap();
     Chain::create(
         &rollup_config,

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -96,6 +96,7 @@ pub fn setup_chain_with_account_lock_manage(
         meta_contract_validator_type_hash: Default::default(),
         rollup_config: rollup_config.clone().into(),
         rollup_type_hash: rollup_script_hash.into(),
+        secp_data_dep: Default::default(),
     };
     let genesis_committed_info = L2BlockCommittedInfo::default();
     let backend_manage = build_backend_manage(&rollup_config);

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -21,6 +21,7 @@ secp256k1 = "0.17"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 ckb-jsonrpc-types = "0.38.0"
 ckb-types = "0.38.0"
+ckb-resource = "0.38.0"
 ckb-hash = "0.38.0"
 ckb-fixed-hash = "0.38.0"
 ckb-sdk = { git = "https://github.com/jjyr/ckb-cli.git", branch = "ckb-v0.38.0" }

--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -237,6 +237,7 @@ pub fn deploy_genesis(
         .allowed_eoa_type_hashes(GwPackVec::pack(allowed_eoa_type_hashes))
         .allowed_contract_type_hashes(GwPackVec::pack(allowed_contract_type_hashes))
         .build();
+    let (secp_data, secp_data_dep) = get_secp_data(&mut rpc_client)?;
     let genesis_config = GenesisConfig {
         timestamp,
         meta_contract_validator_type_hash: deployment_result
@@ -245,8 +246,8 @@ pub fn deploy_genesis(
             .clone(),
         rollup_type_hash: rollup_script_hash.clone(),
         rollup_config: rollup_config.clone().into(),
+        secp_data_dep,
     };
-    let (secp_data, _cell_dep) = get_secp_data(&mut rpc_client)?;
     let genesis_with_global_state =
         build_genesis(&genesis_config, secp_data).map_err(|err| err.to_string())?;
 

--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -8,6 +8,7 @@ use tempfile::NamedTempFile;
 use ckb_fixed_hash::H256;
 use ckb_hash::new_blake2b;
 use ckb_jsonrpc_types as rpc_types;
+use ckb_resource::CODE_HASH_SECP256K1_DATA;
 use ckb_sdk::{
     calc_max_mature_number,
     constants::{CELLBASE_MATURITY, MIN_SECP_CELL_CAPACITY, ONE_CKB},
@@ -245,8 +246,9 @@ pub fn deploy_genesis(
         rollup_type_hash: rollup_script_hash.clone(),
         rollup_config: rollup_config.clone().into(),
     };
+    let (secp_data, _cell_dep) = get_secp_data(&mut rpc_client)?;
     let genesis_with_global_state =
-        build_genesis(&genesis_config).map_err(|err| err.to_string())?;
+        build_genesis(&genesis_config, secp_data).map_err(|err| err.to_string())?;
 
     // 2. build rollup cell (with type id)
     let (rollup_output, rollup_data): (ckb_packed::CellOutput, Bytes) = {
@@ -651,4 +653,38 @@ pub fn is_mature(number: u64, tx_index: u64, max_mature_number: u64) -> bool {
     // Live cells in genesis are all mature
         || number == 0
         || number <= max_mature_number
+}
+
+pub fn get_secp_data(
+    rpc_client: &mut HttpRpcClient,
+) -> Result<(Bytes, gw_jsonrpc_types::blockchain::CellDep), String> {
+    let mut cell_dep = None;
+    rpc_client
+        .get_block_by_number(0)?
+        .expect("get CKB genesis block")
+        .transactions
+        .iter()
+        .for_each(|tx| {
+            tx.inner
+                .outputs_data
+                .iter()
+                .enumerate()
+                .for_each(|(output_index, data)| {
+                    let data_hash = ckb_types::packed::CellOutput::calc_data_hash(data.as_bytes());
+                    if data_hash.as_slice() == CODE_HASH_SECP256K1_DATA.as_bytes() {
+                        let out_point = gw_jsonrpc_types::blockchain::OutPoint {
+                            tx_hash: tx.hash.clone(),
+                            index: (output_index as u32).into(),
+                        };
+                        cell_dep = Some((
+                            data.clone().into_bytes(),
+                            gw_jsonrpc_types::blockchain::CellDep {
+                                out_point,
+                                dep_type: gw_jsonrpc_types::blockchain::DepType::Code,
+                            },
+                        ));
+                    }
+                });
+        });
+    cell_dep.ok_or_else(|| "Can not found secp data cell in CKB genesis block".to_string())
 }

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use crate::deploy_genesis::GenesisDeploymentResult;
+use crate::deploy_genesis::{get_secp_data, GenesisDeploymentResult};
 use crate::deploy_scripts::ScriptsDeploymentResult;
 use anyhow::{anyhow, Result};
 use ckb_sdk::HttpRpcClient;
@@ -82,6 +82,8 @@ pub fn generate_config(
         let dep: ckb_types::packed::CellDep = scripts.stake_lock.cell_dep.clone().into();
         gw_types::packed::CellDep::new_unchecked(dep.as_bytes()).into()
     };
+    let (_data, secp_data_dep) =
+        get_secp_data(&mut rpc_client).map_err(|err| anyhow!("{}", err))?;
 
     let wallet_config: WalletConfig = WalletConfig { privkey_path, lock };
 
@@ -129,6 +131,7 @@ pub fn generate_config(
         rollup_cell_type_dep,
         deposit_cell_lock_dep,
         stake_cell_lock_dep,
+        secp_data_dep,
         wallet_config,
     });
     let genesis: GenesisConfig = GenesisConfig {

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -131,7 +131,6 @@ pub fn generate_config(
         rollup_cell_type_dep,
         deposit_cell_lock_dep,
         stake_cell_lock_dep,
-        secp_data_dep,
         wallet_config,
     });
     let genesis: GenesisConfig = GenesisConfig {
@@ -139,6 +138,7 @@ pub fn generate_config(
         rollup_type_hash,
         meta_contract_validator_type_hash,
         rollup_config,
+        secp_data_dep,
     };
     let eth_account_lock_hash = genesis
         .rollup_config


### PR DESCRIPTION
Register secp256k1 data for `ecrecover` pre-compiled EVM contract to use.

NOTE: this PR add a config field (`secp_data_dep`) in `BlockProducerConfig`, which is a **BREAKING CHANGE** in config, and user should re-generate the `config.toml` config file.
