### PR TITLE
feat(statedb): support loading from checkpoint state

### DIFF
--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -79,7 +79,7 @@ pub fn produce_block(param: ProduceBlockParam<'_>) -> Result<ProduceBlockResult>
         StateDBTransaction::from_checkpoint(
             &db,
             CheckPoint::from_block_hash(&db, tip_block_hash, SubState::Block)?,
-            StateDBMode::Write,
+            StateDBMode::ReadOnly,
         )?
     };
     let mut state = state_db.account_state_tree()?;

--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -15,7 +15,7 @@ use gw_common::{
 use gw_generator::{traits::StateExt, Generator};
 use gw_store::{
     chain_view::ChainView,
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
     transaction::StoreTransaction,
 };
 use gw_types::{
@@ -76,9 +76,10 @@ pub fn produce_block(param: ProduceBlockParam<'_>) -> Result<ProduceBlockResult>
     let state_db = {
         let tip_block_hash = db.get_tip_block_hash()?;
         assert_eq!(parent_block_hash, tip_block_hash);
-        StateDBTransaction::from_version(
+        StateDBTransaction::from_checkpoint(
             &db,
-            StateDBVersion::from_history_state(&db, tip_block_hash, None)?,
+            CheckPoint::from_block_hash(&db, tip_block_hash, SubState::Block)?,
+            StateDBMode::Write,
         )?
     };
     let mut state = state_db.account_state_tree()?;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -6,7 +6,7 @@ use gw_generator::{
 use gw_mem_pool::pool::MemPool;
 use gw_store::{
     chain_view::ChainView,
-    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState, WriteContext},
     transaction::StoreTransaction,
     Store,
 };
@@ -460,7 +460,7 @@ impl Chain {
         let state_db = StateDBTransaction::from_checkpoint(
             db,
             CheckPoint::new(block_number, SubState::Block),
-            StateDBMode::Write,
+            StateDBMode::Write(WriteContext::from_block(&l2block)),
         )?;
         let mut tree = state_db.account_state_tree()?;
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -460,7 +460,7 @@ impl Chain {
         let state_db = StateDBTransaction::from_checkpoint(
             db,
             CheckPoint::new(block_number, SubState::Block),
-            StateDBMode::Write(WriteContext::from_block(&l2block)),
+            StateDBMode::Write(WriteContext::new(l2block.withdrawals().len() as u32)),
         )?;
         let mut tree = state_db.account_state_tree()?;
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -6,7 +6,7 @@ use gw_generator::{
 use gw_mem_pool::pool::MemPool;
 use gw_store::{
     chain_view::ChainView,
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
     transaction::StoreTransaction,
     Store,
 };
@@ -342,9 +342,10 @@ impl Chain {
 
                     // check current state
                     let expected_state = l2block.raw().prev_account();
-                    let state_db = StateDBTransaction::from_version(
+                    let state_db = StateDBTransaction::from_checkpoint(
                         &db,
-                        StateDBVersion::from_history_state(&db, tip_block_hash, None)?,
+                        CheckPoint::from_block_hash(&db, tip_block_hash, SubState::Block)?,
+                        StateDBMode::ReadOnly,
                     )?;
                     let tree = state_db.account_state_tree()?;
                     let expected_root: H256 = expected_state.merkle_root().unpack();
@@ -405,13 +406,14 @@ impl Chain {
                 .post_account()
                 .merkle_root()
                 .unpack();
-            let state_db = StateDBTransaction::from_version(
+            let state_db = StateDBTransaction::from_checkpoint(
                 &db,
-                StateDBVersion::from_history_state(
+                CheckPoint::from_block_hash(
                     &db,
                     self.local_state.tip().hash().into(),
-                    None,
+                    SubState::Block,
                 )?,
+                StateDBMode::ReadOnly,
             )?;
             assert_eq!(
                 state_db.account_smt().unwrap().root(),
@@ -455,9 +457,10 @@ impl Chain {
         };
         let tip_block_hash = self.local_state.tip().hash().into();
         let chain_view = ChainView::new(db, tip_block_hash);
-        let state_db = StateDBTransaction::from_version(
+        let state_db = StateDBTransaction::from_checkpoint(
             db,
-            StateDBVersion::from_future_state(block_number, 0),
+            CheckPoint::new(block_number, SubState::Block),
+            StateDBMode::Write,
         )?;
         let mut tree = state_db.account_state_tree()?;
 
@@ -505,6 +508,7 @@ impl Chain {
             l2block_committed_info,
             global_state,
             result.receipts,
+            result.post_states,
             deposition_requests,
         )?;
         let rollup_config = &self.generator.rollup_context().rollup_config;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -507,8 +507,8 @@ impl Chain {
             l2block.clone(),
             l2block_committed_info,
             global_state,
-            result.receipts,
-            result.post_states,
+            result.tx_receipts,
+            result.withdrawal_receipts,
             deposition_requests,
         )?;
         let rollup_config = &self.generator.rollup_context().rollup_config;

--- a/crates/db/src/schema.rs
+++ b/crates/db/src/schema.rs
@@ -3,7 +3,7 @@
 /// Column families alias type
 pub type Col = u8;
 /// Total column number
-pub const COLUMNS: u32 = 20;
+pub const COLUMNS: u32 = 21;
 /// Column store meta data
 pub const COLUMN_META: Col = 0;
 /// Column store chain index
@@ -44,6 +44,8 @@ pub const COLUMN_CUSTODIAN_ASSETS: Col = 17;
 pub const COLUMN_BLOCK_STATE_RECORD: Col = 18;
 /// Column script prefix
 pub const COLUMN_SCRIPT_PREFIX: Col = 19;
+/// Column checkpoint
+pub const COLUMN_CHECKPOINT: Col = 20;
 
 /// chain id
 pub const META_CHAIN_ID_KEY: &[u8] = b"CHAIN_ID";

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -18,14 +18,13 @@ use gw_common::{
     state::{build_account_field_key, State, GW_ACCOUNT_NONCE},
     H256,
 };
-use gw_store::transaction::WithdrawalReceipt;
 use gw_traits::{ChainStore, CodeStore};
 use gw_types::{
     core::{ChallengeTargetType, ScriptHashType},
     offchain::RunResult,
     packed::{
         AccountMerkleState, BlockInfo, ChallengeTarget, DepositionRequest, L2Block, L2Transaction,
-        RawL2Block, RawL2Transaction, TxReceipt, WithdrawalRequest,
+        RawL2Block, RawL2Transaction, TxReceipt, WithdrawalReceipt, WithdrawalRequest,
     },
     prelude::*,
 };

--- a/crates/generator/src/genesis.rs
+++ b/crates/generator/src/genesis.rs
@@ -56,7 +56,7 @@ pub fn build_genesis_from_store(
     db.set_block_smt_root(H256::zero())?;
     db.set_account_count(0)?;
     let state_db =
-        StateDBTransaction::from_checkpoint(&db, CheckPoint::genesis(), StateDBMode::Genesis)?;
+        StateDBTransaction::from_checkpoint(&db, CheckPoint::from_genesis(), StateDBMode::Genesis)?;
     let mut tree = state_db.account_state_tree()?;
 
     // create a reserved account

--- a/crates/generator/src/genesis.rs
+++ b/crates/generator/src/genesis.rs
@@ -9,7 +9,7 @@ use gw_common::{
 };
 use gw_config::GenesisConfig;
 use gw_store::{
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction},
     transaction::StoreTransaction,
     Store,
 };
@@ -55,7 +55,8 @@ pub fn build_genesis_from_store(
     db.set_account_smt_root(H256::zero())?;
     db.set_block_smt_root(H256::zero())?;
     db.set_account_count(0)?;
-    let state_db = StateDBTransaction::from_version(&db, StateDBVersion::from_genesis())?;
+    let state_db =
+        StateDBTransaction::from_checkpoint(&db, CheckPoint::genesis(), StateDBMode::Genesis)?;
     let mut tree = state_db.account_state_tree()?;
 
     // create a reserved account
@@ -193,6 +194,7 @@ pub fn init_genesis(
         genesis.clone(),
         genesis_committed_info,
         global_state,
+        Vec::new(),
         Vec::new(),
         Vec::new(),
     )?;

--- a/crates/generator/src/tests/genesis.rs
+++ b/crates/generator/src/tests/genesis.rs
@@ -2,7 +2,7 @@ use crate::genesis::{build_genesis, init_genesis};
 use gw_common::{sparse_merkle_tree::H256, state::State};
 use gw_config::GenesisConfig;
 use gw_store::{
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction},
     Store,
 };
 use gw_traits::CodeStore;
@@ -40,7 +40,9 @@ fn test_init_genesis() {
     // check init values
     assert_ne!(db.get_block_smt_root().unwrap(), H256::zero());
     assert_ne!(db.get_account_smt_root().unwrap(), H256::zero());
-    let state_db = StateDBTransaction::from_version(&db, StateDBVersion::from_genesis()).unwrap();
+    let state_db =
+        StateDBTransaction::from_checkpoint(&db, CheckPoint::from_genesis(), StateDBMode::Genesis)
+            .unwrap();
     let tree = state_db.account_state_tree().unwrap();
     assert!(tree.get_account_count().unwrap() > 0);
     // get reserved account's script

--- a/crates/generator/src/traits.rs
+++ b/crates/generator/src/traits.rs
@@ -1,9 +1,10 @@
+use crate::sudt::build_l2_sudt_script;
 use crate::{
     error::{AccountError, DepositionError, Error, WithdrawalError},
     RollupContext,
 };
-use crate::{generator::WithdrawalReceipt, sudt::build_l2_sudt_script};
 use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, state::State, CKB_SUDT_SCRIPT_ARGS};
+use gw_store::transaction::WithdrawalReceipt;
 use gw_traits::CodeStore;
 use gw_types::{
     bytes::Bytes,

--- a/crates/generator/src/traits.rs
+++ b/crates/generator/src/traits.rs
@@ -1,15 +1,15 @@
-use crate::sudt::build_l2_sudt_script;
 use crate::{
     error::{AccountError, DepositionError, Error, WithdrawalError},
     RollupContext,
 };
+use crate::{generator::WithdrawalReceipt, sudt::build_l2_sudt_script};
 use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, state::State, CKB_SUDT_SCRIPT_ARGS};
 use gw_traits::CodeStore;
 use gw_types::{
     bytes::Bytes,
     core::ScriptHashType,
     offchain::RunResult,
-    packed::{DepositionRequest, Script, WithdrawalRequest},
+    packed::{AccountMerkleState, DepositionRequest, Script, WithdrawalRequest},
     prelude::*,
 };
 
@@ -26,7 +26,7 @@ pub trait StateExt {
         &mut self,
         ctx: &RollupContext,
         withdrawal_request: &WithdrawalRequest,
-    ) -> Result<(), Error>;
+    ) -> Result<WithdrawalReceipt, Error>;
 
     fn apply_deposition_requests(
         &mut self,
@@ -43,12 +43,15 @@ pub trait StateExt {
         &mut self,
         ctx: &RollupContext,
         withdrawal_requests: &[WithdrawalRequest],
-    ) -> Result<(), Error> {
+    ) -> Result<Vec<WithdrawalReceipt>, Error> {
+        let mut receipts = Vec::with_capacity(withdrawal_requests.len());
+
         for request in withdrawal_requests {
-            self.apply_withdrawal_request(ctx, request)?;
+            let receipt = self.apply_withdrawal_request(ctx, request)?;
+            receipts.push(receipt);
         }
 
-        Ok(())
+        Ok(receipts)
     }
 }
 
@@ -129,7 +132,7 @@ impl<S: State + CodeStore> StateExt for S {
         &mut self,
         ctx: &RollupContext,
         request: &WithdrawalRequest,
-    ) -> Result<(), Error> {
+    ) -> Result<WithdrawalReceipt, Error> {
         let raw = request.raw();
         let account_script_hash: [u8; 32] = raw.account_script_hash().unpack();
         let l2_sudt_script_hash: [u8; 32] =
@@ -155,6 +158,16 @@ impl<S: State + CodeStore> StateExt for S {
         let nonce = self.get_nonce(id)?;
         let new_nonce = nonce.checked_add(1).ok_or(AccountError::NonceOverflow)?;
         self.set_nonce(id, new_nonce)?;
-        Ok(())
+
+        let post_state = {
+            let account_root = self.calculate_root()?;
+            let account_count = self.get_account_count()?;
+            AccountMerkleState::new_builder()
+                .merkle_root(account_root.pack())
+                .count(account_count.pack())
+                .build()
+        };
+
+        Ok(WithdrawalReceipt { post_state })
     }
 }

--- a/crates/generator/src/traits.rs
+++ b/crates/generator/src/traits.rs
@@ -4,13 +4,12 @@ use crate::{
     RollupContext,
 };
 use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, state::State, CKB_SUDT_SCRIPT_ARGS};
-use gw_store::transaction::WithdrawalReceipt;
 use gw_traits::CodeStore;
 use gw_types::{
     bytes::Bytes,
     core::ScriptHashType,
     offchain::RunResult,
-    packed::{AccountMerkleState, DepositionRequest, Script, WithdrawalRequest},
+    packed::{AccountMerkleState, DepositionRequest, Script, WithdrawalReceipt, WithdrawalRequest},
     prelude::*,
 };
 
@@ -169,6 +168,10 @@ impl<S: State + CodeStore> StateExt for S {
                 .build()
         };
 
-        Ok(WithdrawalReceipt { post_state })
+        let receipt = WithdrawalReceipt::new_builder()
+            .post_state(post_state)
+            .build();
+
+        Ok(receipt)
     }
 }

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -8,7 +8,7 @@ use gw_jsonrpc_types::{
     godwoken::{L2BlockView, RunResult, TxReceipt},
 };
 use gw_store::{
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
     Store,
 };
 use gw_traits::CodeStore;
@@ -229,9 +229,10 @@ async fn get_balance(
 ) -> Result<Uint128> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
 
     let tree = state_db.account_state_tree()?;
@@ -246,9 +247,10 @@ async fn get_storage_at(
 ) -> Result<JsonH256> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
 
     let tree = state_db.account_state_tree()?;
@@ -265,9 +267,10 @@ async fn get_account_id_by_script_hash(
 ) -> Result<Option<AccountID>> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
     let tree = state_db.account_state_tree()?;
 
@@ -286,9 +289,10 @@ async fn get_nonce(
 ) -> Result<Uint32> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
     let tree = state_db.account_state_tree()?;
 
@@ -303,9 +307,10 @@ async fn get_script(
 ) -> Result<Option<Script>> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
     let tree = state_db.account_state_tree()?;
 
@@ -321,9 +326,10 @@ async fn get_script_hash(
 ) -> Result<JsonH256> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
     let tree = state_db.account_state_tree()?;
 
@@ -337,9 +343,10 @@ async fn get_data(
 ) -> Result<Option<JsonBytes>> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
     let tree = state_db.account_state_tree()?;
 

--- a/crates/store/src/state_db.rs
+++ b/crates/store/src/state_db.rs
@@ -568,7 +568,7 @@ impl<'a, 'db> CodeStore for StateTree<'a, 'db> {
 mod tests {
     use super::{CheckPoint, StateDBMode, SubState, WriteContext};
 
-    use crate::{traits::KVStore, Store};
+    use crate::{traits::KVStore, transaction::WithdrawalReceipt, Store};
 
     use gw_common::merkle_utils::calculate_state_checkpoint;
     use gw_db::schema::COLUMN_INDEX;
@@ -613,7 +613,7 @@ mod tests {
                 L2BlockCommittedInfo::default(),
                 GlobalState::default(),
                 vec![TxReceipt::default(); 2],
-                vec![AccountMerkleState::default(); 5],
+                vec![WithdrawalReceipt::default(); 3],
                 Vec::new(),
             )
             .unwrap();

--- a/crates/store/src/state_db.rs
+++ b/crates/store/src/state_db.rs
@@ -184,7 +184,11 @@ impl<'db> StateDBTransaction<'db> {
     }
 
     pub fn commit(&self) -> Result<(), Error> {
-        self.inner.commit()
+        if self.mode == StateDBMode::ReadOnly {
+            Err(Error::from("commit on ReadOnly mode".to_string()))
+        } else {
+            self.inner.commit()
+        }
     }
 
     pub fn account_smt_store(&self) -> Result<SMTStore<'_, Self>, Error> {

--- a/crates/store/src/state_db.rs
+++ b/crates/store/src/state_db.rs
@@ -20,24 +20,18 @@ const FLAG_DELETE_VALUE: u8 = 0;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct WriteContext {
-    pub withdrawal_num: u32,
+    pub tx_offset: u32,
 }
 
 impl WriteContext {
-    pub fn new(withdrawal_num: u32) -> Self {
-        Self { withdrawal_num }
-    }
-
-    pub fn from_block(block: &L2Block) -> Self {
-        Self {
-            withdrawal_num: block.withdrawals().len() as u32,
-        }
+    pub fn new(tx_offset: u32) -> Self {
+        Self { tx_offset }
     }
 }
 
 impl Default for WriteContext {
     fn default() -> Self {
-        Self { withdrawal_num: 0 }
+        Self { tx_offset: 0 }
     }
 }
 
@@ -156,7 +150,7 @@ impl CheckPoint {
 
                     Ok((self.block_number, block.withdrawals().len() as u32 + index))
                 }
-                StateDBMode::Write(ctx) => Ok((self.block_number, ctx.withdrawal_num + index)),
+                StateDBMode::Write(ctx) => Ok((self.block_number, ctx.tx_offset + index)),
             },
             SubState::Block => Ok((self.block_number, 0)),
         }

--- a/crates/store/src/tests/state_db.rs
+++ b/crates/store/src/tests/state_db.rs
@@ -1,5 +1,5 @@
 use crate::{
-    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState, WriteContext},
     traits::KVStore,
     transaction::StoreTransaction,
     Store,
@@ -19,7 +19,8 @@ fn get_state_db_from_mock_data(
     tx_index: u32,
 ) -> StateDBTransaction {
     let checkpoint = CheckPoint::new(block_number, SubState::Tx(tx_index));
-    StateDBTransaction::from_checkpoint(db, checkpoint, StateDBMode::Write).unwrap()
+    StateDBTransaction::from_checkpoint(db, checkpoint, StateDBMode::Write(WriteContext::new(0)))
+        .unwrap()
 }
 
 #[test]
@@ -67,7 +68,11 @@ fn construct_state_db_from_block_hash() {
 
     let state_checkpoint = CheckPoint::new(block_number.into(), SubState::Tx(0u32));
     let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::Write);
+    let state_db = StateDBTransaction::from_checkpoint(
+        &db,
+        state_checkpoint,
+        StateDBMode::Write(WriteContext::new(0)),
+    );
     assert!(state_db.is_ok());
     assert_eq!(false, state_db.unwrap().mode() == StateDBMode::Genesis);
 
@@ -126,13 +131,21 @@ fn construct_state_db_from_sub_state() {
 
     let state_checkpoint = CheckPoint::new(block_number.into(), SubState::Tx(0u32));
     let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::Write);
+    let state_db = StateDBTransaction::from_checkpoint(
+        &db,
+        state_checkpoint,
+        StateDBMode::Write(WriteContext::new(3)),
+    );
     assert!(state_db.is_ok());
     assert_eq!(false, state_db.unwrap().mode() == StateDBMode::Genesis);
 
     let state_checkpoint = CheckPoint::new(block_number.into(), SubState::Tx(1u32));
     let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::Write);
+    let state_db = StateDBTransaction::from_checkpoint(
+        &db,
+        state_checkpoint,
+        StateDBMode::Write(WriteContext::new(3)),
+    );
     assert!(state_db.is_ok());
     assert_eq!(false, state_db.unwrap().mode() == StateDBMode::Genesis);
 

--- a/crates/store/src/tests/state_db.rs
+++ b/crates/store/src/tests/state_db.rs
@@ -1,7 +1,7 @@
 use crate::{
     state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState, WriteContext},
     traits::KVStore,
-    transaction::StoreTransaction,
+    transaction::{StoreTransaction, WithdrawalReceipt},
     Store,
 };
 use gw_common::{merkle_utils::calculate_state_checkpoint, H256};
@@ -118,7 +118,7 @@ fn construct_state_db_from_sub_state() {
             L2BlockCommittedInfo::default(),
             GlobalState::default(),
             vec![TxReceipt::default(); 2],
-            vec![AccountMerkleState::default(); 5],
+            vec![WithdrawalReceipt::default(); 3],
             Vec::new(),
         )
         .unwrap();

--- a/crates/store/src/tests/state_db.rs
+++ b/crates/store/src/tests/state_db.rs
@@ -1,12 +1,15 @@
 use crate::{
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
     traits::KVStore,
     transaction::StoreTransaction,
     Store,
 };
-use gw_common::H256;
+use gw_common::{merkle_utils::calculate_state_checkpoint, H256};
 use gw_types::{
-    packed::{GlobalState, L2Block, L2BlockCommittedInfo, L2Transaction, TxReceipt},
+    packed::{
+        AccountMerkleState, Byte32, GlobalState, L2Block, L2BlockCommittedInfo, L2Transaction,
+        RawL2Block, TxReceipt, WithdrawalRequest,
+    },
     prelude::*,
 };
 
@@ -15,8 +18,8 @@ fn get_state_db_from_mock_data(
     block_number: u64,
     tx_index: u32,
 ) -> StateDBTransaction {
-    let version = StateDBVersion::from_future_state(block_number, tx_index); // just as a placeholder
-    StateDBTransaction::from_version(db, version).unwrap()
+    let checkpoint = CheckPoint::new(block_number, SubState::Tx(tx_index));
+    StateDBTransaction::from_checkpoint(db, checkpoint, StateDBMode::Write).unwrap()
 }
 
 #[test]
@@ -32,61 +35,6 @@ fn construct_state_db_from_block_hash() {
             GlobalState::default(),
             Vec::new(),
             Vec::new(),
-        )
-        .unwrap();
-    store_txn.commit().unwrap();
-
-    let raw = block.raw();
-    let block_number = raw.number().unpack();
-    let block_hash = raw.hash();
-    assert_eq!(0u64, block_number);
-
-    let state_db_version = StateDBVersion::from_genesis();
-    assert_eq!(true, state_db_version.is_genesis_version());
-    let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_version(&db, state_db_version);
-    assert!(state_db.is_ok());
-
-    let state_db_version =
-        StateDBVersion::from_history_state(&db, block_hash.into(), None).unwrap();
-    assert_eq!(false, state_db_version.is_genesis_version());
-    let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_version(&db, state_db_version);
-    assert!(state_db.is_ok());
-
-    let state_db_version = StateDBVersion::from_history_state(&db, H256::zero(), None);
-    assert_eq!(
-        state_db_version.unwrap_err().to_string(),
-        "block isn't exist".to_string()
-    );
-
-    let state_db_version = StateDBVersion::from_future_state(block_number.into(), 0u32);
-    assert_eq!(false, state_db_version.is_genesis_version());
-    let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_version(&db, state_db_version);
-    assert!(state_db.is_ok());
-
-    let state_db_version = StateDBVersion::from_history_state(&db, block_hash.into(), Some(1u32));
-    assert_eq!(
-        state_db_version.unwrap_err().to_string(),
-        "Invalid tx index"
-    );
-}
-
-#[test]
-fn construct_state_db_from_tx_index() {
-    let store = Store::open_tmp().unwrap();
-    let store_txn = store.begin_transaction();
-
-    let block = L2Block::new_builder()
-        .transactions(vec![L2Transaction::default(); 2].pack())
-        .build();
-    store_txn
-        .insert_block(
-            block.clone(),
-            L2BlockCommittedInfo::default(),
-            GlobalState::default(),
-            vec![TxReceipt::default(); 2],
             Vec::new(),
         )
         .unwrap();
@@ -97,22 +45,123 @@ fn construct_state_db_from_tx_index() {
     let block_hash = raw.hash();
     assert_eq!(0u64, block_number);
 
-    let state_db_version = StateDBVersion::from_future_state(block_number.into(), 0u32);
-    assert_eq!(false, state_db_version.is_genesis_version());
     let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_version(&db, state_db_version);
-    assert!(state_db.is_ok());
-
-    let state_db_version = StateDBVersion::from_future_state(block_number.into(), 1u32);
-    assert_eq!(false, state_db_version.is_genesis_version());
-    let db = store.begin_transaction();
-    let state_db = StateDBTransaction::from_version(&db, state_db_version);
-    assert!(state_db.is_ok());
-
-    let state_db_version = StateDBVersion::from_history_state(&db, block_hash.into(), Some(2u32));
+    let state_db =
+        StateDBTransaction::from_checkpoint(&db, CheckPoint::from_genesis(), StateDBMode::Write);
     assert_eq!(
-        state_db_version.unwrap_err().to_string(),
-        "Invalid tx index"
+        state_db.unwrap_err().to_string(),
+        "DB error use StateDBMode::Write on genesis checkpoint"
+    );
+
+    let state_checkpoint = CheckPoint::from_genesis();
+    assert_eq!(true, state_checkpoint.is_genesis());
+    let db = store.begin_transaction();
+    let state_db = StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::Genesis);
+    assert!(state_db.is_ok());
+
+    let state_checkpoint =
+        CheckPoint::from_block_hash(&db, block_hash.into(), SubState::Block).unwrap();
+    assert_eq!(true, state_checkpoint.is_genesis()); // Since block number is zero
+    let db = store.begin_transaction();
+    let state_db =
+        StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::ReadOnly);
+    assert!(state_db.is_ok());
+
+    let state_checkpoint = CheckPoint::from_block_hash(&db, H256::zero(), SubState::Block);
+    assert_eq!(
+        state_checkpoint.unwrap_err().to_string(),
+        "block isn't exist".to_string()
+    );
+
+    let state_checkpoint = CheckPoint::new(block_number.into(), SubState::Tx(0u32));
+    assert_eq!(false, state_checkpoint.is_genesis());
+    let db = store.begin_transaction();
+    let state_db = StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::Write);
+    assert!(state_db.is_ok());
+
+    let state_checkpoint = CheckPoint::from_block_hash(&db, block_hash.into(), SubState::Tx(1u32));
+    assert_eq!(
+        state_checkpoint.unwrap_err().to_string(),
+        "invalid tx substate index"
+    );
+
+    let state_checkpoint =
+        CheckPoint::from_block_hash(&db, block_hash.into(), SubState::Withdrawal(1u32));
+    assert_eq!(
+        state_checkpoint.unwrap_err().to_string(),
+        "invalid withdrawal substate index"
+    );
+}
+
+#[test]
+fn construct_state_db_from_sub_state() {
+    let store = Store::open_tmp().unwrap();
+    let store_txn = store.begin_transaction();
+
+    let default_state_checkpoint: Byte32 = {
+        let post_state = AccountMerkleState::default();
+        let root: [u8; 32] = post_state.merkle_root().unpack();
+        let checkpoint: [u8; 32] =
+            calculate_state_checkpoint(&root.into(), post_state.count().unpack()).into();
+        checkpoint.pack()
+    };
+
+    let raw_block = RawL2Block::new_builder()
+        .state_checkpoint_list(vec![default_state_checkpoint; 5].pack())
+        .build();
+
+    let block = L2Block::new_builder()
+        .transactions(vec![L2Transaction::default(); 2].pack())
+        .withdrawals(vec![WithdrawalRequest::default(); 3].pack())
+        .raw(raw_block)
+        .build();
+    store_txn
+        .insert_block(
+            block.clone(),
+            L2BlockCommittedInfo::default(),
+            GlobalState::default(),
+            vec![TxReceipt::default(); 2],
+            vec![AccountMerkleState::default(); 5],
+            Vec::new(),
+        )
+        .unwrap();
+    store_txn.commit().unwrap();
+
+    let raw = block.raw();
+    let block_number = raw.number().unpack();
+    let block_hash = raw.hash();
+    assert_eq!(0u64, block_number);
+
+    let state_checkpoint = CheckPoint::new(block_number.into(), SubState::Tx(0u32));
+    assert_eq!(false, state_checkpoint.is_genesis());
+    let db = store.begin_transaction();
+    let state_db = StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::Write);
+    assert!(state_db.is_ok());
+
+    let state_checkpoint = CheckPoint::new(block_number.into(), SubState::Tx(1u32));
+    assert_eq!(false, state_checkpoint.is_genesis());
+    let db = store.begin_transaction();
+    let state_db = StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::Write);
+    assert!(state_db.is_ok());
+
+    let state_checkpoint = CheckPoint::new(block_number.into(), SubState::Withdrawal(1u32));
+    assert_eq!(false, state_checkpoint.is_genesis());
+    let db = store.begin_transaction();
+    let state_db =
+        StateDBTransaction::from_checkpoint(&db, state_checkpoint, StateDBMode::ReadOnly);
+    assert!(state_db.is_ok());
+
+    let state_checkpoint =
+        CheckPoint::from_block_hash(&db, block_hash.into(), SubState::Withdrawal(3u32));
+    assert_eq!(
+        state_checkpoint.unwrap_err().to_string(),
+        "invalid withdrawal substate index"
+    );
+
+    let state_checkpoint = CheckPoint::from_block_hash(&db, block_hash.into(), SubState::Tx(2u32));
+    assert_eq!(
+        state_checkpoint.unwrap_err().to_string(),
+        "invalid tx substate index"
     );
 }
 

--- a/crates/store/src/tests/state_db.rs
+++ b/crates/store/src/tests/state_db.rs
@@ -1,7 +1,7 @@
 use crate::{
     state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState, WriteContext},
     traits::KVStore,
-    transaction::{StoreTransaction, WithdrawalReceipt},
+    transaction::StoreTransaction,
     Store,
 };
 use gw_common::{merkle_utils::calculate_state_checkpoint, H256};
@@ -9,7 +9,7 @@ use gw_db::schema::COLUMN_INDEX;
 use gw_types::{
     packed::{
         AccountMerkleState, Byte32, GlobalState, L2Block, L2BlockCommittedInfo, L2Transaction,
-        RawL2Block, TxReceipt, WithdrawalRequest,
+        RawL2Block, TxReceipt, WithdrawalReceipt, WithdrawalRequest,
     },
     prelude::*,
 };

--- a/crates/store/src/tests/transaction_clear_block_state.rs
+++ b/crates/store/src/tests/transaction_clear_block_state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState, WriteContext},
     traits::KVStore,
     Store,
 };
@@ -18,7 +18,7 @@ fn insert_to_state_db(
     let state_db_txn = StateDBTransaction::from_checkpoint(
         &store_txn,
         CheckPoint::new(block_number, SubState::Tx(tx_index)),
-        StateDBMode::Write,
+        StateDBMode::Write(WriteContext::new(0)),
     )
     .unwrap();
     state_db_txn.insert_raw(col, key, value).unwrap();
@@ -30,7 +30,7 @@ fn delete_from_state_db(db: &Store, col: Col, block_number: u64, tx_index: u32, 
     let state_db_txn = StateDBTransaction::from_checkpoint(
         &store_txn,
         CheckPoint::new(block_number, SubState::Tx(tx_index)),
-        StateDBMode::Write,
+        StateDBMode::Write(WriteContext::new(0)),
     )
     .unwrap();
     state_db_txn.delete(col, key).unwrap();
@@ -78,7 +78,7 @@ fn get_from_state_db(
     let state_db = StateDBTransaction::from_checkpoint(
         &store_txn,
         CheckPoint::new(block_number, SubState::Tx(tx_index)),
-        StateDBMode::Write,
+        StateDBMode::Write(WriteContext::new(0)),
     )
     .unwrap();
     state_db.get(col, key)

--- a/crates/store/src/tests/transaction_clear_block_state.rs
+++ b/crates/store/src/tests/transaction_clear_block_state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
     traits::KVStore,
     Store,
 };
@@ -15,9 +15,10 @@ fn insert_to_state_db(
     value: &[u8],
 ) {
     let store_txn = db.begin_transaction();
-    let state_db_txn = StateDBTransaction::from_version(
+    let state_db_txn = StateDBTransaction::from_checkpoint(
         &store_txn,
-        StateDBVersion::from_future_state(block_number, tx_index),
+        CheckPoint::new(block_number, SubState::Tx(tx_index)),
+        StateDBMode::Write,
     )
     .unwrap();
     state_db_txn.insert_raw(col, key, value).unwrap();
@@ -26,9 +27,10 @@ fn insert_to_state_db(
 
 fn delete_from_state_db(db: &Store, col: Col, block_number: u64, tx_index: u32, key: &[u8]) {
     let store_txn = db.begin_transaction();
-    let state_db_txn = StateDBTransaction::from_version(
+    let state_db_txn = StateDBTransaction::from_checkpoint(
         &store_txn,
-        StateDBVersion::from_future_state(block_number, tx_index),
+        CheckPoint::new(block_number, SubState::Tx(tx_index)),
+        StateDBMode::Write,
     )
     .unwrap();
     state_db_txn.delete(col, key).unwrap();
@@ -73,9 +75,10 @@ fn get_from_state_db(
     key: &[u8],
 ) -> Option<Box<[u8]>> {
     let store_txn = db.begin_transaction();
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &store_txn,
-        StateDBVersion::from_future_state(block_number, tx_index),
+        CheckPoint::new(block_number, SubState::Tx(tx_index)),
+        StateDBMode::Write,
     )
     .unwrap();
     state_db.get(col, key)

--- a/crates/store/src/transaction.rs
+++ b/crates/store/src/transaction.rs
@@ -13,25 +13,12 @@ use gw_db::{
 };
 use gw_types::packed::AccountMerkleState;
 use gw_types::{
-    packed::{self, Byte32, RollupConfig, TransactionKey},
+    packed::{self, Byte32, RollupConfig, TransactionKey, WithdrawalReceipt},
     prelude::*,
 };
 use std::{borrow::BorrowMut, collections::HashMap};
 
 const NUMBER_OF_CONFIRMATION: u64 = 100;
-
-#[derive(Clone)]
-pub struct WithdrawalReceipt {
-    pub post_state: AccountMerkleState,
-}
-
-impl Default for WithdrawalReceipt {
-    fn default() -> Self {
-        Self {
-            post_state: AccountMerkleState::default(),
-        }
-    }
-}
 
 pub struct StoreTransaction {
     pub(crate) inner: RocksDBTransaction,
@@ -332,7 +319,7 @@ impl StoreTransaction {
         }
 
         let post_states: Vec<AccountMerkleState> = {
-            let withdrawal_post_states = withdrawal_receipts.into_iter().map(|w| w.post_state);
+            let withdrawal_post_states = withdrawal_receipts.into_iter().map(|w| w.post_state());
             let tx_post_states = tx_receipts.iter().map(|t| t.post_state());
             withdrawal_post_states.chain(tx_post_states).collect()
         };

--- a/crates/tests/src/tests/deposition_withdrawal.rs
+++ b/crates/tests/src/tests/deposition_withdrawal.rs
@@ -4,7 +4,7 @@ use gw_generator::{
     error::{DepositionError, WithdrawalError},
     Error,
 };
-use gw_store::state_db::{StateDBTransaction, StateDBVersion};
+use gw_store::state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState};
 use gw_types::{
     core::ScriptHashType,
     packed::{CellOutput, DepositionRequest, RawWithdrawalRequest, Script, WithdrawalRequest},
@@ -103,9 +103,10 @@ fn test_deposition_and_withdrawal() {
     let (user_id, ckb_balance) = {
         let tip_block_hash = chain.store().get_tip_block_hash().unwrap();
         let db = chain.store().begin_transaction();
-        let state_db = StateDBTransaction::from_version(
+        let state_db = StateDBTransaction::from_checkpoint(
             &db,
-            StateDBVersion::from_history_state(&db, tip_block_hash, None).unwrap(),
+            CheckPoint::from_block_hash(&db, tip_block_hash, SubState::Block).unwrap(),
+            StateDBMode::ReadOnly,
         )
         .unwrap();
         let tree = state_db.account_state_tree().unwrap();
@@ -158,9 +159,10 @@ fn test_deposition_and_withdrawal() {
     // check status
     let tip_block_hash = chain.store().get_tip_block_hash().unwrap();
     let db = chain.store().begin_transaction();
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_block_hash, None).unwrap(),
+        CheckPoint::from_block_hash(&db, tip_block_hash, SubState::Block).unwrap(),
+        StateDBMode::ReadOnly,
     )
     .unwrap();
     let tree = state_db.account_state_tree().unwrap();

--- a/crates/types/schemas/store.mol
+++ b/crates/types/schemas/store.mol
@@ -36,6 +36,10 @@ table TxReceipt {
     logs: LogItemVec,
 }
 
+table WithdrawalReceipt {
+    post_state: AccountMerkleState,
+}
+
 table SMTBranchNode {
     fork_height: byte,
     key: Byte32,

--- a/crates/types/src/generated/store.rs
+++ b/crates/types/src/generated/store.rs
@@ -2357,6 +2357,246 @@ impl molecule::prelude::Builder for TxReceiptBuilder {
     }
 }
 #[derive(Clone)]
+pub struct WithdrawalReceipt(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for WithdrawalReceipt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for WithdrawalReceipt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for WithdrawalReceipt {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "post_state", self.post_state())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for WithdrawalReceipt {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            44, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        WithdrawalReceipt::new_unchecked(v.into())
+    }
+}
+impl WithdrawalReceipt {
+    pub const FIELD_COUNT: usize = 1;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn post_state(&self) -> AccountMerkleState {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[8..]) as usize;
+            AccountMerkleState::new_unchecked(self.0.slice(start..end))
+        } else {
+            AccountMerkleState::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> WithdrawalReceiptReader<'r> {
+        WithdrawalReceiptReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for WithdrawalReceipt {
+    type Builder = WithdrawalReceiptBuilder;
+    const NAME: &'static str = "WithdrawalReceipt";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        WithdrawalReceipt(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        WithdrawalReceiptReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        WithdrawalReceiptReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().post_state(self.post_state())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct WithdrawalReceiptReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for WithdrawalReceiptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for WithdrawalReceiptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for WithdrawalReceiptReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "post_state", self.post_state())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> WithdrawalReceiptReader<'r> {
+    pub const FIELD_COUNT: usize = 1;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn post_state(&self) -> AccountMerkleStateReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[8..]) as usize;
+            AccountMerkleStateReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            AccountMerkleStateReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for WithdrawalReceiptReader<'r> {
+    type Entity = WithdrawalReceipt;
+    const NAME: &'static str = "WithdrawalReceiptReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        WithdrawalReceiptReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % 4 != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        let field_count = offset_first / 4 - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let header_size = molecule::NUMBER_SIZE * (field_count + 1);
+        if slice_len < header_size {
+            return ve!(Self, HeaderIsBroken, header_size, slice_len);
+        }
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..]
+            .chunks(molecule::NUMBER_SIZE)
+            .take(field_count)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        AccountMerkleStateReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct WithdrawalReceiptBuilder {
+    pub(crate) post_state: AccountMerkleState,
+}
+impl WithdrawalReceiptBuilder {
+    pub const FIELD_COUNT: usize = 1;
+    pub fn post_state(mut self, v: AccountMerkleState) -> Self {
+        self.post_state = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for WithdrawalReceiptBuilder {
+    type Entity = WithdrawalReceipt;
+    const NAME: &'static str = "WithdrawalReceiptBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1) + self.post_state.as_slice().len()
+    }
+    fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.post_state.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.post_state.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        WithdrawalReceipt::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct SMTBranchNode(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for SMTBranchNode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {

--- a/crates/web3-indexer/src/indexer.rs
+++ b/crates/web3-indexer/src/indexer.rs
@@ -13,7 +13,7 @@ use ckb_types::H256;
 use gw_common::builtins::CKB_SUDT_ACCOUNT_ID;
 use gw_common::state::State;
 use gw_store::{
-    state_db::{StateDBTransaction, StateDBVersion},
+    state_db::{CheckPoint, StateDBMode, StateDBTransaction, SubState},
     Store,
 };
 use gw_traits::CodeStore;
@@ -509,9 +509,10 @@ impl Web3Indexer {
 async fn get_script_hash(store: Store, account_id: u32) -> Result<gw_common::H256> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
     let tree = state_db.account_state_tree()?;
 
@@ -522,9 +523,10 @@ async fn get_script_hash(store: Store, account_id: u32) -> Result<gw_common::H25
 async fn get_script(store: Store, script_hash: gw_common::H256) -> Result<Option<Script>> {
     let db = store.begin_transaction();
     let tip_hash = db.get_tip_block_hash()?;
-    let state_db = StateDBTransaction::from_version(
+    let state_db = StateDBTransaction::from_checkpoint(
         &db,
-        StateDBVersion::from_history_state(&db, tip_hash, None)?,
+        CheckPoint::from_block_hash(&db, tip_hash, SubState::Block)?,
+        StateDBMode::ReadOnly,
     )?;
     let tree = state_db.account_state_tree()?;
 


### PR DESCRIPTION
Add ```CheckPoint```, ```SubState``` and ```StateDBMode```
Save every withdrawal and transaction post state to db
Able to load statedb from checkpoint(block_number with ```SubState```) and ```StateDBMode```