### PR TITLE
chore: turn off offchain-validator on default

### DIFF
--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -301,7 +301,7 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
             };
 
             let mut offchain_validator_context = None;
-            if config.offchain_validator.enable {
+            if let Some(validator_config) = config.offchain_validator {
                 let debug_config = config.debug.clone();
                 let wallet = {
                     let config = &block_producer_config.wallet_config;
@@ -310,7 +310,6 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
                 let ckb_genesis_info = gw_challenge::offchain::CKBGenesisInfo {
                     sighash_dep: ckb_genesis_info.sighash_dep(),
                 };
-                let validator_config = config.offchain_validator.clone();
 
                 let context = smol::block_on(async {
                     let poa = poa.lock().await;

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
     pub block_producer: Option<BlockProducerConfig>,
     pub web3_indexer: Option<Web3IndexerConfig>,
     #[serde(default)]
-    pub offchain_validator: OffChainValidatorConfig,
+    pub offchain_validator: Option<OffChainValidatorConfig>,
     #[serde(default)]
     pub mem_pool: MemPoolConfig,
 }
@@ -141,7 +141,6 @@ pub struct Web3IndexerConfig {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OffChainValidatorConfig {
-    pub enable: bool,
     pub verify_withdrawal_signature: bool,
     pub verify_tx_signature: bool,
     pub verify_tx_execution: bool,
@@ -152,12 +151,11 @@ pub struct OffChainValidatorConfig {
 impl Default for OffChainValidatorConfig {
     fn default() -> Self {
         Self {
-            enable: true,
             verify_withdrawal_signature: true,
             verify_tx_signature: true,
             verify_tx_execution: true,
             verify_max_cycles: 70_000_000,
-            dump_tx_on_failure: false,
+            dump_tx_on_failure: true,
         }
     }
 }


### PR DESCRIPTION
* Remove enable from OffchainValidatorConfig
* Turn off OffchainValidator by default. (We will enable it again afterwe successfully validate all testnet txs)
* set dump failed txs to true.