### PR TITLE
feat: Support block parameter

### DIFF
--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -240,7 +240,10 @@ impl MemPool {
         block_hash: H256,
     ) -> Result<RunResult> {
         let db = self.store.begin_transaction();
-        let state_db = self.fetch_state_db(&db)?;
+        let state_db = StateDBTransaction::from_version(
+            &db,
+            StateDBVersion::from_history_state(&db, block_hash, None)?,
+        )?;
         let state = state_db.account_state_tree()?;
         let chain_view = ChainView::new(&db, block_hash);
         // execute tx

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -237,12 +237,12 @@ impl MemPool {
         &self,
         raw_tx: RawL2Transaction,
         block_info: &BlockInfo,
+        block_hash: H256,
     ) -> Result<RunResult> {
         let db = self.store.begin_transaction();
         let state_db = self.fetch_state_db(&db)?;
         let state = state_db.account_state_tree()?;
-        let tip_block_hash = self.store.get_tip_block_hash()?;
-        let chain_view = ChainView::new(&db, tip_block_hash);
+        let chain_view = ChainView::new(&db, block_hash);
         // execute tx
         let run_result =
             self.generator

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -182,7 +182,6 @@ async fn execute_raw_l2transaction(
     let raw_l2tx_bytes = raw_l2tx.into_bytes();
     let raw_l2tx = packed::RawL2Transaction::from_slice(&raw_l2tx_bytes)?;
 
-    // let raw_block = store.get_tip_block()?.raw();
     let raw_block = match db.get_block(&block_hash)? {
         Some(block) => block.raw(),
         None => return Ok(None),


### PR DESCRIPTION
This PR add `block_number` parameter to JSON RPC `get_balance | get_storage_at | get_nonce | execute_raw_l2transaction`:

1. The response value would be wrapped as `option`, when `block_number` > `tip_block_number`, it just returns `None`;
2. The `execute_raw_l2transaction` impl is still not decoupled from mem_pool, as it needs  accessing `generator` to [execute_transaction](https://github.com/nervosnetwork/godwoken/pull/182/files#diff-99a766892812406083a959acd68f0fd2a6f62ff590f6187457f62038b499f76eR251);
