### PR TITLE
fix: try to recover error when failed to generate withdrawal cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ dependencies = [
  "gw-traits",
  "gw-types",
  "log",
+ "rand 0.8.2",
 ]
 
 [[package]]

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -12,5 +12,6 @@ gw-common = { path = "../common" }
 gw-generator = { path = "../generator" }
 gw-store = { path = "../store" }
 gw-traits = { path = "../traits" }
+rand = "0.8"
 anyhow = "1.0"
 log = "0.4"


### PR DESCRIPTION
If only one or two finalized custodian cells are in the rollup, Godwoken may fail to generate the withdrawal cells. The reason is that cells need a specific capacity to keep themselves on-chain, so if a user wants to withdraw from the rollup, the remained capacity may not be enough for a refunded cell. 
Since the mechanism of mem pool, Godwoken will continually retry this process and failed to produce a new block.

This PR applied a temporary fix: when we failed to generate withdrawal cells, we randomly reject withdrawals from the mem pool. Thus, when this bug occurred, the rollup still can provide service except for withdrawal. 
This affects limited users since it only occurred when there are very few finalized cells in the rollup.

In the future, we will refactor the mem pool and provide a better message for users who failed to withdraw.