### PR TITLE
Add readonly mode

### DIFF
--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -167,8 +167,14 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
 
     if !skip_config_check {
         check_ckb_version(&rpc_client)?;
-        // check ckb indexer version
-        check_rollup_config_cell(&block_producer_config, &rollup_config, &rpc_client)?;
+        // TODO: check ckb indexer version
+        if NodeMode::ReadOnly != config.node_mode {
+            let block_producer_config = config
+                .block_producer
+                .clone()
+                .ok_or_else(|| anyhow!("not set block producer"))?;
+            check_rollup_config_cell(&block_producer_config, &rollup_config, &rpc_client)?;
+        }
     }
 
     // Open store

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -107,8 +107,8 @@ async fn poll_loop(
             }
 
             // TODO: implement test mode challenge control
-            if NodeMode::Disable == test_mode_control.mode()
-                || NodeMode::Enable == test_mode_control.mode()
+            if NodeMode::FullNode == test_mode_control.mode()
+                || NodeMode::Test == test_mode_control.mode()
                     && Some(TestModePayload::None) == test_mode_control.take_payload().await
             {
                 if let Err(err) = inner.block_producer.handle_event(event.clone()).await {
@@ -329,7 +329,7 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
         log::info!("Rollup config hash: {}", rollup_config_hash);
     }
 
-    if NodeMode::Enable == config.node_mode {
+    if NodeMode::Test == config.node_mode {
         log::info!("Test mode enabled!!!");
     }
 

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -241,8 +241,7 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
         store.clone(),
         mem_pool.clone(),
         generator.clone(),
-        config.node_mode,
-        test_mode_control.clone(),
+        Some(Box::new(test_mode_control.clone())),
     );
 
     // create web3 indexer

--- a/crates/block-producer/src/test_mode_control.rs
+++ b/crates/block-producer/src/test_mode_control.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use ckb_types::prelude::{Builder, Entity};
 use gw_common::H256;
-use gw_config::{BlockProducerConfig, TestMode};
+use gw_config::{BlockProducerConfig, NodeMode};
 use gw_jsonrpc_types::{
     godwoken::GlobalState,
     test_mode::{ShouldProduceBlock, TestModePayload},
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct TestModeControl {
-    mode: TestMode,
+    mode: NodeMode,
     payload: Arc<Mutex<Option<TestModePayload>>>,
     rpc_client: RPCClient,
     poa: Arc<Mutex<PoA>>,
@@ -28,7 +28,7 @@ pub struct TestModeControl {
 
 impl TestModeControl {
     pub fn create(
-        mode: TestMode,
+        mode: NodeMode,
         rpc_client: RPCClient,
         config: &BlockProducerConfig,
     ) -> Result<Self> {
@@ -48,7 +48,7 @@ impl TestModeControl {
         })
     }
 
-    pub fn mode(&self) -> TestMode {
+    pub fn mode(&self) -> NodeMode {
         self.mode
     }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -99,6 +99,6 @@ pub enum NodeMode {
 
 impl Default for NodeMode {
     fn default() -> Self {
-        NodeMode::FullNode
+        NodeMode::ReadOnly
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -94,6 +94,7 @@ pub struct Web3IndexerConfig {
 pub enum NodeMode {
     FullNode,
     Test,
+    ReadOnly,
 }
 
 impl Default for NodeMode {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -92,12 +92,12 @@ pub struct Web3IndexerConfig {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum NodeMode {
-    Enable,
-    Disable,
+    FullNode,
+    Test,
 }
 
 impl Default for NodeMode {
     fn default() -> Self {
-        NodeMode::Disable
+        NodeMode::FullNode
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
-    pub test_mode: TestMode,
+    pub node_mode: NodeMode,
     pub backends: Vec<BackendConfig>,
     pub store: StoreConfig,
     pub genesis: GenesisConfig,
@@ -91,13 +91,13 @@ pub struct Web3IndexerConfig {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum TestMode {
+pub enum NodeMode {
     Enable,
     Disable,
 }
 
-impl Default for TestMode {
+impl Default for NodeMode {
     fn default() -> Self {
-        TestMode::Disable
+        NodeMode::Disable
     }
 }

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use ckb_types::prelude::{Builder, Entity};
 use gw_common::{state::State, H256};
-use gw_config::TestMode;
+use gw_config::NodeMode;
 use gw_generator::{sudt::build_l2_sudt_script, Generator};
 use gw_jsonrpc_types::{
     blockchain::Script,
@@ -51,7 +51,7 @@ pub struct Registry {
     generator: Arc<Generator>,
     mem_pool: Arc<MemPool>,
     store: Store,
-    test_mode: TestMode,
+    node_mode: NodeMode,
     tests_rpc_impl: Arc<BoxedTestsRPCImpl>,
 }
 
@@ -60,7 +60,7 @@ impl Registry {
         store: Store,
         mem_pool: Arc<MemPool>,
         generator: Arc<Generator>,
-        test_mode: TestMode,
+        node_mode: NodeMode,
         tests_rpc_impl: T,
     ) -> Self
     where
@@ -70,7 +70,7 @@ impl Registry {
             mem_pool,
             store,
             generator,
-            test_mode,
+            node_mode,
             tests_rpc_impl: Arc::new(Box::new(tests_rpc_impl)),
         }
     }
@@ -109,7 +109,7 @@ impl Registry {
             .with_method("compute_l2_sudt_script_hash", compute_l2_sudt_script_hash);
 
         // Tests
-        if TestMode::Enable == self.test_mode {
+        if NodeMode::Enable == self.node_mode {
             server = server
                 .with_data(Data(Arc::clone(&self.tests_rpc_impl)))
                 .with_method("tests_produce_block", tests_produce_block)

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -106,9 +106,9 @@ impl Registry {
             .with_method("compute_l2_sudt_script_hash", compute_l2_sudt_script_hash);
 
         // Tests
-        if let Some(r) = self.tests_rpc_impl {
+        if let Some(tests_rpc_impl) = self.tests_rpc_impl {
             server = server
-                .with_data(Data(Arc::clone(&r)))
+                .with_data(Data(Arc::clone(&tests_rpc_impl)))
                 .with_method("tests_produce_block", tests_produce_block)
                 .with_method("tests_should_produce_block", tests_should_produce_block)
                 .with_method("tests_get_global_state", tests_get_global_state);

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use ckb_types::prelude::{Builder, Entity};
 use gw_common::{state::State, H256};
-use gw_config::NodeMode;
 use gw_generator::{sudt::build_l2_sudt_script, Generator};
 use gw_jsonrpc_types::{
     blockchain::Script,
@@ -51,8 +50,7 @@ pub struct Registry {
     generator: Arc<Generator>,
     mem_pool: Arc<MemPool>,
     store: Store,
-    node_mode: NodeMode,
-    tests_rpc_impl: Arc<BoxedTestsRPCImpl>,
+    tests_rpc_impl: Option<Arc<BoxedTestsRPCImpl>>,
 }
 
 impl Registry {
@@ -60,8 +58,7 @@ impl Registry {
         store: Store,
         mem_pool: Arc<MemPool>,
         generator: Arc<Generator>,
-        node_mode: NodeMode,
-        tests_rpc_impl: T,
+        tests_rpc_impl: Option<Box<T>>,
     ) -> Self
     where
         T: TestModeRPC + Send + Sync + 'static,
@@ -70,8 +67,8 @@ impl Registry {
             mem_pool,
             store,
             generator,
-            node_mode,
-            tests_rpc_impl: Arc::new(Box::new(tests_rpc_impl)),
+            tests_rpc_impl: tests_rpc_impl
+                .map(|r| Arc::new(r as Box<dyn TestModeRPC + Sync + Send + 'static>)),
         }
     }
 
@@ -109,9 +106,9 @@ impl Registry {
             .with_method("compute_l2_sudt_script_hash", compute_l2_sudt_script_hash);
 
         // Tests
-        if NodeMode::Test == self.node_mode {
+        if let Some(r) = self.tests_rpc_impl {
             server = server
-                .with_data(Data(Arc::clone(&self.tests_rpc_impl)))
+                .with_data(Data(Arc::clone(&r)))
                 .with_method("tests_produce_block", tests_produce_block)
                 .with_method("tests_should_produce_block", tests_should_produce_block)
                 .with_method("tests_get_global_state", tests_get_global_state);

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -109,7 +109,7 @@ impl Registry {
             .with_method("compute_l2_sudt_script_hash", compute_l2_sudt_script_hash);
 
         // Tests
-        if NodeMode::Enable == self.node_mode {
+        if NodeMode::Test == self.node_mode {
             server = server
                 .with_data(Data(Arc::clone(&self.tests_rpc_impl)))
                 .with_method("tests_produce_block", tests_produce_block)

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -236,7 +236,7 @@ pub fn generate_config(
         rpc_server,
         block_producer,
         web3_indexer,
-        node_mode: NodeMode::Disable,
+        node_mode: NodeMode::FullNode,
     };
 
     let output_content = toml::to_string_pretty(&config).expect("serde toml to string pretty");

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -5,8 +5,8 @@ use anyhow::{anyhow, Result};
 use ckb_sdk::HttpRpcClient;
 use ckb_types::prelude::{Builder, Entity};
 use gw_config::{
-    BackendConfig, BlockProducerConfig, ChainConfig, Config, GenesisConfig, RPCClientConfig,
-    RPCServerConfig, StoreConfig, TestMode, WalletConfig, Web3IndexerConfig,
+    BackendConfig, BlockProducerConfig, ChainConfig, Config, GenesisConfig, NodeMode,
+    RPCClientConfig, RPCServerConfig, StoreConfig, WalletConfig, Web3IndexerConfig,
 };
 use gw_jsonrpc_types::godwoken::L2BlockCommittedInfo;
 use gw_types::{core::ScriptHashType, packed::Script, prelude::*};
@@ -236,7 +236,7 @@ pub fn generate_config(
         rpc_server,
         block_producer,
         web3_indexer,
-        test_mode: TestMode::Disable,
+        node_mode: NodeMode::Disable,
     };
 
     let output_content = toml::to_string_pretty(&config).expect("serde toml to string pretty");

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -236,7 +236,7 @@ pub fn generate_config(
         rpc_server,
         block_producer,
         web3_indexer,
-        node_mode: NodeMode::FullNode,
+        node_mode: NodeMode::ReadOnly,
     };
 
     let output_content = toml::to_string_pretty(&config).expect("serde toml to string pretty");


### PR DESCRIPTION
When ReadOnly:

- node will not produce blocks.
- node block_producer configuration can be filled in blanks
- skip check check_rollup_config_cell