### PR TITLE
Hotfix v0.6.2 rc6

### DIFF
--- a/crates/block-producer/src/block_producer.rs
+++ b/crates/block-producer/src/block_producer.rs
@@ -348,6 +348,10 @@ impl BlockProducer {
                         tx.clone(),
                     )
                     .await;
+                    self.mem_pool
+                        .lock()
+                        .await
+                        .try_to_recovery_from_invalid_state()?;
                 } else {
                     log::debug!("Skip dumping non-script-error tx");
                 }

--- a/crates/mem-pool/src/mem_block.rs
+++ b/crates/mem-pool/src/mem_block.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use gw_common::{merkle_utils::calculate_state_checkpoint, H256};
 use gw_types::{
@@ -32,7 +35,7 @@ pub struct MemBlock {
     /// Mem block prev merkle state
     prev_merkle_state: AccountMerkleState,
     /// touched keys
-    touched_keys: Vec<H256>,
+    touched_keys: HashSet<H256>,
 }
 
 impl MemBlock {
@@ -128,7 +131,7 @@ impl MemBlock {
         self.block_producer_id
     }
 
-    pub fn touched_keys(&self) -> &[H256] {
+    pub fn touched_keys(&self) -> &HashSet<H256> {
         &self.touched_keys
     }
 

--- a/crates/mem-pool/src/mem_block.rs
+++ b/crates/mem-pool/src/mem_block.rs
@@ -57,6 +57,11 @@ impl MemBlock {
             withdrawals: self.withdrawals.clone(),
         };
         // reset status
+        self.clear();
+        content
+    }
+
+    pub fn clear(&mut self) {
         self.tx_receipts.clear();
         self.txs.clear();
         self.withdrawals.clear();
@@ -64,7 +69,6 @@ impl MemBlock {
         self.state_checkpoints.clear();
         self.txs_prev_state_checkpoint = None;
         self.touched_keys.clear();
-        content
     }
 
     pub fn push_withdrawal(&mut self, withdrawal_hash: H256, state_checkpoint: H256) {

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -312,6 +312,26 @@ impl MemPool {
         Ok(())
     }
 
+    /// FIXME
+    /// This function is a temporary mechanism
+    /// Try to recovery from invalid state by drop txs & deposit
+    pub fn try_to_recovery_from_invalid_state(&mut self) -> Result<()> {
+        log::info!("[mem-pool] try recovery from invalid state by drop txs & deposits");
+        log::info!("[mem-pool] drop mem-block");
+        self.mem_block.clear();
+        log::info!("[mem-pool] drop pending: {}", self.pending.len());
+        self.pending.clear();
+        log::info!(
+            "[mem-pool] drop withdrawals: {}",
+            self.all_withdrawals.len()
+        );
+        self.all_withdrawals.clear();
+        log::info!("[mem-pool] drop txs: {}", self.all_txs.len());
+        self.all_txs.clear();
+        log::info!("[mem-pool] try_to_recovery - done");
+        Ok(())
+    }
+
     /// output mem block
     pub fn output_mem_block(&self) -> Result<BlockParam> {
         let db = self.store.begin_transaction();


### PR DESCRIPTION
* Prevent duplicated state keys in the witness
* Try to recovery from invalid state by empty the mem-pool(a temporary fix)