### PR TITLE
Set l2tx max cycles

### DIFF
--- a/crates/block-producer/src/block_producer.rs
+++ b/crates/block-producer/src/block_producer.rs
@@ -390,16 +390,18 @@ impl BlockProducer {
             mut global_state,
             unused_transactions,
             unused_withdrawal_requests,
+            l2tx_offchain_used_cycles,
         } = block_result;
         let number: u64 = block.raw().number().unpack();
         log::info!(
-            "produce new block #{} (txs: {}, deposits: {}, withdrawals: {}, staled txs: {}, staled withdrawals: {})",
+            "produce new block #{} (txs: {}, deposits: {}, withdrawals: {}, staled txs: {}, staled withdrawals: {}, offchain cycles: {})",
             number,
             block.transactions().len(),
             deposit_cells.len(),
             block.withdrawals().len(),
             unused_transactions.len(),
-            unused_withdrawal_requests.len()
+            unused_withdrawal_requests.len(),
+            l2tx_offchain_used_cycles
         );
 
         if let Some(ref tests_control) = self.tests_control {

--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -33,6 +33,7 @@ pub struct ProduceBlockResult {
     pub global_state: GlobalState,
     pub unused_transactions: Vec<L2Transaction>,
     pub unused_withdrawal_requests: Vec<WithdrawalRequest>,
+    pub l2tx_offchain_used_cycles: u64,
 }
 
 pub struct ProduceBlockParam<'a> {
@@ -158,6 +159,7 @@ pub fn produce_block(param: ProduceBlockParam<'_>) -> Result<ProduceBlockResult>
         .build();
     let chain_view = ChainView::new(&db, parent_block_hash);
 
+    let mut l2tx_offchain_used_cycles: u64 = 0;
     let has_txs = !txs.is_empty();
     for tx in txs {
         // 1. verify tx
@@ -209,6 +211,8 @@ pub fn produce_block(param: ProduceBlockParam<'_>) -> Result<ProduceBlockResult>
             .build();
         used_transactions.push(tx);
         tx_receipts.push(receipt);
+        l2tx_offchain_used_cycles =
+            l2tx_offchain_used_cycles.saturating_add(run_result.used_cycles);
     }
     assert_eq!(used_transactions.len(), tx_receipts.len());
     let touched_keys: Vec<H256> = state
@@ -357,5 +361,6 @@ pub fn produce_block(param: ProduceBlockParam<'_>) -> Result<ProduceBlockResult>
         global_state,
         unused_transactions,
         unused_withdrawal_requests,
+        l2tx_offchain_used_cycles,
     })
 }

--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -179,7 +179,11 @@ pub fn produce_block(param: ProduceBlockParam<'_>) -> Result<ProduceBlockResult>
             match generator.execute_transaction(&chain_view, &state, &block_info, &raw_tx) {
                 Ok(run_result) => run_result,
                 Err(err) => {
-                    log::debug!("produce_block.execute tx error: {:?}", err);
+                    log::info!(
+                        "[produce_block] execute tx {} error: {:?}",
+                        hex::encode(&tx.hash()),
+                        err
+                    );
                     unused_transactions.push(tx);
                     continue;
                 }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -830,7 +830,16 @@ impl Chain {
                     tx_receipts,
                     prev_txs_state,
                     withdrawal_receipts,
-                } => (withdrawal_receipts, prev_txs_state, tx_receipts),
+                    offchain_used_cycles,
+                } => {
+                    log::debug!(
+                        "Process #{} txs: {} offchain used cycles {}",
+                        block_number,
+                        tx_receipts.len(),
+                        offchain_used_cycles
+                    );
+                    (withdrawal_receipts, prev_txs_state, tx_receipts)
+                }
                 StateTransitionResult::Challenge { target, error } => {
                     log::debug!("verify and apply state transition error {}", error);
                     return Ok(Some(target));

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -40,6 +40,8 @@ const MIN_WITHDRAWAL_CAPACITY: u64 = 100_00000000;
 const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25_000;
 // 2MB
 const MAX_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
+// max cycles
+const L2TX_MAX_CYCLES: u64 = 3500_0000;
 
 pub struct StateTransitionArgs {
     pub l2block: L2Block,
@@ -465,7 +467,7 @@ impl Generator {
 
         let mut run_result = RunResult::default();
         {
-            let core_machine = Box::<AsmCoreMachine>::default();
+            let core_machine = AsmCoreMachine::new_with_max_cycles(L2TX_MAX_CYCLES);
             let machine_builder =
                 DefaultMachineBuilder::new(core_machine).syscall(Box::new(L2Syscalls {
                     chain,

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -42,7 +42,7 @@ const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25_000;
 // 2MB
 const MAX_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
 // max cycles
-const L2TX_MAX_CYCLES: u64 = 3500_0000;
+const L2TX_MAX_CYCLES: u64 = 4500_0000;
 
 pub struct StateTransitionArgs {
     pub l2block: L2Block,

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -42,7 +42,7 @@ const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25_000;
 // 2MB
 const MAX_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
 // max cycles
-const L2TX_MAX_CYCLES: u64 = 4500_0000;
+const L2TX_MAX_CYCLES: u64 = 5000_0000;
 
 pub struct StateTransitionArgs {
     pub l2block: L2Block,

--- a/crates/generator/src/lib.rs
+++ b/crates/generator/src/lib.rs
@@ -11,6 +11,7 @@ pub mod sudt;
 pub mod syscalls;
 pub mod traits;
 pub mod types;
+pub mod vm_cost_model;
 
 #[cfg(test)]
 mod tests;

--- a/crates/generator/src/vm_cost_model.rs
+++ b/crates/generator/src/vm_cost_model.rs
@@ -1,0 +1,68 @@
+//! CKB VM cost model.
+//!
+//! The cost model assign cycles to instructions.
+//! copied from https://github.com/nervosnetwork/ckb/blob/develop/script/src/cost_model.rs
+use ckb_vm::{
+    instructions::{extract_opcode, insts},
+    Instruction,
+};
+
+/// How many bytes can transfer when VM costs one cycle.
+// 0.25 cycles per byte
+pub const BYTES_PER_CYCLE: u64 = 4;
+
+/// Calculates how many cycles spent to load the specified number of bytes.
+pub fn transferred_byte_cycles(bytes: u64) -> u64 {
+    // Compiler will optimize the divisin here to shifts.
+    (bytes + BYTES_PER_CYCLE - 1) / BYTES_PER_CYCLE
+}
+
+/// Returns the spent cycles to execute the secific instruction.
+pub fn instruction_cycles(i: Instruction) -> u64 {
+    match extract_opcode(i) {
+        // IMC
+        insts::OP_JALR => 3,
+        insts::OP_LD => 2,
+        insts::OP_LW => 3,
+        insts::OP_LH => 3,
+        insts::OP_LB => 3,
+        insts::OP_LWU => 3,
+        insts::OP_LHU => 3,
+        insts::OP_LBU => 3,
+        insts::OP_SB => 3,
+        insts::OP_SH => 3,
+        insts::OP_SW => 3,
+        insts::OP_SD => 2,
+        insts::OP_BEQ => 3,
+        insts::OP_BGE => 3,
+        insts::OP_BGEU => 3,
+        insts::OP_BLT => 3,
+        insts::OP_BLTU => 3,
+        insts::OP_BNE => 3,
+        insts::OP_EBREAK => 500,
+        insts::OP_ECALL => 500,
+        insts::OP_JAL => 3,
+        insts::OP_MUL => 5,
+        insts::OP_MULW => 5,
+        insts::OP_MULH => 5,
+        insts::OP_MULHU => 5,
+        insts::OP_MULHSU => 5,
+        insts::OP_DIV => 32,
+        insts::OP_DIVW => 32,
+        insts::OP_DIVU => 32,
+        insts::OP_DIVUW => 32,
+        insts::OP_REM => 32,
+        insts::OP_REMW => 32,
+        insts::OP_REMU => 32,
+        insts::OP_REMUW => 32,
+        // // MOP
+        // insts::OP_WIDE_MUL => 5,
+        // insts::OP_WIDE_MULU => 5,
+        // insts::OP_WIDE_MULSU => 5,
+        // insts::OP_WIDE_DIV => 32,
+        // insts::OP_WIDE_DIVU => 32,
+        // insts::OP_FAR_JUMP_REL => 3,
+        // insts::OP_FAR_JUMP_ABS => 3,
+        _ => 1,
+    }
+}

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -140,6 +140,7 @@ pub fn build_sync_tx(
         global_state,
         unused_transactions,
         unused_withdrawal_requests,
+        l2tx_offchain_used_cycles: _,
     } = produce_block_result;
     assert!(unused_transactions.is_empty());
     assert!(unused_withdrawal_requests.is_empty());

--- a/crates/types/src/offchain.rs
+++ b/crates/types/src/offchain.rs
@@ -15,4 +15,6 @@ pub struct RunResult {
     pub read_data: HashMap<H256, usize>,
     // log data
     pub logs: Vec<LogItem>,
+    // used cycles
+    pub used_cycles: u64,
 }


### PR DESCRIPTION
1. Introduce VM cycles model.
2. Limit a single l2 tx to 5000_0000 cycles. based on our previous test case, the maximum cycles is ~4900_0000, so I choose a value higher than this.
3. Output offchain cycles of a layer2 block.