### PR TITLE
Support charge tx fee in built-in scripts & withdrawal

### DIFF
--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -128,7 +128,7 @@ pub fn produce_block(param: ProduceBlockParam<'_>) -> Result<ProduceBlockResult>
         }
 
         // update the state
-        match state.apply_withdrawal_request(rollup_context, &request) {
+        match state.apply_withdrawal_request(rollup_context, block_producer_id, &request) {
             Ok(_) => {
                 used_withdrawal_requests.push(request);
                 state_checkpoint_list.push(state.calculate_state_checkpoint()?);

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -21,6 +21,4 @@ rlp = "0.5.0"
 secp256k1 = { version = "0.20", features = ["recovery"] }
 sha3 = "0.9.1"
 log = "0.4"
-
-[dev-dependencies]
 hex = "0.4"

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -258,15 +258,19 @@ impl Generator {
         args: StateTransitionArgs,
     ) -> Result<StateTransitionResult, Error> {
         let raw_block = args.l2block.raw();
+        let block_info = get_block_info(&raw_block);
         let withdrawal_requests: Vec<_> = args.l2block.withdrawals().into_iter().collect();
         // apply withdrawal to state
-        let withdrawal_receipts =
-            state.apply_withdrawal_requests(&self.rollup_context, &withdrawal_requests)?;
+        let block_producer_id: u32 = block_info.block_producer_id().unpack();
+        let withdrawal_receipts = state.apply_withdrawal_requests(
+            &self.rollup_context,
+            block_producer_id,
+            &withdrawal_requests,
+        )?;
         // apply deposition to state
         state.apply_deposit_requests(&self.rollup_context, &args.deposit_requests)?;
 
         // handle transactions
-        let block_info = get_block_info(&raw_block);
         let block_hash = raw_block.hash();
         let mut tx_receipts = Vec::with_capacity(args.l2block.transactions().len());
         for (tx_index, tx) in args.l2block.transactions().into_iter().enumerate() {

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -90,6 +90,10 @@ impl Generator {
         let sudt_script_hash: H256 = raw.sudt_script_hash().unpack();
         let amount: u128 = raw.amount().unpack();
         let capacity: u64 = raw.capacity().unpack();
+        let fee = raw.fee();
+        let fee_sudt_id: u32 = fee.sudt_id().unpack();
+        let fee_amount: u128 = fee.amount().unpack();
+        let account_short_address = to_short_address(&account_script_hash);
 
         // check capacity
         if capacity < MIN_WITHDRAWAL_CAPACITY {
@@ -106,9 +110,16 @@ impl Generator {
             .ok_or(AccountError::UnknownAccount)?; // find Simple UDT account
 
         // check CKB balance
-        let ckb_balance =
-            state.get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&account_script_hash))?;
-        if capacity as u128 > ckb_balance {
+        let ckb_balance = state.get_sudt_balance(CKB_SUDT_ACCOUNT_ID, account_short_address)?;
+        let required_ckb_capacity = {
+            let mut required_capacity = capacity as u128;
+            // Count withdrawal fee
+            if fee_sudt_id == CKB_SUDT_ACCOUNT_ID {
+                required_capacity = required_capacity.saturating_add(fee_amount);
+            }
+            required_capacity
+        };
+        if required_ckb_capacity > ckb_balance {
             return Err(WithdrawalError::Overdraft.into());
         }
         let l2_sudt_script_hash =
@@ -116,20 +127,32 @@ impl Generator {
         let sudt_id = state
             .get_account_id_by_script_hash(&l2_sudt_script_hash.into())?
             .ok_or(AccountError::UnknownSUDT)?;
+        // The sUDT id must not be equals to the CKB sUDT id if amount isn't 0
         if sudt_id != CKB_SUDT_ACCOUNT_ID {
             // check SUDT balance
             // user can't withdrawal 0 SUDT when non-CKB sudt_id exists
             if amount == 0 {
                 return Err(WithdrawalError::NonPositiveSUDTAmount.into());
             }
-            let balance =
-                state.get_sudt_balance(sudt_id, to_short_address(&account_script_hash))?;
-            if amount > balance {
+            let mut required_amount = amount;
+            if sudt_id == fee_sudt_id {
+                required_amount = required_amount.saturating_add(fee_amount);
+            }
+            let balance = state.get_sudt_balance(sudt_id, account_short_address)?;
+            if required_amount > balance {
                 return Err(WithdrawalError::Overdraft.into());
             }
         } else if amount != 0 {
             // user can't withdrawal CKB token via SUDT fields
             return Err(WithdrawalError::WithdrawFakedCKB.into());
+        }
+
+        // check fees if it isn't been cheked yet
+        if fee_sudt_id != CKB_SUDT_ACCOUNT_ID && fee_sudt_id != sudt_id && fee_amount > 0 {
+            let balance = state.get_sudt_balance(fee_sudt_id, account_short_address)?;
+            if fee_amount > balance {
+                return Err(WithdrawalError::Overdraft.into());
+            }
         }
 
         // check nonce

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -470,6 +470,7 @@ impl<'a, S: State, C: ChainStore, Mac: SupportMachine> Syscalls<Mac> for L2Sysca
                     sudt_id,
                     amount
                 );
+                machine.set_register(A0, Mac::REG::from_u8(SUCCESS));
                 Ok(true)
             }
             DEBUG_PRINT_SYSCALL_NUMBER => {

--- a/crates/generator/src/traits.rs
+++ b/crates/generator/src/traits.rs
@@ -29,6 +29,7 @@ pub trait StateExt {
     fn apply_withdrawal_request(
         &mut self,
         ctx: &RollupContext,
+        block_producer_id: u32,
         withdrawal_request: &WithdrawalRequest,
     ) -> Result<WithdrawalReceipt, Error>;
 
@@ -43,15 +44,24 @@ pub trait StateExt {
         Ok(())
     }
 
+    fn pay_fee(
+        &mut self,
+        payer_short_address: &[u8],
+        block_producer_short_address: &[u8],
+        sudt_id: u32,
+        amount: u128,
+    ) -> Result<(), Error>;
+
     fn apply_withdrawal_requests(
         &mut self,
         ctx: &RollupContext,
+        block_producer_id: u32,
         withdrawal_requests: &[WithdrawalRequest],
     ) -> Result<Vec<WithdrawalReceipt>, Error> {
         let mut receipts = Vec::with_capacity(withdrawal_requests.len());
 
         for request in withdrawal_requests {
-            let receipt = self.apply_withdrawal_request(ctx, request)?;
+            let receipt = self.apply_withdrawal_request(ctx, block_producer_id, request)?;
             receipts.push(receipt);
         }
 
@@ -86,6 +96,25 @@ impl<S: State + CodeStore> StateExt for S {
             self.store_data_hash(*data_hash)?;
             self.insert_data(*data_hash, Bytes::from(data.clone()));
         }
+        Ok(())
+    }
+
+    fn pay_fee(
+        &mut self,
+        payer_short_address: &[u8],
+        block_producer_short_address: &[u8],
+        sudt_id: u32,
+        amount: u128,
+    ) -> Result<(), Error> {
+        log::debug!(
+            "account: 0x{} pay fee to block_producer: 0x{}, sudt_id: {}, amount: {}",
+            hex::encode(&payer_short_address),
+            hex::encode(&block_producer_short_address),
+            sudt_id,
+            &amount
+        );
+        self.burn_sudt(sudt_id, payer_short_address, amount.into())?;
+        self.mint_sudt(sudt_id, block_producer_short_address, amount.into())?;
         Ok(())
     }
 
@@ -140,6 +169,7 @@ impl<S: State + CodeStore> StateExt for S {
     fn apply_withdrawal_request(
         &mut self,
         ctx: &RollupContext,
+        block_producer_id: u32,
         request: &WithdrawalRequest,
     ) -> Result<WithdrawalReceipt, Error> {
         let raw = request.raw();
@@ -147,15 +177,29 @@ impl<S: State + CodeStore> StateExt for S {
         let l2_sudt_script_hash: [u8; 32] =
             build_l2_sudt_script(&ctx, &raw.sudt_script_hash().unpack()).hash();
         let amount: u128 = raw.amount().unpack();
+        let withdrawal_short_address = to_short_address(&account_script_hash);
         // find user account
         let id = self
             .get_account_id_by_script_hash(&account_script_hash)?
             .ok_or(AccountError::UnknownAccount)?; // find Simple UDT account
         let capacity: u64 = raw.capacity().unpack();
+        // pay fee to block producer
+        {
+            let sudt_id: u32 = raw.fee().sudt_id().unpack();
+            let amount: u128 = raw.fee().amount().unpack();
+            let block_producer_script_hash = self.get_script_hash(block_producer_id)?;
+            let block_producer_short_address = to_short_address(&&block_producer_script_hash);
+            self.pay_fee(
+                withdrawal_short_address,
+                block_producer_short_address,
+                sudt_id,
+                amount,
+            )?;
+        }
         // burn CKB
         self.burn_sudt(
             CKB_SUDT_ACCOUNT_ID,
-            to_short_address(&account_script_hash),
+            withdrawal_short_address,
             capacity.into(),
         )?;
         let sudt_id = self
@@ -163,7 +207,7 @@ impl<S: State + CodeStore> StateExt for S {
             .ok_or(AccountError::UnknownSUDT)?;
         if sudt_id != CKB_SUDT_ACCOUNT_ID {
             // burn sudt
-            self.burn_sudt(sudt_id, to_short_address(&account_script_hash), amount)?;
+            self.burn_sudt(sudt_id, withdrawal_short_address, amount)?;
         } else if amount != 0 {
             return Err(WithdrawalError::WithdrawFakedCKB.into());
         }

--- a/crates/generator/src/traits.rs
+++ b/crates/generator/src/traits.rs
@@ -113,8 +113,8 @@ impl<S: State + CodeStore> StateExt for S {
             sudt_id,
             &amount
         );
-        self.burn_sudt(sudt_id, payer_short_address, amount.into())?;
-        self.mint_sudt(sudt_id, block_producer_short_address, amount.into())?;
+        self.burn_sudt(sudt_id, payer_short_address, amount)?;
+        self.mint_sudt(sudt_id, block_producer_short_address, amount)?;
         Ok(())
     }
 

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -5,7 +5,7 @@ use gw_types::{bytes::Bytes, packed::Script};
 pub trait CodeStore {
     fn insert_script(&mut self, script_hash: H256, script: Script);
     fn get_script(&self, script_hash: &H256) -> Option<Script>;
-    fn get_script_hash_by_short_address(&self, script_hash_prefix: &[u8]) -> Option<H256>;
+    fn get_script_hash_by_short_address(&self, short_address: &[u8]) -> Option<H256>;
     fn insert_data(&mut self, data_hash: H256, code: Bytes);
     fn get_data(&self, data_hash: &H256) -> Option<Bytes>;
 }

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -237,7 +237,7 @@ table SUDTTransfer {
     // godwoken short address (script_hash[0..n])
     to: Bytes,
     amount: Uint128,
-    fee_amount: Uint128,
+    fee: Uint128,
 }
 // --- end of layer2 SUDT ---
 

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -117,6 +117,8 @@ struct RawWithdrawalRequest {
     owner_lock_hash: Byte32,
     // layer1 lock to receive the payment, must exists on the chain
     payment_lock_hash: Byte32,
+    // withdrawal fee, paid to block producer
+    fee: Fee,
 }
 
 vector WithdrawalRequestVec <WithdrawalRequest>;
@@ -209,8 +211,14 @@ union MetaContractArgs {
     CreateAccount,
 }
 
+struct Fee {
+    sudt_id: Uint32,
+    amount: Uint128,
+}
+
 table CreateAccount {
     script: Script,
+    fee: Fee,
 }
 // --- end of Meta contract
 
@@ -229,7 +237,7 @@ table SUDTTransfer {
     // godwoken short address (script_hash[0..n])
     to: Bytes,
     amount: Uint128,
-    fee: Uint128,
+    fee_amount: Uint128,
 }
 // --- end of layer2 SUDT ---
 

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -4611,6 +4611,7 @@ impl ::core::fmt::Display for RawWithdrawalRequest {
         write!(f, ", {}: {}", "sell_capacity", self.sell_capacity())?;
         write!(f, ", {}: {}", "owner_lock_hash", self.owner_lock_hash())?;
         write!(f, ", {}: {}", "payment_lock_hash", self.payment_lock_hash())?;
+        write!(f, ", {}: {}", "fee", self.fee())?;
         write!(f, " }}")
     }
 }
@@ -4623,15 +4624,15 @@ impl ::core::default::Default for RawWithdrawalRequest {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         RawWithdrawalRequest::new_unchecked(v.into())
     }
 }
 impl RawWithdrawalRequest {
-    pub const TOTAL_SIZE: usize = 180;
-    pub const FIELD_SIZES: [usize; 9] = [4, 8, 16, 32, 32, 16, 8, 32, 32];
-    pub const FIELD_COUNT: usize = 9;
+    pub const TOTAL_SIZE: usize = 200;
+    pub const FIELD_SIZES: [usize; 10] = [4, 8, 16, 32, 32, 16, 8, 32, 32, 20];
+    pub const FIELD_COUNT: usize = 10;
     pub fn nonce(&self) -> Uint32 {
         Uint32::new_unchecked(self.0.slice(0..4))
     }
@@ -4658,6 +4659,9 @@ impl RawWithdrawalRequest {
     }
     pub fn payment_lock_hash(&self) -> Byte32 {
         Byte32::new_unchecked(self.0.slice(148..180))
+    }
+    pub fn fee(&self) -> Fee {
+        Fee::new_unchecked(self.0.slice(180..200))
     }
     pub fn as_reader<'r>(&'r self) -> RawWithdrawalRequestReader<'r> {
         RawWithdrawalRequestReader::new_unchecked(self.as_slice())
@@ -4695,6 +4699,7 @@ impl molecule::prelude::Entity for RawWithdrawalRequest {
             .sell_capacity(self.sell_capacity())
             .owner_lock_hash(self.owner_lock_hash())
             .payment_lock_hash(self.payment_lock_hash())
+            .fee(self.fee())
     }
 }
 #[derive(Clone, Copy)]
@@ -4730,13 +4735,14 @@ impl<'r> ::core::fmt::Display for RawWithdrawalRequestReader<'r> {
         write!(f, ", {}: {}", "sell_capacity", self.sell_capacity())?;
         write!(f, ", {}: {}", "owner_lock_hash", self.owner_lock_hash())?;
         write!(f, ", {}: {}", "payment_lock_hash", self.payment_lock_hash())?;
+        write!(f, ", {}: {}", "fee", self.fee())?;
         write!(f, " }}")
     }
 }
 impl<'r> RawWithdrawalRequestReader<'r> {
-    pub const TOTAL_SIZE: usize = 180;
-    pub const FIELD_SIZES: [usize; 9] = [4, 8, 16, 32, 32, 16, 8, 32, 32];
-    pub const FIELD_COUNT: usize = 9;
+    pub const TOTAL_SIZE: usize = 200;
+    pub const FIELD_SIZES: [usize; 10] = [4, 8, 16, 32, 32, 16, 8, 32, 32, 20];
+    pub const FIELD_COUNT: usize = 10;
     pub fn nonce(&self) -> Uint32Reader<'r> {
         Uint32Reader::new_unchecked(&self.as_slice()[0..4])
     }
@@ -4763,6 +4769,9 @@ impl<'r> RawWithdrawalRequestReader<'r> {
     }
     pub fn payment_lock_hash(&self) -> Byte32Reader<'r> {
         Byte32Reader::new_unchecked(&self.as_slice()[148..180])
+    }
+    pub fn fee(&self) -> FeeReader<'r> {
+        FeeReader::new_unchecked(&self.as_slice()[180..200])
     }
 }
 impl<'r> molecule::prelude::Reader<'r> for RawWithdrawalRequestReader<'r> {
@@ -4797,11 +4806,12 @@ pub struct RawWithdrawalRequestBuilder {
     pub(crate) sell_capacity: Uint64,
     pub(crate) owner_lock_hash: Byte32,
     pub(crate) payment_lock_hash: Byte32,
+    pub(crate) fee: Fee,
 }
 impl RawWithdrawalRequestBuilder {
-    pub const TOTAL_SIZE: usize = 180;
-    pub const FIELD_SIZES: [usize; 9] = [4, 8, 16, 32, 32, 16, 8, 32, 32];
-    pub const FIELD_COUNT: usize = 9;
+    pub const TOTAL_SIZE: usize = 200;
+    pub const FIELD_SIZES: [usize; 10] = [4, 8, 16, 32, 32, 16, 8, 32, 32, 20];
+    pub const FIELD_COUNT: usize = 10;
     pub fn nonce(mut self, v: Uint32) -> Self {
         self.nonce = v;
         self
@@ -4838,6 +4848,10 @@ impl RawWithdrawalRequestBuilder {
         self.payment_lock_hash = v;
         self
     }
+    pub fn fee(mut self, v: Fee) -> Self {
+        self.fee = v;
+        self
+    }
 }
 impl molecule::prelude::Builder for RawWithdrawalRequestBuilder {
     type Entity = RawWithdrawalRequest;
@@ -4855,6 +4869,7 @@ impl molecule::prelude::Builder for RawWithdrawalRequestBuilder {
         writer.write_all(self.sell_capacity.as_slice())?;
         writer.write_all(self.owner_lock_hash.as_slice())?;
         writer.write_all(self.payment_lock_hash.as_slice())?;
+        writer.write_all(self.fee.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {
@@ -5239,13 +5254,14 @@ impl ::core::fmt::Display for WithdrawalRequest {
 impl ::core::default::Default for WithdrawalRequest {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            196, 0, 0, 0, 12, 0, 0, 0, 192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            216, 0, 0, 0, 12, 0, 0, 0, 212, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         WithdrawalRequest::new_unchecked(v.into())
     }
@@ -8492,9 +8508,10 @@ impl ::core::fmt::Display for MetaContractArgs {
 impl ::core::default::Default for MetaContractArgs {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            0, 0, 0, 0, 61, 0, 0, 0, 8, 0, 0, 0, 53, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0, 0, 49, 0, 0,
+            0, 0, 0, 0, 85, 0, 0, 0, 12, 0, 0, 0, 65, 0, 0, 0, 53, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0,
+            0, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
         ];
         MetaContractArgs::new_unchecked(v.into())
     }
@@ -8734,6 +8751,169 @@ impl<'r> MetaContractArgsUnionReader<'r> {
     }
 }
 #[derive(Clone)]
+pub struct Fee(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for Fee {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for Fee {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for Fee {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "sudt_id", self.sudt_id())?;
+        write!(f, ", {}: {}", "amount", self.amount())?;
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for Fee {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        Fee::new_unchecked(v.into())
+    }
+}
+impl Fee {
+    pub const TOTAL_SIZE: usize = 20;
+    pub const FIELD_SIZES: [usize; 2] = [4, 16];
+    pub const FIELD_COUNT: usize = 2;
+    pub fn sudt_id(&self) -> Uint32 {
+        Uint32::new_unchecked(self.0.slice(0..4))
+    }
+    pub fn amount(&self) -> Uint128 {
+        Uint128::new_unchecked(self.0.slice(4..20))
+    }
+    pub fn as_reader<'r>(&'r self) -> FeeReader<'r> {
+        FeeReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Fee {
+    type Builder = FeeBuilder;
+    const NAME: &'static str = "Fee";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Fee(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        FeeReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        FeeReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .sudt_id(self.sudt_id())
+            .amount(self.amount())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct FeeReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for FeeReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for FeeReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for FeeReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "sudt_id", self.sudt_id())?;
+        write!(f, ", {}: {}", "amount", self.amount())?;
+        write!(f, " }}")
+    }
+}
+impl<'r> FeeReader<'r> {
+    pub const TOTAL_SIZE: usize = 20;
+    pub const FIELD_SIZES: [usize; 2] = [4, 16];
+    pub const FIELD_COUNT: usize = 2;
+    pub fn sudt_id(&self) -> Uint32Reader<'r> {
+        Uint32Reader::new_unchecked(&self.as_slice()[0..4])
+    }
+    pub fn amount(&self) -> Uint128Reader<'r> {
+        Uint128Reader::new_unchecked(&self.as_slice()[4..20])
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for FeeReader<'r> {
+    type Entity = Fee;
+    const NAME: &'static str = "FeeReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        FeeReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len != Self::TOTAL_SIZE {
+            return ve!(Self, TotalSizeNotMatch, Self::TOTAL_SIZE, slice_len);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct FeeBuilder {
+    pub(crate) sudt_id: Uint32,
+    pub(crate) amount: Uint128,
+}
+impl FeeBuilder {
+    pub const TOTAL_SIZE: usize = 20;
+    pub const FIELD_SIZES: [usize; 2] = [4, 16];
+    pub const FIELD_COUNT: usize = 2;
+    pub fn sudt_id(mut self, v: Uint32) -> Self {
+        self.sudt_id = v;
+        self
+    }
+    pub fn amount(mut self, v: Uint128) -> Self {
+        self.amount = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for FeeBuilder {
+    type Entity = Fee;
+    const NAME: &'static str = "FeeBuilder";
+    fn expected_length(&self) -> usize {
+        Self::TOTAL_SIZE
+    }
+    fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
+        writer.write_all(self.sudt_id.as_slice())?;
+        writer.write_all(self.amount.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Fee::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct CreateAccount(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for CreateAccount {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -8753,6 +8933,7 @@ impl ::core::fmt::Display for CreateAccount {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "script", self.script())?;
+        write!(f, ", {}: {}", "fee", self.fee())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -8763,15 +8944,15 @@ impl ::core::fmt::Display for CreateAccount {
 impl ::core::default::Default for CreateAccount {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            61, 0, 0, 0, 8, 0, 0, 0, 53, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0,
+            85, 0, 0, 0, 12, 0, 0, 0, 65, 0, 0, 0, 53, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0, 0, 49, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         CreateAccount::new_unchecked(v.into())
     }
 }
 impl CreateAccount {
-    pub const FIELD_COUNT: usize = 1;
+    pub const FIELD_COUNT: usize = 2;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -8791,11 +8972,17 @@ impl CreateAccount {
     pub fn script(&self) -> Script {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Script::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn fee(&self) -> Fee {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[8..]) as usize;
-            Script::new_unchecked(self.0.slice(start..end))
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Fee::new_unchecked(self.0.slice(start..end))
         } else {
-            Script::new_unchecked(self.0.slice(start..))
+            Fee::new_unchecked(self.0.slice(start..))
         }
     }
     pub fn as_reader<'r>(&'r self) -> CreateAccountReader<'r> {
@@ -8824,7 +9011,7 @@ impl molecule::prelude::Entity for CreateAccount {
         ::core::default::Default::default()
     }
     fn as_builder(self) -> Self::Builder {
-        Self::new_builder().script(self.script())
+        Self::new_builder().script(self.script()).fee(self.fee())
     }
 }
 #[derive(Clone, Copy)]
@@ -8847,6 +9034,7 @@ impl<'r> ::core::fmt::Display for CreateAccountReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "script", self.script())?;
+        write!(f, ", {}: {}", "fee", self.fee())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -8855,7 +9043,7 @@ impl<'r> ::core::fmt::Display for CreateAccountReader<'r> {
     }
 }
 impl<'r> CreateAccountReader<'r> {
-    pub const FIELD_COUNT: usize = 1;
+    pub const FIELD_COUNT: usize = 2;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -8875,11 +9063,17 @@ impl<'r> CreateAccountReader<'r> {
     pub fn script(&self) -> ScriptReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        ScriptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn fee(&self) -> FeeReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[8..]) as usize;
-            ScriptReader::new_unchecked(&self.as_slice()[start..end])
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            FeeReader::new_unchecked(&self.as_slice()[start..end])
         } else {
-            ScriptReader::new_unchecked(&self.as_slice()[start..])
+            FeeReader::new_unchecked(&self.as_slice()[start..])
         }
     }
 }
@@ -8935,17 +9129,23 @@ impl<'r> molecule::prelude::Reader<'r> for CreateAccountReader<'r> {
             return ve!(Self, OffsetsNotMatch);
         }
         ScriptReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        FeeReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
         Ok(())
     }
 }
 #[derive(Debug, Default)]
 pub struct CreateAccountBuilder {
     pub(crate) script: Script,
+    pub(crate) fee: Fee,
 }
 impl CreateAccountBuilder {
-    pub const FIELD_COUNT: usize = 1;
+    pub const FIELD_COUNT: usize = 2;
     pub fn script(mut self, v: Script) -> Self {
         self.script = v;
+        self
+    }
+    pub fn fee(mut self, v: Fee) -> Self {
+        self.fee = v;
         self
     }
 }
@@ -8953,18 +9153,23 @@ impl molecule::prelude::Builder for CreateAccountBuilder {
     type Entity = CreateAccount;
     const NAME: &'static str = "CreateAccountBuilder";
     fn expected_length(&self) -> usize {
-        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1) + self.script.as_slice().len()
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.script.as_slice().len()
+            + self.fee.as_slice().len()
     }
     fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
         let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
         let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
         offsets.push(total_size);
         total_size += self.script.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.fee.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
         }
         writer.write_all(self.script.as_slice())?;
+        writer.write_all(self.fee.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {
@@ -9526,7 +9731,7 @@ impl ::core::fmt::Display for SUDTTransfer {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "to", self.to())?;
         write!(f, ", {}: {}", "amount", self.amount())?;
-        write!(f, ", {}: {}", "fee", self.fee())?;
+        write!(f, ", {}: {}", "fee_amount", self.fee_amount())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -9573,7 +9778,7 @@ impl SUDTTransfer {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         Uint128::new_unchecked(self.0.slice(start..end))
     }
-    pub fn fee(&self) -> Uint128 {
+    pub fn fee_amount(&self) -> Uint128 {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
@@ -9612,7 +9817,7 @@ impl molecule::prelude::Entity for SUDTTransfer {
         Self::new_builder()
             .to(self.to())
             .amount(self.amount())
-            .fee(self.fee())
+            .fee_amount(self.fee_amount())
     }
 }
 #[derive(Clone, Copy)]
@@ -9636,7 +9841,7 @@ impl<'r> ::core::fmt::Display for SUDTTransferReader<'r> {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "to", self.to())?;
         write!(f, ", {}: {}", "amount", self.amount())?;
-        write!(f, ", {}: {}", "fee", self.fee())?;
+        write!(f, ", {}: {}", "fee_amount", self.fee_amount())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -9674,7 +9879,7 @@ impl<'r> SUDTTransferReader<'r> {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         Uint128Reader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn fee(&self) -> Uint128Reader<'r> {
+    pub fn fee_amount(&self) -> Uint128Reader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
@@ -9746,7 +9951,7 @@ impl<'r> molecule::prelude::Reader<'r> for SUDTTransferReader<'r> {
 pub struct SUDTTransferBuilder {
     pub(crate) to: Bytes,
     pub(crate) amount: Uint128,
-    pub(crate) fee: Uint128,
+    pub(crate) fee_amount: Uint128,
 }
 impl SUDTTransferBuilder {
     pub const FIELD_COUNT: usize = 3;
@@ -9758,8 +9963,8 @@ impl SUDTTransferBuilder {
         self.amount = v;
         self
     }
-    pub fn fee(mut self, v: Uint128) -> Self {
-        self.fee = v;
+    pub fn fee_amount(mut self, v: Uint128) -> Self {
+        self.fee_amount = v;
         self
     }
 }
@@ -9770,7 +9975,7 @@ impl molecule::prelude::Builder for SUDTTransferBuilder {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.to.as_slice().len()
             + self.amount.as_slice().len()
-            + self.fee.as_slice().len()
+            + self.fee_amount.as_slice().len()
     }
     fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
         let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
@@ -9780,14 +9985,14 @@ impl molecule::prelude::Builder for SUDTTransferBuilder {
         offsets.push(total_size);
         total_size += self.amount.as_slice().len();
         offsets.push(total_size);
-        total_size += self.fee.as_slice().len();
+        total_size += self.fee_amount.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
         }
         writer.write_all(self.to.as_slice())?;
         writer.write_all(self.amount.as_slice())?;
-        writer.write_all(self.fee.as_slice())?;
+        writer.write_all(self.fee_amount.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {
@@ -12728,7 +12933,7 @@ impl ::core::fmt::Display for VerifyWithdrawalWitness {
 impl ::core::default::Default for VerifyWithdrawalWitness {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            28, 2, 0, 0, 16, 0, 0, 0, 84, 1, 0, 0, 24, 2, 0, 0, 68, 1, 0, 0, 44, 0, 0, 0, 52, 0, 0,
+            48, 2, 0, 0, 16, 0, 0, 0, 84, 1, 0, 0, 44, 2, 0, 0, 68, 1, 0, 0, 44, 0, 0, 0, 52, 0, 0,
             0, 56, 0, 0, 0, 88, 0, 0, 0, 120, 0, 0, 0, 128, 0, 0, 0, 164, 0, 0, 0, 200, 0, 0, 0,
             204, 0, 0, 0, 240, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -12740,13 +12945,14 @@ impl ::core::default::Default for VerifyWithdrawalWitness {
             0, 0, 84, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0, 0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            196, 0, 0, 0, 12, 0, 0, 0, 192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            216, 0, 0, 0, 12, 0, 0, 0, 212, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         VerifyWithdrawalWitness::new_unchecked(v.into())
     }

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -9731,7 +9731,7 @@ impl ::core::fmt::Display for SUDTTransfer {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "to", self.to())?;
         write!(f, ", {}: {}", "amount", self.amount())?;
-        write!(f, ", {}: {}", "fee_amount", self.fee_amount())?;
+        write!(f, ", {}: {}", "fee", self.fee())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -9778,7 +9778,7 @@ impl SUDTTransfer {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         Uint128::new_unchecked(self.0.slice(start..end))
     }
-    pub fn fee_amount(&self) -> Uint128 {
+    pub fn fee(&self) -> Uint128 {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
@@ -9817,7 +9817,7 @@ impl molecule::prelude::Entity for SUDTTransfer {
         Self::new_builder()
             .to(self.to())
             .amount(self.amount())
-            .fee_amount(self.fee_amount())
+            .fee(self.fee())
     }
 }
 #[derive(Clone, Copy)]
@@ -9841,7 +9841,7 @@ impl<'r> ::core::fmt::Display for SUDTTransferReader<'r> {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "to", self.to())?;
         write!(f, ", {}: {}", "amount", self.amount())?;
-        write!(f, ", {}: {}", "fee_amount", self.fee_amount())?;
+        write!(f, ", {}: {}", "fee", self.fee())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -9879,7 +9879,7 @@ impl<'r> SUDTTransferReader<'r> {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         Uint128Reader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn fee_amount(&self) -> Uint128Reader<'r> {
+    pub fn fee(&self) -> Uint128Reader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
@@ -9951,7 +9951,7 @@ impl<'r> molecule::prelude::Reader<'r> for SUDTTransferReader<'r> {
 pub struct SUDTTransferBuilder {
     pub(crate) to: Bytes,
     pub(crate) amount: Uint128,
-    pub(crate) fee_amount: Uint128,
+    pub(crate) fee: Uint128,
 }
 impl SUDTTransferBuilder {
     pub const FIELD_COUNT: usize = 3;
@@ -9963,8 +9963,8 @@ impl SUDTTransferBuilder {
         self.amount = v;
         self
     }
-    pub fn fee_amount(mut self, v: Uint128) -> Self {
-        self.fee_amount = v;
+    pub fn fee(mut self, v: Uint128) -> Self {
+        self.fee = v;
         self
     }
 }
@@ -9975,7 +9975,7 @@ impl molecule::prelude::Builder for SUDTTransferBuilder {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.to.as_slice().len()
             + self.amount.as_slice().len()
-            + self.fee_amount.as_slice().len()
+            + self.fee.as_slice().len()
     }
     fn write<W: ::molecule::io::Write>(&self, writer: &mut W) -> ::molecule::io::Result<()> {
         let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
@@ -9985,14 +9985,14 @@ impl molecule::prelude::Builder for SUDTTransferBuilder {
         offsets.push(total_size);
         total_size += self.amount.as_slice().len();
         offsets.push(total_size);
-        total_size += self.fee_amount.as_slice().len();
+        total_size += self.fee.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
         }
         writer.write_all(self.to.as_slice())?;
         writer.write_all(self.amount.as_slice())?;
-        writer.write_all(self.fee_amount.as_slice())?;
+        writer.write_all(self.fee.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {

--- a/crates/web3-indexer/src/indexer.rs
+++ b/crates/web3-indexer/src/indexer.rs
@@ -390,12 +390,12 @@ impl Web3Indexer {
                         to_address.copy_from_slice(to_address_data.as_ref());
 
                         let amount: u128 = sudt_transfer.amount().unpack();
-                        let fee: u128 = sudt_transfer.fee().unpack();
+                        let fee_amount: u128 = sudt_transfer.fee_amount().unpack();
                         let value = amount;
 
                         // Represent SUDTTransfer fee in web3 style, set gas_price as 1 temporary.
                         let gas_price = 1;
-                        let gas_limit = fee;
+                        let gas_limit = fee_amount;
                         cumulative_gas_used += gas_limit;
 
                         let nonce: u32 = l2_transaction.raw().nonce().unpack();

--- a/crates/web3-indexer/src/indexer.rs
+++ b/crates/web3-indexer/src/indexer.rs
@@ -390,12 +390,12 @@ impl Web3Indexer {
                         to_address.copy_from_slice(to_address_data.as_ref());
 
                         let amount: u128 = sudt_transfer.amount().unpack();
-                        let fee_amount: u128 = sudt_transfer.fee_amount().unpack();
+                        let fee: u128 = sudt_transfer.fee().unpack();
                         let value = amount;
 
                         // Represent SUDTTransfer fee in web3 style, set gas_price as 1 temporary.
                         let gas_price = 1;
-                        let gas_limit = fee_amount;
+                        let gas_limit = fee;
                         cumulative_gas_used += gas_limit;
 
                         let nonce: u32 = l2_transaction.raw().nonce().unpack();


### PR DESCRIPTION
This PR aims to adjust structures & syscalls to make it possible to charge fees in built-in scripts & in the withdrawal.

Changes:

1. Update the godwoken.mol file, add `fee` fields to built-in scripts arguments.
2. Add the logic to charge the fee for withdrawal.
3. Adjust syscall numbers.
4. Add a new syscall SYS_PAY_FEE to record the fee paid to the block producer.