### PR TITLE
fix(web3-indexer): collect tron transaction to support getTransactionReceipt for tron

### DIFF
--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -289,6 +289,7 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
             })?;
             let polyjuce_type_script_hash = web3_indexer_config.polyjuice_script_type_hash;
             let eth_account_lock_hash = web3_indexer_config.eth_account_lock_hash;
+            let tron_account_lock_hash = web3_indexer_config.tron_account_lock_hash;
             let web3_indexer = Web3Indexer::new(
                 pool,
                 config
@@ -298,6 +299,7 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
                 polyjuce_type_script_hash,
                 config.genesis.rollup_type_hash,
                 eth_account_lock_hash,
+                tron_account_lock_hash,
             );
             Some(web3_indexer)
         }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -124,7 +124,7 @@ pub struct Web3IndexerConfig {
     pub database_url: String,
     pub polyjuice_script_type_hash: H256,
     pub eth_account_lock_hash: H256,
-    pub tron_account_lock_hash: H256,
+    pub tron_account_lock_hash: Option<H256>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -124,6 +124,7 @@ pub struct Web3IndexerConfig {
     pub database_url: String,
     pub polyjuice_script_type_hash: H256,
     pub eth_account_lock_hash: H256,
+    pub tron_account_lock_hash: H256,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -291,7 +291,7 @@ pub fn generate_config(
             database_url: database_url.to_owned(),
             polyjuice_script_type_hash: scripts_results.polyjuice_validator.script_type_hash,
             eth_account_lock_hash: eth_account_lock_hash.to_owned(),
-            tron_account_lock_hash: tron_account_lock_hash,
+            tron_account_lock_hash,
         }),
         None => None,
     };

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -2,6 +2,7 @@ use crate::deploy_genesis::{get_secp_data, GenesisDeploymentResult};
 use crate::deploy_scripts::ScriptsDeploymentResult;
 use crate::setup::get_wallet_info;
 use anyhow::{anyhow, Result};
+use ckb_fixed_hash::H256;
 use ckb_sdk::HttpRpcClient;
 use ckb_types::prelude::{Builder, Entity};
 use gw_config::{
@@ -281,11 +282,18 @@ pub fn generate_config(
         .allowed_eoa_type_hashes
         .get(0)
         .ok_or_else(|| anyhow!("No allowed EoA type hashes in the rollup config"))?;
+    let tron_allowed_eoa = genesis.rollup_config.allowed_eoa_type_hashes.get(1);
+    let default_tron = &H256([0u8; 32]);
+    let tron_account_lock_hash = match tron_allowed_eoa {
+        Some(code_hash) => code_hash,
+        _ => default_tron, // set a default value
+    };
     let web3_indexer = match database_url {
         Some(database_url) => Some(Web3IndexerConfig {
             database_url: database_url.to_owned(),
             polyjuice_script_type_hash: scripts_results.polyjuice_validator.script_type_hash,
             eth_account_lock_hash: eth_account_lock_hash.to_owned(),
+            tron_account_lock_hash: tron_account_lock_hash.to_owned(),
         }),
         None => None,
     };

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -2,7 +2,6 @@ use crate::deploy_genesis::{get_secp_data, GenesisDeploymentResult};
 use crate::deploy_scripts::ScriptsDeploymentResult;
 use crate::setup::get_wallet_info;
 use anyhow::{anyhow, Result};
-use ckb_fixed_hash::H256;
 use ckb_sdk::HttpRpcClient;
 use ckb_types::prelude::{Builder, Entity};
 use gw_config::{
@@ -282,18 +281,17 @@ pub fn generate_config(
         .allowed_eoa_type_hashes
         .get(0)
         .ok_or_else(|| anyhow!("No allowed EoA type hashes in the rollup config"))?;
-    let tron_allowed_eoa = genesis.rollup_config.allowed_eoa_type_hashes.get(1);
-    let default_tron = &H256([0u8; 32]);
-    let tron_account_lock_hash = match tron_allowed_eoa {
-        Some(code_hash) => code_hash,
-        _ => default_tron, // set a default value
+    let tron_allowed_eoa_hash = genesis.rollup_config.allowed_eoa_type_hashes.get(1);
+    let tron_account_lock_hash = match tron_allowed_eoa_hash {
+        Some(code_hash) => Some(code_hash.to_owned()),
+        None => None,
     };
     let web3_indexer = match database_url {
         Some(database_url) => Some(Web3IndexerConfig {
             database_url: database_url.to_owned(),
             polyjuice_script_type_hash: scripts_results.polyjuice_validator.script_type_hash,
             eth_account_lock_hash: eth_account_lock_hash.to_owned(),
-            tron_account_lock_hash: tron_account_lock_hash.to_owned(),
+            tron_account_lock_hash: tron_account_lock_hash,
         }),
         None => None,
     };

--- a/crates/web3-indexer/src/indexer.rs
+++ b/crates/web3-indexer/src/indexer.rs
@@ -36,6 +36,7 @@ pub struct Web3Indexer {
     polyjuice_type_script_hash: H256,
     rollup_type_hash: H256,
     eth_account_lock_hash: H256,
+    tron_account_lock_hash: H256,
 }
 
 impl Web3Indexer {
@@ -45,6 +46,7 @@ impl Web3Indexer {
         polyjuice_type_script_hash: H256,
         rollup_type_hash: H256,
         eth_account_lock_hash: H256,
+        tron_account_lock_hash: H256,
     ) -> Self {
         Web3Indexer {
             pool,
@@ -52,6 +54,7 @@ impl Web3Indexer {
             polyjuice_type_script_hash,
             rollup_type_hash,
             eth_account_lock_hash,
+            tron_account_lock_hash,
         }
     }
 
@@ -203,8 +206,10 @@ impl Web3Indexer {
                     anyhow!("Can't get script by script_hash: {:?}", from_script_hash)
                 })?;
             let from_script_code_hash: H256 = from_script.code_hash().unpack();
-            // skip tx with non eth_account_lock from_id
-            if from_script_code_hash != self.eth_account_lock_hash {
+            // skip tx with non eth_account_lock or non tron_account_lock from_id
+            if from_script_code_hash != self.eth_account_lock_hash
+                || from_script_code_hash != self.tron_account_lock_hash
+            {
                 continue;
             }
             // from_address is the script's args in eth account lock

--- a/crates/web3-indexer/src/indexer.rs
+++ b/crates/web3-indexer/src/indexer.rs
@@ -206,9 +206,9 @@ impl Web3Indexer {
                     anyhow!("Can't get script by script_hash: {:?}", from_script_hash)
                 })?;
             let from_script_code_hash: H256 = from_script.code_hash().unpack();
-            // skip tx with non eth_account_lock or non tron_account_lock from_id
+            // skip tx with neither eth_account_lock nor tron_account_lock from_id
             if from_script_code_hash != self.eth_account_lock_hash
-                || from_script_code_hash != self.tron_account_lock_hash
+                && from_script_code_hash != self.tron_account_lock_hash
             {
                 continue;
             }

--- a/crates/web3-indexer/src/indexer.rs
+++ b/crates/web3-indexer/src/indexer.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::{
     helper::{
         account_id_to_eth_address, hex, parse_log, GwLog, PolyjuiceArgs, GW_LOG_POLYJUICE_SYSTEM,
@@ -35,8 +37,7 @@ pub struct Web3Indexer {
     l2_sudt_type_script_hash: H256,
     polyjuice_type_script_hash: H256,
     rollup_type_hash: H256,
-    eth_account_lock_hash: H256,
-    tron_account_lock_hash: Option<H256>,
+    allowed_eoa_hashes: HashSet<H256>,
 }
 
 impl Web3Indexer {
@@ -48,13 +49,17 @@ impl Web3Indexer {
         eth_account_lock_hash: H256,
         tron_account_lock_hash: Option<H256>,
     ) -> Self {
+        let mut allowed_eoa_hashes = HashSet::default();
+        allowed_eoa_hashes.insert(eth_account_lock_hash);
+        if let Some(code_hash) = tron_account_lock_hash {
+            allowed_eoa_hashes.insert(code_hash);
+        };
         Web3Indexer {
             pool,
             l2_sudt_type_script_hash,
             polyjuice_type_script_hash,
             rollup_type_hash,
-            eth_account_lock_hash,
-            tron_account_lock_hash,
+            allowed_eoa_hashes,
         }
     }
 
@@ -206,12 +211,8 @@ impl Web3Indexer {
                     anyhow!("Can't get script by script_hash: {:?}", from_script_hash)
                 })?;
             let from_script_code_hash: H256 = from_script.code_hash().unpack();
-            let mut allowed_account_lock_hashes = vec![self.eth_account_lock_hash.to_owned()];
-            if let Some(code_hash) = self.tron_account_lock_hash.to_owned() {
-                allowed_account_lock_hashes.push(code_hash)
-            };
             // skip tx not in the allowed eoa account lock
-            if !allowed_account_lock_hashes.contains(&from_script_code_hash) {
+            if !self.allowed_eoa_hashes.contains(&from_script_code_hash) {
                 continue;
             }
             // from_address is the script's args in eth account lock


### PR DESCRIPTION
make web3-indexer collect the transaction with tron_account_lock as well as eth_account_lock, thus the web3 rpc can support tron account related transaction receipt. 