### PR TITLE
Add syscall: get script hash by prefix

### DIFF
--- a/crates/db/src/schema.rs
+++ b/crates/db/src/schema.rs
@@ -3,7 +3,7 @@
 /// Column families alias type
 pub type Col = u8;
 /// Total column number
-pub const COLUMNS: u32 = 19;
+pub const COLUMNS: u32 = 20;
 /// Column store meta data
 pub const COLUMN_META: Col = 0;
 /// Column store chain index
@@ -42,6 +42,8 @@ pub const COLUMN_BLOCK_DEPOSITION_REQUESTS: Col = 16;
 pub const COLUMN_CUSTODIAN_ASSETS: Col = 17;
 /// Column block state record
 pub const COLUMN_BLOCK_STATE_RECORD: Col = 18;
+/// Column script prefix
+pub const COLUMN_SCRIPT_PREFIX: Col = 19;
 
 /// chain id
 pub const META_CHAIN_ID_KEY: &[u8] = b"CHAIN_ID";

--- a/crates/generator/src/dummy_state.rs
+++ b/crates/generator/src/dummy_state.rs
@@ -46,7 +46,8 @@ impl CodeStore for DummyState {
     }
     fn get_script_hash_by_prefix(&self, script_hash_prefix: &[u8]) -> Option<H256> {
         self.scripts.iter().find_map(|(script_hash, _script)| {
-            if script_hash.as_slice() == script_hash_prefix {
+            let prefix_len = script_hash_prefix.len();
+            if &script_hash.as_slice()[..prefix_len] == script_hash_prefix {
                 Some(*script_hash)
             } else {
                 None

--- a/crates/generator/src/dummy_state.rs
+++ b/crates/generator/src/dummy_state.rs
@@ -44,6 +44,15 @@ impl CodeStore for DummyState {
     fn get_script(&self, script_hash: &H256) -> Option<Script> {
         self.scripts.get(&script_hash).cloned()
     }
+    fn get_script_hash_by_prefix(&self, script_hash_prefix: &[u8]) -> Option<H256> {
+        self.scripts.iter().find_map(|(script_hash, _script)| {
+            if script_hash.as_slice() == script_hash_prefix {
+                Some(*script_hash)
+            } else {
+                None
+            }
+        })
+    }
     fn insert_data(&mut self, script_hash: H256, code: Bytes) {
         self.codes.insert(script_hash, code);
     }

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -5,6 +5,7 @@ use gw_types::{bytes::Bytes, packed::Script};
 pub trait CodeStore {
     fn insert_script(&mut self, script_hash: H256, script: Script);
     fn get_script(&self, script_hash: &H256) -> Option<Script>;
+    fn get_script_hash_by_prefix(&self, script_hash_prefix: &[u8]) -> Option<H256>;
     fn insert_data(&mut self, data_hash: H256, code: Bytes);
     fn get_data(&self, data_hash: &H256) -> Option<Bytes>;
 }


### PR DESCRIPTION
* Add new syscall: get_script_hash_by_prefix, which allows us to search script_hash with a 20-bytes prefix string
* Adjust syscall error codes https://github.com/nervosnetwork/godwoken/pull/195/files#diff-16f67f4822618c8e4616f5d07b43084312bdba514bf01f1c696cd16a86a6d496R54
* Change the behavior of syscall `SYS_LOAD_ACCOUNT_ID_BY_SCRIPT_HASH` & `SYS_LOAD_DATA`, return error code if not found instead of terminating the execution.