### PR TITLE
Update generate-config command

### DIFF
--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -1,5 +1,6 @@
 use crate::deploy_genesis::{get_secp_data, GenesisDeploymentResult};
 use crate::deploy_scripts::ScriptsDeploymentResult;
+use crate::setup_nodes::get_wallet_info;
 use anyhow::{anyhow, Result};
 use ckb_sdk::HttpRpcClient;
 use ckb_types::prelude::Entity;
@@ -38,6 +39,7 @@ pub fn generate_config(
     output_path: &Path,
     database_url: Option<&str>,
     server_url: String,
+    privkey_path: &Path,
 ) -> Result<()> {
     let genesis: GenesisDeploymentResult = {
         let content = fs::read(genesis_path)?;
@@ -72,7 +74,7 @@ pub fn generate_config(
 
     // build configuration
     let account_id = 0;
-    let privkey_path = "<private key path>".into();
+    let _node_wallet_info = get_wallet_info(privkey_path);
     let lock = Default::default();
 
     let rollup_config = genesis.rollup_config.clone();
@@ -120,7 +122,10 @@ pub fn generate_config(
     // TODO: automatic generation
     let l1_sudt_type_dep = gw_types::packed::CellDep::default().into();
 
-    let wallet_config: WalletConfig = WalletConfig { privkey_path, lock };
+    let wallet_config: WalletConfig = WalletConfig {
+        privkey_path: privkey_path.into(),
+        lock,
+    };
 
     let mut backends: Vec<BackendConfig> = Vec::new();
     backends.push(BackendConfig {

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -1,5 +1,3 @@
-use std::{fs, path::Path};
-
 use crate::deploy_genesis::{get_secp_data, GenesisDeploymentResult};
 use crate::deploy_scripts::ScriptsDeploymentResult;
 use anyhow::{anyhow, Result};
@@ -10,6 +8,7 @@ use gw_config::{
     RPCServerConfig, StoreConfig, WalletConfig, Web3IndexerConfig,
 };
 use gw_jsonrpc_types::godwoken::L2BlockCommittedInfo;
+use std::{fs, path::Path};
 
 const BACKEND_BINARIES_DIR: &str = "godwoken-scripts/c/build";
 
@@ -21,6 +20,7 @@ pub fn generate_config(
     indexer_url: String,
     output_path: &Path,
     database_url: Option<&str>,
+    server_url: String,
 ) -> Result<()> {
     let genesis: GenesisDeploymentResult = {
         let content = fs::read(genesis_path)?;
@@ -134,7 +134,7 @@ pub fn generate_config(
         ckb_url,
     };
     let rpc_server = RPCServerConfig {
-        listen: "localhost:8119".to_string(),
+        listen: server_url,
     };
     let block_producer: Option<BlockProducerConfig> = Some(BlockProducerConfig {
         account_id,

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -88,17 +88,12 @@ pub fn generate_config(
         )?;
         hash
     };
-    let args: [u8; 20] = {
-        let mut args: [u8; 20] = [0u8; 20];
-        hex::decode_to_slice(
-            node_wallet_info
-                .lock_arg
-                .strip_prefix("0x")
-                .expect("get code hash"),
-            &mut args as &mut [u8],
-        )?;
-        args
-    };
+    let args = hex::decode(
+        node_wallet_info
+            .lock_arg
+            .strip_prefix("0x")
+            .expect("get args"),
+    )?;
     let lock = Script::new_builder()
         .code_hash(code_hash.pack())
         .hash_type(ScriptHashType::Type.into())

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -113,13 +113,7 @@ fn main() {
                         .required(true)
                         .help("The genesis deployment results json file path"),
                 )
-                .arg(
-                    Arg::with_name("scripts-deploy-config-path")
-                        .short("c")
-                        .takes_value(true)
-                        .required(true)
-                        .help("Scripts depoly config json file path"),
-                )
+                .arg(arg_privkey_path.clone())
                 .arg(
                     Arg::with_name("database-url")
                         .short("d")
@@ -134,19 +128,19 @@ fn main() {
                         .help("The output json file path"),
                 )
                 .arg(
+                    Arg::with_name("scripts-deploy-config-path")
+                        .short("c")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Scripts depoly config json file path"),
+                )
+                .arg(
                     Arg::with_name("rpc-server-url")
                         .short("u")
                         .takes_value(true)
                         .default_value("localhost:8119")
                         .required(true)
                         .help("The URL of rpc server"),
-                )
-                .arg(
-                    Arg::with_name("private-key-path")
-                        .short("p")
-                        .takes_value(true)
-                        .required(true)
-                        .help("Godwoken node private key path"),
                 ),
         )
         .subcommand(
@@ -335,22 +329,23 @@ fn main() {
             let indexer_url = m.value_of("indexer-rpc-url").unwrap().to_string();
             let scripts_path = Path::new(m.value_of("scripts-deployment-results-path").unwrap());
             let genesis_path = Path::new(m.value_of("genesis-deployment-results-path").unwrap());
-            let scripts_config_path = Path::new(m.value_of("scripts-deploy-config-path").unwrap());
+            let privkey_path = Path::new(m.value_of("privkey-path").unwrap());
             let output_path = Path::new(m.value_of("output-path").unwrap());
             let database_url = m.value_of("database-url");
+            let scripts_deploy_config_path =
+                Path::new(m.value_of("scripts-deploy-config-path").unwrap());
             let server_url = m.value_of("rpc-server-url").unwrap().to_string();
-            let privkey_path = Path::new(m.value_of("private-key-path").unwrap());
 
             if let Err(err) = generate_config::generate_config(
                 genesis_path,
                 scripts_path,
-                scripts_config_path,
+                privkey_path,
                 ckb_url,
                 indexer_url,
                 output_path,
                 database_url,
+                scripts_deploy_config_path,
                 server_url,
-                privkey_path,
             ) {
                 log::error!("Deploy genesis error: {}", err);
                 std::process::exit(-1);

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -128,11 +128,11 @@ fn main() {
                         .help("The output json file path"),
                 )
                 .arg(
-                    Arg::with_name("scripts-deploy-config-path")
+                    Arg::with_name("scripts-deployment-config-path")
                         .short("c")
                         .takes_value(true)
                         .required(true)
-                        .help("Scripts depoly config json file path"),
+                        .help("Scripts deployment config json file path"),
                 )
                 .arg(
                     Arg::with_name("rpc-server-url")
@@ -327,24 +327,25 @@ fn main() {
         ("generate-config", Some(m)) => {
             let ckb_url = m.value_of("ckb-rpc-url").unwrap().to_string();
             let indexer_url = m.value_of("indexer-rpc-url").unwrap().to_string();
-            let scripts_path = Path::new(m.value_of("scripts-deployment-results-path").unwrap());
+            let scripts_results_path =
+                Path::new(m.value_of("scripts-deployment-results-path").unwrap());
             let genesis_path = Path::new(m.value_of("genesis-deployment-results-path").unwrap());
             let privkey_path = Path::new(m.value_of("privkey-path").unwrap());
             let output_path = Path::new(m.value_of("output-path").unwrap());
             let database_url = m.value_of("database-url");
-            let scripts_deploy_config_path =
-                Path::new(m.value_of("scripts-deploy-config-path").unwrap());
+            let scripts_config_path =
+                Path::new(m.value_of("scripts-deployment-config-path").unwrap());
             let server_url = m.value_of("rpc-server-url").unwrap().to_string();
 
             if let Err(err) = generate_config::generate_config(
                 genesis_path,
-                scripts_path,
+                scripts_results_path,
                 privkey_path,
                 ckb_url,
                 indexer_url,
                 output_path,
                 database_url,
-                scripts_deploy_config_path,
+                scripts_config_path,
                 server_url,
             ) {
                 log::error!("Deploy genesis error: {}", err);

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -140,6 +140,13 @@ fn main() {
                         .default_value("localhost:8119")
                         .required(true)
                         .help("The URL of rpc server"),
+                )
+                .arg(
+                    Arg::with_name("private-key-path")
+                        .short("p")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Godwoken node private key path"),
                 ),
         )
         .subcommand(
@@ -332,6 +339,7 @@ fn main() {
             let output_path = Path::new(m.value_of("output-path").unwrap());
             let database_url = m.value_of("database-url");
             let server_url = m.value_of("rpc-server-url").unwrap().to_string();
+            let privkey_path = Path::new(m.value_of("private-key-path").unwrap());
 
             if let Err(err) = generate_config::generate_config(
                 genesis_path,
@@ -342,6 +350,7 @@ fn main() {
                 output_path,
                 database_url,
                 server_url,
+                privkey_path,
             ) {
                 log::error!("Deploy genesis error: {}", err);
                 std::process::exit(-1);

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -114,11 +114,11 @@ fn main() {
                         .help("The genesis deployment results json file path"),
                 )
                 .arg(
-                    Arg::with_name("polyjuice-binaries-dir-path")
-                        .short("p")
+                    Arg::with_name("scripts-deploy-config-path")
+                        .short("c")
                         .takes_value(true)
                         .required(true)
-                        .help("Polyjuice binaries directory path"),
+                        .help("Scripts depoly config json file path"),
                 )
                 .arg(
                     Arg::with_name("database-url")
@@ -328,8 +328,7 @@ fn main() {
             let indexer_url = m.value_of("indexer-rpc-url").unwrap().to_string();
             let scripts_path = Path::new(m.value_of("scripts-deployment-results-path").unwrap());
             let genesis_path = Path::new(m.value_of("genesis-deployment-results-path").unwrap());
-            let polyjuice_binaries_dir =
-                Path::new(m.value_of("polyjuice-binaries-dir-path").unwrap());
+            let scripts_config_path = Path::new(m.value_of("scripts-deploy-config-path").unwrap());
             let output_path = Path::new(m.value_of("output-path").unwrap());
             let database_url = m.value_of("database-url");
             let server_url = m.value_of("rpc-server-url").unwrap().to_string();
@@ -337,7 +336,7 @@ fn main() {
             if let Err(err) = generate_config::generate_config(
                 genesis_path,
                 scripts_path,
-                polyjuice_binaries_dir,
+                scripts_config_path,
                 ckb_url,
                 indexer_url,
                 output_path,

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -132,6 +132,14 @@ fn main() {
                         .takes_value(true)
                         .required(true)
                         .help("The output json file path"),
+                )
+                .arg(
+                    Arg::with_name("rpc-server-url")
+                        .short("u")
+                        .takes_value(true)
+                        .default_value("localhost:8119")
+                        .required(true)
+                        .help("The URL of rpc server"),
                 ),
         )
         .subcommand(
@@ -324,6 +332,7 @@ fn main() {
                 Path::new(m.value_of("polyjuice-binaries-dir-path").unwrap());
             let output_path = Path::new(m.value_of("output-path").unwrap());
             let database_url = m.value_of("database-url");
+            let server_url = m.value_of("rpc-server-url").unwrap().to_string();
 
             if let Err(err) = generate_config::generate_config(
                 genesis_path,
@@ -333,6 +342,7 @@ fn main() {
                 indexer_url,
                 output_path,
                 database_url,
+                server_url,
             ) {
                 log::error!("Deploy genesis error: {}", err);
                 std::process::exit(-1);

--- a/crates/tools/src/setup_nodes.rs
+++ b/crates/tools/src/setup_nodes.rs
@@ -12,13 +12,12 @@ use std::{
 const MIN_WALLET_CAPACITY: f64 = 100000.0f64;
 
 #[derive(Debug)]
-struct NodeWalletInfo {
-    node_name: String,
-    privkey_path: PathBuf,
-    testnet_address: String,
-    lock_hash: String,
-    lock_arg: String,
-    block_assembler_code_hash: String,
+pub struct NodeWalletInfo {
+    pub privkey_path: PathBuf,
+    pub testnet_address: String,
+    pub lock_hash: String,
+    pub lock_arg: String,
+    pub block_assembler_code_hash: String,
 }
 
 pub fn setup_nodes(
@@ -61,11 +60,11 @@ fn check_wallets_info(
     nodes_privkeys: HashMap<String, PathBuf>,
     capacity: u32,
     payer_privkey_path: &Path,
-) -> Vec<NodeWalletInfo> {
+) -> HashMap<String, NodeWalletInfo> {
     nodes_privkeys
         .into_iter()
         .map(|(node, privkey)| {
-            let wallet_info = get_wallet_info(&node, privkey);
+            let wallet_info = get_wallet_info(&privkey);
             let mut current_capacity = query_wallet_capacity(&wallet_info.testnet_address);
             log::info!("{}'s wallet capacity: {}", node, current_capacity);
             if current_capacity < MIN_WALLET_CAPACITY {
@@ -79,15 +78,15 @@ fn check_wallets_info(
                 );
                 log::info!("{}'s wallet capacity: {}", node, current_capacity);
             }
-            wallet_info
+            (node, wallet_info)
         })
         .collect()
 }
 
-fn generate_poa_config(nodes_info: &[NodeWalletInfo], poa_config_path: &Path) {
+fn generate_poa_config(nodes_info: &HashMap<String, NodeWalletInfo>, poa_config_path: &Path) {
     let identities: Vec<&str> = nodes_info
         .iter()
-        .map(|node| node.lock_hash.as_str())
+        .map(|(_, node)| node.lock_hash.as_str())
         .collect();
     let poa_config = json!({
         "poa_setup" : {
@@ -123,7 +122,7 @@ fn generate_privkey_file(privkey_file_path: &Path) {
     fs::write(&privkey_file_path, &privkey).expect("create pk file");
 }
 
-fn get_wallet_info(node_name: &str, privkey_path: PathBuf) -> NodeWalletInfo {
+pub fn get_wallet_info(privkey_path: &Path) -> NodeWalletInfo {
     let (stdout, stderr) = utils::run_in_output_mode(
         "ckb-cli",
         vec![
@@ -135,8 +134,7 @@ fn get_wallet_info(node_name: &str, privkey_path: PathBuf) -> NodeWalletInfo {
     )
     .expect("get key info");
     NodeWalletInfo {
-        node_name: node_name.into(),
-        privkey_path,
+        privkey_path: privkey_path.into(),
         testnet_address: look_after_in_line(&stdout, "testnet:"),
         lock_hash: look_after_in_line(&stdout, "lock_hash:"),
         lock_arg: look_after_in_line(&stdout, "lock_arg:"),

--- a/crates/tools/src/setup_nodes.rs
+++ b/crates/tools/src/setup_nodes.rs
@@ -13,7 +13,6 @@ const MIN_WALLET_CAPACITY: f64 = 100000.0f64;
 
 #[derive(Debug)]
 pub struct NodeWalletInfo {
-    pub privkey_path: PathBuf,
     pub testnet_address: String,
     pub lock_hash: String,
     pub lock_arg: String,
@@ -134,7 +133,6 @@ pub fn get_wallet_info(privkey_path: &Path) -> NodeWalletInfo {
     )
     .expect("get key info");
     NodeWalletInfo {
-        privkey_path: privkey_path.into(),
         testnet_address: look_after_in_line(&stdout, "testnet:"),
         lock_hash: look_after_in_line(&stdout, "lock_hash:"),
         lock_arg: look_after_in_line(&stdout, "lock_arg:"),


### PR DESCRIPTION
Update OPTIONS( delete one and add new three):	
    ...
    ~~-p  \<polyjuice-binaries-dir-path\>   Polyjuice binaries directory path~~	
    -k  \<privkey-path\>			            The private key file path
    -c  \<scripts-deploy-config-path\> 	    Scripts depoly config json file path
    -u  \<rpc-server-url\>				    Rpc server url [default: localhost:8119]

The original command line is as follows:

```bash
cargo run --bin gw-tools -- generate-config -g deploy/genesis-deploy-result.json -s deploy/scripts-deploy-result.json  
-o config.toml -p deploy/
```

The updated command line is as follows:

```bash
cargo run --bin gw-tools -- generate-config -g deploy/genesis-deploy-result.json -s deploy/scripts-deploy-result.json  
-o deploy/node1/config.toml -k deploy/node1/pk -c deploy/scripts-deploy.json 
```

All fields of the output config.toml will be filled in correctly. 

Note: 
- The scripts-deploy.json is generated by the command prepare-scripts.
- Each call can only output config file for one node.