### PR TITLE
check config when deploy genesis and godwoken node run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.11.1",
+ "semver 1.0.3",
  "serde",
  "serde_json",
  "smol",
@@ -3943,7 +3944,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -4086,6 +4087,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -46,3 +46,4 @@ lazy_static = "1.4"
 sqlx = { version = "0.5", features = [ "runtime-async-std-native-tls", "postgres", "sqlite", "chrono", "decimal" ] }
 hex = "0.4"
 async-trait = "0.1"
+semver = "1.0"

--- a/crates/block-producer/src/main.rs
+++ b/crates/block-producer/src/main.rs
@@ -8,6 +8,7 @@ const COMMAND_RUN: &str = "run";
 const COMMAND_EXAMPLE_CONFIG: &str = "generate-example-config";
 const ARG_OUTPUT_PATH: &str = "output-path";
 const ARG_CONFIG: &str = "config";
+const ARG_SKIP_CONFIG_CHECK: &str = "skip-config-check";
 
 fn read_config<P: AsRef<Path>>(path: P) -> Result<Config> {
     let content = fs::read(&path)
@@ -40,6 +41,11 @@ fn run_cli() -> Result<()> {
                         .default_value("./config.toml")
                         .help("The config file path"),
                 )
+                .arg(
+                    Arg::with_name(ARG_SKIP_CONFIG_CHECK)
+                        .long(ARG_SKIP_CONFIG_CHECK)
+                        .help("Force to accept unsafe config file"),
+                )
                 .display_order(0),
         )
         .subcommand(
@@ -62,6 +68,9 @@ fn run_cli() -> Result<()> {
         (COMMAND_RUN, Some(m)) => {
             let config_path = m.value_of(ARG_CONFIG).unwrap();
             let config = read_config(&config_path)?;
+            if !m.is_present(ARG_SKIP_CONFIG_CHECK) {
+                unimplemented!()
+            }
             runner::run(config)?;
         }
         (COMMAND_EXAMPLE_CONFIG, Some(m)) => {

--- a/crates/block-producer/src/main.rs
+++ b/crates/block-producer/src/main.rs
@@ -68,10 +68,7 @@ fn run_cli() -> Result<()> {
         (COMMAND_RUN, Some(m)) => {
             let config_path = m.value_of(ARG_CONFIG).unwrap();
             let config = read_config(&config_path)?;
-            if !m.is_present(ARG_SKIP_CONFIG_CHECK) {
-                unimplemented!()
-            }
-            runner::run(config)?;
+            runner::run(config, m.is_present(ARG_SKIP_CONFIG_CHECK))?;
         }
         (COMMAND_EXAMPLE_CONFIG, Some(m)) => {
             let path = m.value_of(ARG_OUTPUT_PATH).unwrap();
@@ -81,7 +78,7 @@ fn run_cli() -> Result<()> {
             // default command: start a Godwoken node
             let config_path = "./config.toml";
             let config = read_config(&config_path)?;
-            runner::run(config)?;
+            runner::run(config, false)?;
         }
     };
     Ok(())

--- a/crates/block-producer/src/rpc_client.rs
+++ b/crates/block-producer/src/rpc_client.rs
@@ -954,4 +954,10 @@ impl RPCClient {
         )?;
         Ok(to_h256(tx_hash))
     }
+
+    pub async fn get_ckb_version(&self) -> Result<String> {
+        let node: ckb_jsonrpc_types::LocalNode =
+            to_result(self.ckb_client.request("local_node_info", None).await?)?;
+        Ok(node.version)
+    }
 }

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -7,7 +7,7 @@ use async_jsonrpc_client::HttpClient;
 use futures::{executor::block_on, select, FutureExt};
 use gw_chain::chain::Chain;
 use gw_common::H256;
-use gw_config::{Config, TestMode};
+use gw_config::{BlockProducerConfig, Config, TestMode};
 use gw_db::{config::Config as DBConfig, schema::COLUMNS, RocksDB};
 use gw_generator::{
     account_lock_manage::{secp256k1::Secp256k1Eth, AccountLockManage},
@@ -19,6 +19,7 @@ use gw_jsonrpc_types::test_mode::TestModePayload;
 use gw_mem_pool::pool::MemPool;
 use gw_rpc_server::{registry::Registry, server::start_jsonrpc_server};
 use gw_store::Store;
+use gw_types::prelude::{Pack, Unpack};
 use gw_types::{
     bytes::Bytes,
     packed::{NumberHash, RollupConfig, Script},
@@ -26,6 +27,7 @@ use gw_types::{
 };
 use gw_web3_indexer::Web3Indexer;
 use parking_lot::Mutex;
+use semver::Version;
 use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
     ConnectOptions,
@@ -36,6 +38,8 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+
+const MIN_CKB_VERSION: &str = "0.40.0";
 
 async fn poll_loop(
     rpc_client: RPCClient,
@@ -133,7 +137,7 @@ async fn poll_loop(
     }
 }
 
-pub fn run(config: Config) -> Result<()> {
+pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
     let rollup_config: RollupConfig = config.genesis.rollup_config.clone().into();
     let block_producer_config = config
         .block_producer
@@ -160,6 +164,12 @@ pub fn run(config: Config) -> Result<()> {
             rollup_type_script,
         }
     };
+
+    if !skip_config_check {
+        check_ckb_version(&rpc_client)?;
+        // check ckb indexer version
+        check_rollup_config_cell(&block_producer_config, &rollup_config, &rpc_client)?;
+    }
 
     // Open store
     let store = if config.store.path.as_os_str().is_empty() {
@@ -336,5 +346,56 @@ pub fn run(config: Config) -> Result<()> {
         };
     });
 
+    Ok(())
+}
+
+fn check_ckb_version(rpc_client: &RPCClient) -> Result<()> {
+    let ckb_version = block_on(rpc_client.get_ckb_version())?;
+    let ckb_version = ckb_version.split('(').collect::<Vec<&str>>()[0].trim_end();
+    if Version::parse(&ckb_version)? < Version::parse(MIN_CKB_VERSION)? {
+        return Err(anyhow!(
+            "The version of CKB node {} is lower than the minimum version {}",
+            ckb_version,
+            MIN_CKB_VERSION
+        ));
+    }
+    Ok(())
+}
+
+fn check_rollup_config_cell(
+    block_producer_config: &BlockProducerConfig,
+    rollup_config: &RollupConfig,
+    rpc_client: &RPCClient,
+) -> Result<()> {
+    let rollup_config_cell = block_on(
+        rpc_client.get_cell(
+            block_producer_config
+                .rollup_config_cell_dep
+                .out_point
+                .clone()
+                .into(),
+        ),
+    )?
+    .ok_or_else(|| anyhow!("can't find rollup config cell"))?;
+    let cell_data = format!("{:?}", rollup_config_cell.data.to_vec());
+    let accounts = rollup_config.allowed_eoa_type_hashes();
+    for i in accounts {
+        let account = format!("{:?}", i.as_slice());
+        let account = account.trim_matches(|c| c == '[' || c == ']');
+        if !cell_data.contains(&account) {
+            return Err(anyhow!("The eoa type is not registered: {}", i.to_string()));
+        }
+    }
+    let contracts = rollup_config.allowed_contract_type_hashes();
+    for i in contracts {
+        let contract = format!("{:?}", i.as_slice());
+        let contract = contract.trim_matches(|c| c == '[' || c == ']');
+        if !cell_data.contains(&contract) {
+            return Err(anyhow!(
+                "The contract type is not registered: {}",
+                i.to_string()
+            ));
+        }
+    }
     Ok(())
 }

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -398,8 +398,8 @@ fn check_rollup_config_cell(
         .collect::<Vec<_>>();
     if !unregistered_eoas.is_empty() || !unregistered_contracts.is_empty() {
         return Err(anyhow!(
-            "The eoa type hashes are not registered: {:#?}, \
-            the contract type hashes are not registered: {:#?}",
+            "Unregistered eoa type hashes: {:#?}, \
+            unregistered contract type hashes: {:#?}",
             unregistered_eoas,
             unregistered_contracts
         ));

--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -264,7 +264,12 @@ pub fn deploy_genesis(
     let poa_setup = poa_config.poa_setup;
 
     if !skip_config_check {
-        unimplemented!()
+        if H256([0u8; 32]) != user_rollup_config.burn_lock_hash {
+            return Err("burn lock hash is not all zeros as expected".to_string());
+        }
+        if poa_setup.round_intervals <= 0 {
+            return Err("round intervals value must be greater than 0".to_string());
+        }
     }
 
     let mut rpc_client = HttpRpcClient::new(ckb_rpc_url.to_string());

--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -267,7 +267,7 @@ pub fn deploy_genesis(
         if H256([0u8; 32]) != user_rollup_config.burn_lock_hash {
             return Err("burn lock hash is not all zeros as expected".to_string());
         }
-        if poa_setup.round_intervals <= 0 {
+        if poa_setup.round_intervals == 0 {
             return Err("round intervals value must be greater than 0".to_string());
         }
     }

--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -238,6 +238,7 @@ impl<'a> DeployContext<'a> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn deploy_genesis(
     privkey_path: &Path,
     ckb_rpc_url: &str,
@@ -246,6 +247,7 @@ pub fn deploy_genesis(
     poa_config_path: &Path,
     timestamp: Option<u64>,
     output_path: &Path,
+    skip_config_check: bool,
 ) -> Result<(), String> {
     let deployment_result_string =
         std::fs::read_to_string(deployment_result_path).map_err(|err| err.to_string())?;
@@ -260,6 +262,10 @@ pub fn deploy_genesis(
     let poa_config: PoAConfig =
         serde_json::from_str(&poa_config_string).map_err(|err| err.to_string())?;
     let poa_setup = poa_config.poa_setup;
+
+    if !skip_config_check {
+        unimplemented!()
+    }
 
     let mut rpc_client = HttpRpcClient::new(ckb_rpc_url.to_string());
     let network_type = get_network_type(&mut rpc_client)?;

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -87,6 +87,11 @@ fn main() {
                         .takes_value(true)
                         .required(true)
                         .help("The output json file path"),
+                )
+                .arg(
+                    Arg::with_name("skip-config-check")
+                        .long("skip-config-check")
+                        .help("Force to accept unsafe config file"),
                 ),
         )
         .subcommand(
@@ -438,6 +443,7 @@ fn main() {
                 &poa_config_path,
                 timestamp,
                 &output_path,
+                m.is_present("skip-config-check"),
             ) {
                 log::error!("Deploy genesis error: {}", err);
                 std::process::exit(-1);

--- a/crates/tools/src/setup.rs
+++ b/crates/tools/src/setup.rs
@@ -60,6 +60,7 @@ pub fn setup(
         &poa_config_path,
         None,
         &genesis_deploy_result,
+        false,
     )
     .expect("deploy genesis");
 


### PR DESCRIPTION
### check when deploy genesis:

- rollup-config.json：burn_lock_hash must be 0x0000..00
- poa-config.json: round_intervals > 0

If skip the check can use --skip-config-check flag：

```bash
cargo run --bin gw-tools -- deploy-genesis -k deploy/pk -d deploy/scripts-deploy-result.json -p deploy/poa-config.json  
-u deploy/rollup-config.json -o deploy/genesis-deploy-result.json --skip-config-check
``` 

### check when godwoken node start:

- ckb version > 0.40.0
- all eoa type hashes in the rollup config cell are registered in godwoken
- all contract type hashes in the rollup config cell are registered in godwoken

If skip the check can use --skip-config-check flag：

```bash
RUST_LOG=info cargo +nightly run --bin godwoken run -c deploy/node1/config.toml --skip-config-check
```