### PR TITLE
feat: allow mem-pool.execute-l2tx-max-cycles option; increase MAX_L2TX_CYCLES to 70M

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,7 @@ dependencies = [
  "anyhow",
  "gw-challenge",
  "gw-common",
+ "gw-config",
  "gw-generator",
  "gw-poa",
  "gw-rpc-client",

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -5,8 +5,9 @@ use gw_common::{
 };
 use gw_config::BackendConfig;
 use gw_generator::{
-    account_lock_manage::AccountLockManage, backend_manage::BackendManage, dummy_state::DummyState,
-    error::TransactionError, traits::StateExt, Generator,
+    account_lock_manage::AccountLockManage, backend_manage::BackendManage,
+    constants::L2TX_MAX_CYCLES, dummy_state::DummyState, error::TransactionError, traits::StateExt,
+    Generator,
 };
 use gw_traits::{ChainStore, CodeStore};
 use gw_types::{
@@ -86,7 +87,8 @@ fn run_contract_get_result<S: State + CodeStore>(
     };
     let generator = Generator::new(backend_manage, account_lock_manage, rollup_ctx);
     let chain_view = DummyChainStore;
-    let run_result = generator.execute_transaction(&chain_view, tree, block_info, &raw_tx)?;
+    let run_result =
+        generator.execute_transaction(&chain_view, tree, block_info, &raw_tx, L2TX_MAX_CYCLES)?;
     tree.apply_run_result(&run_result).expect("update state");
     Ok(run_result)
 }

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -339,6 +339,7 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
                     generator.clone(),
                     Box::new(mem_pool_provider),
                     offchain_validator_context,
+                    config.mem_pool.clone(),
                 )
                 .with_context(|| "create mem-pool")?,
             ));

--- a/crates/challenge/src/context.rs
+++ b/crates/challenge/src/context.rs
@@ -8,6 +8,7 @@ use gw_common::sparse_merkle_tree::default_store::DefaultStore;
 use gw_common::sparse_merkle_tree::CompiledMerkleProof;
 use gw_common::state::State;
 use gw_common::{blake2b::new_blake2b, H256};
+use gw_generator::constants::L2TX_MAX_CYCLES;
 use gw_generator::traits::StateExt;
 use gw_generator::{ChallengeContext, Generator};
 use gw_store::chain_view::ChainView;
@@ -374,8 +375,13 @@ fn build_tx_kv_witness(
                 .block_producer_id(raw_block.block_producer_id().to_entity())
                 .build();
 
-            let run_result =
-                generator.execute_transaction(&chain_view, &tree, &block_info, raw_tx)?;
+            let run_result = generator.execute_transaction(
+                &chain_view,
+                &tree,
+                &block_info,
+                raw_tx,
+                L2TX_MAX_CYCLES,
+            )?;
             tree.apply_run_result(&run_result)?;
 
             Some(run_result)

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,6 +20,8 @@ pub struct Config {
     pub block_producer: Option<BlockProducerConfig>,
     pub web3_indexer: Option<Web3IndexerConfig>,
     pub offchain_validator: OffChainValidatorConfig,
+    #[serde(default)]
+    pub mem_pool: MemPoolConfig,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
@@ -147,6 +149,19 @@ impl Default for OffChainValidatorConfig {
             verify_tx_execution: true,
             verify_max_cycles: 70_000_000,
             dump_tx_on_failure: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MemPoolConfig {
+    pub execute_l2tx_max_cycles: u64,
+}
+
+impl Default for MemPoolConfig {
+    fn default() -> Self {
+        Self {
+            execute_l2tx_max_cycles: 100_000_000,
         }
     }
 }

--- a/crates/generator/src/constants.rs
+++ b/crates/generator/src/constants.rs
@@ -7,4 +7,4 @@ pub const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25_000;
 // 2MB
 pub const MAX_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
 // max cycles
-pub const L2TX_MAX_CYCLES: u64 = 5000_0000;
+pub const L2TX_MAX_CYCLES: u64 = 7000_0000;

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -15,6 +15,7 @@ gw-store = { path = "../store" }
 gw-traits = { path = "../traits" }
 gw-rpc-client = { path = "../rpc-client" }
 gw-poa = { path = "../poa" }
+gw-config = { path = "../config" }
 smol = "1.2.5"
 anyhow = "1.0"
 log = "0.4"

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -137,6 +137,7 @@ pub fn setup_chain_with_account_lock_manage(
         Arc::clone(&generator),
         Box::new(provider),
         None,
+        Default::default(),
     )
     .unwrap();
     Chain::create(

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -308,6 +308,7 @@ pub fn generate_config(
         node_mode: NodeMode::ReadOnly,
         debug: Default::default(),
         offchain_validator: Default::default(),
+        mem_pool: Default::default(),
     };
 
     let output_content = toml::to_string_pretty(&config).expect("serde toml to string pretty");


### PR DESCRIPTION
* execute tx max cycles 50M -> 100M(default)
* submit tx max cycles 50M -> 70M

Since we introduced offchain validator, even a l2tx exceeded the max cycles in the challenge context, the validator will prevent it get packaged.