### PR TITLE
impl gw-tools-setup

### DIFF
--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -166,7 +166,7 @@ fn main() {
                     Arg::with_name("repos-dir-path")
                         .short("r")
                         .takes_value(true)
-                        .default_value("tmp/scripts-build-dir/")
+                        .default_value(prepare_scripts::REPOS_DIR_PATH)
                         .required(true)
                         .help("The repos dir path"),
                 )
@@ -174,7 +174,7 @@ fn main() {
                     Arg::with_name("scripts-dir-path")
                         .short("s")
                         .takes_value(true)
-                        .default_value("scripts/")
+                        .default_value(prepare_scripts::SCRIPTS_DIR_PATH)
                         .required(true)
                         .help("Scripts directory path"),
                 )
@@ -249,7 +249,7 @@ fn main() {
                     Arg::with_name("capacity")
                         .short("c")
                         .takes_value(true)
-                        .default_value("200000")
+                        .default_value(setup_nodes::TRANSFER_CAPACITY)
                         .required(true)
                         .help("Capacity transferred to every node"),
                 )
@@ -282,6 +282,59 @@ fn main() {
                         .takes_value(true)
                         .required(true)
                         .help("Output rollup config file path"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("setup")
+                .about("Prepare scripts, deploy scripts, setup nodes, deploy genesis and generate configs")
+                .arg(arg_ckb_rpc.clone())
+                .arg(
+                    Arg::with_name("indexer-rpc-url")
+                        .short("i")
+                        .takes_value(true)
+                        .default_value("http://127.0.0.1:8116")
+                        .required(true)
+                        .help("The URL of ckb indexer"),
+                )
+                .arg(
+                    Arg::with_name("mode")
+                        .short("m")
+                        .takes_value(true)
+                        .default_value("build")
+                        .required(true)
+                        .help("Scripts generation mode: build or copy"),
+                )
+                .arg(
+                    Arg::with_name("scripts-build-file-path")
+                        .short("s")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The scripts build json file path"),
+                )
+                .arg(arg_privkey_path.clone())
+                .arg(
+                    Arg::with_name("nodes-count")
+                        .short("n")
+                        .takes_value(true)
+                        .default_value("2")
+                        .required(true)
+                        .help("The godwoken nodes count"),
+                )
+                .arg(
+                    Arg::with_name("rpc-server-url")
+                        .short("u")
+                        .takes_value(true)
+                        .default_value("localhost:8119")
+                        .required(true)
+                        .help("The URL of rpc server"),
+                )
+                .arg(
+                    Arg::with_name("output-dir-path")
+                        .short("o")
+                        .takes_value(true)
+                        .default_value("deploy/")
+                        .required(true)
+                        .help("The godwoken nodes configs output dir path"),
                 ),
         );
 
@@ -414,6 +467,29 @@ fn main() {
                 output_dir,
                 poa_config_path,
                 rollup_config_path,
+            );
+        }
+        ("setup", Some(m)) => {
+            let ckb_rpc_url = m.value_of("ckb-rpc-url").unwrap();
+            let indexer_url = m.value_of("indexer-rpc-url").unwrap();
+            let mode = value_t!(m, "mode", prepare_scripts::ScriptsBuildMode).unwrap();
+            let scripts_path = Path::new(m.value_of("scripts-build-file-path").unwrap());
+            let privkey_path = Path::new(m.value_of("privkey-path").unwrap());
+            let nodes_count = m
+                .value_of("nodes-count")
+                .map(|c| c.parse().expect("nodes count"))
+                .unwrap();
+            let server_url = m.value_of("rpc-server-url").unwrap();
+            let output_dir = Path::new(m.value_of("output-dir-path").unwrap());
+            setup::setup(
+                ckb_rpc_url,
+                indexer_url,
+                mode,
+                scripts_path,
+                privkey_path,
+                nodes_count,
+                server_url,
+                output_dir,
             );
         }
         _ => {

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -4,6 +4,7 @@ mod deposit_ckb;
 mod generate_config;
 pub mod godwoken_rpc;
 mod prepare_scripts;
+mod setup;
 mod setup_nodes;
 mod utils;
 

--- a/crates/tools/src/prepare_scripts.rs
+++ b/crates/tools/src/prepare_scripts.rs
@@ -12,6 +12,8 @@ use std::{
 };
 use url::Url;
 
+pub const REPOS_DIR_PATH: &str = "tmp/scripts-build-dir/";
+pub const SCRIPTS_DIR_PATH: &str = "scripts/";
 const GODWOKEN_SCRIPTS: &str = "godwoken-scripts";
 const GODWOKEN_POLYJUICE: &str = "godwoken-polyjuice";
 const CLERKB: &str = "clerkb";

--- a/crates/tools/src/setup.rs
+++ b/crates/tools/src/setup.rs
@@ -6,11 +6,12 @@ use crate::setup_nodes::{self, setup_nodes};
 use crate::utils;
 use std::path::Path;
 
+#[allow(clippy::too_many_arguments)]
 pub fn setup(
     ckb_rpc_url: &str,
     indexer_url: &str,
     mode: ScriptsBuildMode,
-    input_file_path: &Path,
+    scripts_path: &Path,
     privkey_path: &Path,
     nodes_count: u8,
     server_url: &str,
@@ -19,7 +20,7 @@ pub fn setup(
     let prepare_scripts_result = Path::new("deploy/scripts-deploy.json");
     prepare_scripts(
         mode,
-        input_file_path,
+        scripts_path,
         Path::new(prepare_scripts::REPOS_DIR_PATH),
         Path::new(prepare_scripts::SCRIPTS_DIR_PATH),
         prepare_scripts_result,
@@ -37,7 +38,9 @@ pub fn setup(
 
     let poa_config_path = Path::new("deploy/poa-config.json");
     let rollup_config_path = Path::new("deploy/rollup-config.json");
-    let capacity = setup_nodes::TRANSFER_CAPACITY;
+    let capacity = setup_nodes::TRANSFER_CAPACITY
+        .parse()
+        .expect("get capacity");
     setup_nodes(
         privkey_path,
         capacity,
@@ -77,4 +80,6 @@ pub fn setup(
         )
         .expect("generate_config");
     });
+
+    log::info!("Finish");
 }

--- a/crates/tools/src/setup.rs
+++ b/crates/tools/src/setup.rs
@@ -1,0 +1,80 @@
+use crate::deploy_genesis::deploy_genesis;
+use crate::deploy_scripts::deploy_scripts;
+use crate::generate_config::generate_config;
+use crate::prepare_scripts::{self, prepare_scripts, ScriptsBuildMode};
+use crate::setup_nodes::{self, setup_nodes};
+use crate::utils;
+use std::path::Path;
+
+pub fn setup(
+    ckb_rpc_url: &str,
+    indexer_url: &str,
+    mode: ScriptsBuildMode,
+    input_file_path: &Path,
+    privkey_path: &Path,
+    nodes_count: u8,
+    server_url: &str,
+    output_dir: &Path,
+) {
+    let prepare_scripts_result = Path::new("deploy/scripts-deploy.json");
+    prepare_scripts(
+        mode,
+        input_file_path,
+        Path::new(prepare_scripts::REPOS_DIR_PATH),
+        Path::new(prepare_scripts::SCRIPTS_DIR_PATH),
+        prepare_scripts_result,
+    )
+    .expect("prepare scripts");
+
+    let scripts_deployment_result = Path::new("deploy/scripts-deploy-result.json");
+    deploy_scripts(
+        privkey_path,
+        ckb_rpc_url,
+        prepare_scripts_result,
+        scripts_deployment_result,
+    )
+    .expect("deploy scripts");
+
+    let poa_config_path = Path::new("deploy/poa-config.json");
+    let rollup_config_path = Path::new("deploy/rollup-config.json");
+    let capacity = setup_nodes::TRANSFER_CAPACITY;
+    setup_nodes(
+        privkey_path,
+        capacity,
+        nodes_count,
+        output_dir,
+        poa_config_path,
+        rollup_config_path,
+    );
+
+    let genesis_deploy_result = Path::new("deploy/genesis-deploy-result.json");
+    deploy_genesis(
+        privkey_path,
+        ckb_rpc_url,
+        scripts_deployment_result,
+        rollup_config_path,
+        poa_config_path,
+        None,
+        genesis_deploy_result,
+    )
+    .expect("deploy genesis");
+
+    (0..nodes_count).for_each(|index| {
+        let node_name = format!("node{}", index + 1);
+        let privkey_path = utils::make_path(output_dir, vec![&node_name, &"pk".to_owned()]);
+        let output_file_path =
+            utils::make_path(output_dir, vec![node_name, "config.toml".to_owned()]);
+        generate_config(
+            genesis_deploy_result,
+            scripts_deployment_result,
+            privkey_path.as_ref(),
+            ckb_rpc_url.to_owned(),
+            indexer_url.to_owned(),
+            output_file_path.as_ref(),
+            None,
+            prepare_scripts_result,
+            server_url.to_string(),
+        )
+        .expect("generate_config");
+    });
+}

--- a/crates/tools/src/setup.rs
+++ b/crates/tools/src/setup.rs
@@ -17,27 +17,28 @@ pub fn setup(
     server_url: &str,
     output_dir: &Path,
 ) {
-    let prepare_scripts_result = Path::new("deploy/scripts-deploy.json");
+    let prepare_scripts_result = utils::make_path(output_dir, vec!["scripts-deploy.json"]);
     prepare_scripts(
         mode,
         scripts_path,
         Path::new(prepare_scripts::REPOS_DIR_PATH),
         Path::new(prepare_scripts::SCRIPTS_DIR_PATH),
-        prepare_scripts_result,
+        &prepare_scripts_result,
     )
     .expect("prepare scripts");
 
-    let scripts_deployment_result = Path::new("deploy/scripts-deploy-result.json");
+    let scripts_deployment_result =
+        utils::make_path(output_dir, vec!["scripts-deploy-result.json"]);
     deploy_scripts(
         privkey_path,
         ckb_rpc_url,
-        prepare_scripts_result,
-        scripts_deployment_result,
+        &prepare_scripts_result,
+        &scripts_deployment_result,
     )
     .expect("deploy scripts");
 
-    let poa_config_path = Path::new("deploy/poa-config.json");
-    let rollup_config_path = Path::new("deploy/rollup-config.json");
+    let poa_config_path = utils::make_path(output_dir, vec!["poa-config.json"]);
+    let rollup_config_path = utils::make_path(output_dir, vec!["rollup-config.json"]);
     let capacity = setup_nodes::TRANSFER_CAPACITY
         .parse()
         .expect("get capacity");
@@ -46,19 +47,19 @@ pub fn setup(
         capacity,
         nodes_count,
         output_dir,
-        poa_config_path,
-        rollup_config_path,
+        &poa_config_path,
+        &rollup_config_path,
     );
 
-    let genesis_deploy_result = Path::new("deploy/genesis-deploy-result.json");
+    let genesis_deploy_result = utils::make_path(output_dir, vec!["genesis-deploy-result.json"]);
     deploy_genesis(
         privkey_path,
         ckb_rpc_url,
-        scripts_deployment_result,
-        rollup_config_path,
-        poa_config_path,
+        &scripts_deployment_result,
+        &rollup_config_path,
+        &poa_config_path,
         None,
-        genesis_deploy_result,
+        &genesis_deploy_result,
     )
     .expect("deploy genesis");
 
@@ -68,14 +69,14 @@ pub fn setup(
         let output_file_path =
             utils::make_path(output_dir, vec![node_name, "config.toml".to_owned()]);
         generate_config(
-            genesis_deploy_result,
-            scripts_deployment_result,
+            &genesis_deploy_result,
+            &scripts_deployment_result,
             privkey_path.as_ref(),
             ckb_rpc_url.to_owned(),
             indexer_url.to_owned(),
             output_file_path.as_ref(),
             None,
-            prepare_scripts_result,
+            &prepare_scripts_result,
             server_url.to_string(),
         )
         .expect("generate_config");

--- a/crates/tools/src/setup_nodes.rs
+++ b/crates/tools/src/setup_nodes.rs
@@ -9,7 +9,7 @@ use std::{
     thread, time,
 };
 
-pub const TRANSFER_CAPACITY: u32 = 200000;
+pub const TRANSFER_CAPACITY: &str = "200000";
 const MIN_WALLET_CAPACITY: f64 = 100000.0f64;
 
 #[derive(Debug)]

--- a/crates/tools/src/setup_nodes.rs
+++ b/crates/tools/src/setup_nodes.rs
@@ -9,6 +9,7 @@ use std::{
     thread, time,
 };
 
+pub const TRANSFER_CAPACITY: u32 = 200000;
 const MIN_WALLET_CAPACITY: f64 = 100000.0f64;
 
 #[derive(Debug)]


### PR DESCRIPTION
This command can do all the tasks such as preparing scripts, deploying scripts, setting nodes, deploying genesis and generating configs, with one line of command， the call is as follows:

```bash
RUST_LOG=info cargo +nightly run --bin gw-tools -- setup -s deploy/scripts-build.json -k deploy/pk -o deploy/
```

The input file scripts-build.json of this command is the same as the input file of prepare-scripts:

```json
{
    "prebuild_image": "nervos/godwoken-prebuilds:v0.3.1",
    "repos": {
        "godwoken_scripts": "https://github.com/nervosnetwork/godwoken-scripts#v0.6.0-rc1",
        "godwoken_polyjuice": "https://github.com/nervosnetwork/godwoken-polyjuice#v0.6.0-rc6",
        "clerkb": "https://github.com/nervosnetwork/clerkb#v0.4.0"
    },
    "scripts": {
        "challenge_lock": { "always_success": true },
        "tron_account_lock": { "always_success": true },
        "state_validator": { "always_success": true },
        "l2_sudt_validator": { "always_success": true },
        "meta_contract_validator": { "always_success": true },
        "eth_account_lock": { "always_success": true },
        "polyjuice_validator": { "always_success": true }
    }
}
```

After calling this command, you can start the Godwoken node directly, such as:

```bash
RUST_LOG=info cargo +nightly run --bin godwoken run -c deploy/node1/config.toml
```

```bash
RUST_LOG=info cargo +nightly run --bin godwoken run -c deploy/node2/config.toml
```

NOTE: If multiple node processes are started in the same environment, the listening port number can be manually modified in their respective config.toml. 