### PR TITLE
feat(command): db block validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,6 +2005,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "rayon",
  "semver 1.0.3",
  "serde",
  "serde_json",

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -50,3 +50,4 @@ sqlx = { version = "0.5", features = [ "runtime-async-std-native-tls", "postgres
 hex = "0.4"
 async-trait = "0.1"
 semver = "1.0"
+rayon = "1.5"

--- a/crates/block-producer/src/db_block_validator.rs
+++ b/crates/block-producer/src/db_block_validator.rs
@@ -220,7 +220,7 @@ impl DBBlockCancelChallengeValidator {
 
     fn verify_db(&self, from_block: Option<u64>, to_block: Option<u64>) -> Result<()> {
         let db = self.store.begin_transaction();
-        let from_block = from_block.unwrap_or_else(|| 0);
+        let from_block = from_block.unwrap_or(0);
         let to_block = match to_block {
             Some(to) => to,
             None => db.get_tip_block()?.raw().number().unpack(),

--- a/crates/block-producer/src/db_block_validator.rs
+++ b/crates/block-producer/src/db_block_validator.rs
@@ -8,7 +8,6 @@ use gw_challenge::{
         OffChainMockContext,
     },
 };
-use gw_utils::wallet::Wallet;
 use gw_common::H256;
 use gw_config::{Config, DBBlockValidatorConfig, DebugConfig};
 use gw_generator::Generator;
@@ -19,6 +18,7 @@ use gw_types::{
     packed::{ChallengeTarget, GlobalState, L2Block},
     prelude::{Builder, Entity, Pack, Unpack},
 };
+use gw_utils::wallet::Wallet;
 use rayon::prelude::*;
 
 use std::{

--- a/crates/block-producer/src/db_block_validator.rs
+++ b/crates/block-producer/src/db_block_validator.rs
@@ -8,6 +8,7 @@ use gw_challenge::{
         OffChainMockContext,
     },
 };
+use gw_utils::wallet::Wallet;
 use gw_common::H256;
 use gw_config::{Config, DBBlockValidatorConfig, DebugConfig};
 use gw_generator::Generator;
@@ -26,7 +27,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{runner::BaseInitComponents, wallet::Wallet};
+use crate::runner::BaseInitComponents;
 
 pub fn verify(config: Config, from_block: Option<u64>, to_block: Option<u64>) -> Result<()> {
     if config.store.path.as_os_str().is_empty() {

--- a/crates/block-producer/src/db_block_validator.rs
+++ b/crates/block-producer/src/db_block_validator.rs
@@ -29,7 +29,7 @@ use crate::{runner::BaseInitComponents, wallet::Wallet};
 
 pub fn verify(config: Config, from_block: Option<u64>, to_block: Option<u64>) -> Result<()> {
     if config.store.path.as_os_str().is_empty() {
-        bail!("empty store path, no history to verify");
+        bail!("empty store path, no db block to verify");
     }
     if config.block_producer.is_none() {
         bail!("db block validator require block producer config");

--- a/crates/block-producer/src/history_validator.rs
+++ b/crates/block-producer/src/history_validator.rs
@@ -25,7 +25,7 @@ use gw_rpc_client::RPCClient;
 use gw_store::Store;
 use gw_types::{
     bytes::Bytes,
-    core::ChallengeTargetType,
+    core::{ChallengeTargetType, Status},
     offchain::RollupContext,
     packed::{ChallengeTarget, GlobalState, RollupConfig, Script},
     prelude::{Builder, Entity, Pack, Unpack},
@@ -217,7 +217,10 @@ impl HistoryCancelChallengeValidator {
         };
         let global_state = {
             let maybe = db.get_block_post_global_state(&block_hash)?;
-            maybe.ok_or_else(|| anyhow!("block #{} global state not found", block_number))?
+            let state =
+                maybe.ok_or_else(|| anyhow!("block #{} global state not found", block_number))?;
+            let to_builder = state.as_builder().status((Status::Halting as u8).into());
+            to_builder.build()
         };
         let block = {
             let maybe = db.get_block(&block_hash)?;

--- a/crates/block-producer/src/history_validator.rs
+++ b/crates/block-producer/src/history_validator.rs
@@ -1,0 +1,304 @@
+use anyhow::{anyhow, bail, Context, Result};
+use async_jsonrpc_client::HttpClient;
+use gw_challenge::{
+    cancel_challenge::LoadDataStrategy,
+    context::build_verify_context,
+    offchain::{
+        mock_cancel_challenge_tx,
+        verify_tx::{verify_tx, TxWithContext},
+        OffChainMockContext,
+    },
+};
+use gw_common::{blake2b::new_blake2b, H256};
+use gw_config::Config;
+use gw_db::{schema::COLUMNS, RocksDB};
+use gw_generator::{
+    account_lock_manage::{
+        secp256k1::{Secp256k1Eth, Secp256k1Tron},
+        AccountLockManage,
+    },
+    backend_manage::BackendManage,
+    Generator,
+};
+use gw_poa::PoA;
+use gw_rpc_client::RPCClient;
+use gw_store::Store;
+use gw_types::{
+    bytes::Bytes,
+    core::ChallengeTargetType,
+    offchain::RollupContext,
+    packed::{ChallengeTarget, GlobalState, RollupConfig, Script},
+    prelude::{Builder, Entity, Pack, Unpack},
+};
+
+use std::{collections::HashMap, sync::Arc};
+
+use crate::{utils::CKBGenesisInfo, wallet::Wallet};
+
+const MAX_CYCLES: u64 = 7000_0000;
+
+pub fn verify(config: Config, from_block: Option<u64>, to_block: Option<u64>) -> Result<()> {
+    if config.store.path.as_os_str().is_empty() {
+        bail!("empty store path, no history to verify");
+    }
+    if config.block_producer.is_none() {
+        bail!("history validator require block producer config");
+    }
+
+    let validator = build_validator(config)?;
+    validator.verify_history(from_block, to_block)?;
+
+    Ok(())
+}
+
+fn build_validator(config: Config) -> Result<HistoryCancelChallengeValidator> {
+    let rollup_config: RollupConfig = config.genesis.rollup_config.clone().into();
+    let rollup_context = RollupContext {
+        rollup_config: rollup_config.clone(),
+        rollup_script_hash: {
+            let rollup_script_hash: [u8; 32] = config.genesis.rollup_type_hash.clone().into();
+            rollup_script_hash.into()
+        },
+    };
+    let rollup_type_script: Script = config.chain.rollup_type_script.clone().into();
+
+    let rpc_client = {
+        let indexer_client = HttpClient::new(config.rpc_client.indexer_url)?;
+        let ckb_client = HttpClient::new(config.rpc_client.ckb_url)?;
+        let rollup_type_script =
+            ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
+        RPCClient {
+            indexer_client,
+            ckb_client,
+            rollup_context: rollup_context.clone(),
+            rollup_type_script,
+        }
+    };
+
+    let generator = {
+        let backend_manage = BackendManage::from_config(config.backends.clone())
+            .with_context(|| "config backends")?;
+        let mut account_lock_manage = AccountLockManage::default();
+        let eth_lock_script_type_hash = rollup_config
+            .allowed_eoa_type_hashes()
+            .get(0)
+            .ok_or_else(|| anyhow!("Eth: No allowed EoA type hashes in the rollup config"))?;
+        account_lock_manage.register_lock_algorithm(
+            eth_lock_script_type_hash.unpack(),
+            Box::new(Secp256k1Eth::default()),
+        );
+        let tron_lock_script_type_hash = rollup_config.allowed_eoa_type_hashes().get(1);
+        if let Some(code_hash) = tron_lock_script_type_hash {
+            account_lock_manage
+                .register_lock_algorithm(code_hash.unpack(), Box::new(Secp256k1Tron::default()))
+        }
+        Arc::new(Generator::new(
+            backend_manage,
+            account_lock_manage,
+            rollup_context.clone(),
+        ))
+    };
+
+    let db_config = gw_db::config::Config {
+        path: config.store.path,
+        options: Default::default(),
+        options_file: Default::default(),
+    };
+    let store = Store::new(RocksDB::open(&db_config, COLUMNS));
+
+    let block_producer_config = config.block_producer.expect("should exists");
+    let ckb_genesis_info = {
+        let ckb_genesis = smol::block_on(async { rpc_client.get_block_by_number(0).await })?
+            .ok_or_else(|| anyhow!("can't found CKB genesis block"))?;
+        CKBGenesisInfo::from_block(&ckb_genesis)?
+    };
+
+    let secp_data: Bytes = {
+        let out_point = config.genesis.secp_data_dep.out_point.clone();
+        smol::block_on(rpc_client.get_transaction(out_point.tx_hash.0.into()))?
+            .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?
+            .raw()
+            .outputs_data()
+            .get(out_point.index.value() as usize)
+            .expect("get secp output data")
+            .raw_data()
+    };
+
+    let to_hash = |data| -> [u8; 32] {
+        let mut hasher = new_blake2b();
+        hasher.update(data);
+        let mut hash = [0u8; 32];
+        hasher.finalize(&mut hash);
+        hash
+    };
+    let mut builtin_load_data = HashMap::new();
+    builtin_load_data.insert(
+        to_hash(secp_data.as_ref()).into(),
+        config.genesis.secp_data_dep.clone().into(),
+    );
+
+    let wallet =
+        Wallet::from_config(&block_producer_config.wallet_config).with_context(|| "init wallet")?;
+
+    let poa = {
+        let poa = PoA::new(
+            rpc_client.clone(),
+            wallet.lock_script().to_owned(),
+            block_producer_config.poa_lock_dep.clone().into(),
+            block_producer_config.poa_state_dep.clone().into(),
+        );
+        Arc::new(smol::lock::Mutex::new(poa))
+    };
+
+    let ckb_genesis_info = gw_challenge::offchain::CKBGenesisInfo {
+        sighash_dep: ckb_genesis_info.sighash_dep(),
+    };
+
+    let offchain_mock_context = smol::block_on(async {
+        let wallet = {
+            let config = &block_producer_config.wallet_config;
+            gw_challenge::Wallet::from_config(config).with_context(|| "init wallet")?
+        };
+        let poa = poa.lock().await;
+
+        OffChainMockContext::build(
+            &rpc_client,
+            &poa,
+            rollup_context.clone(),
+            wallet,
+            block_producer_config.clone(),
+            ckb_genesis_info,
+            builtin_load_data.clone(),
+        )
+        .await
+    })?;
+
+    let validator = HistoryCancelChallengeValidator::new(generator, store, offchain_mock_context);
+    Ok(validator)
+}
+
+struct HistoryCancelChallengeValidator {
+    generator: Arc<Generator>,
+    store: Store,
+    mock_ctx: OffChainMockContext,
+}
+
+impl HistoryCancelChallengeValidator {
+    fn new(generator: Arc<Generator>, store: Store, mock_ctx: OffChainMockContext) -> Self {
+        HistoryCancelChallengeValidator {
+            generator,
+            store,
+            mock_ctx,
+        }
+    }
+
+    fn verify_history(&self, from_block: Option<u64>, to_block: Option<u64>) -> Result<()> {
+        let db = self.store.begin_transaction();
+        let from_block = from_block.unwrap_or_else(|| 0);
+        let to_block = match to_block {
+            Some(to) => to,
+            None => db.get_tip_block()?.raw().number().unpack(),
+        };
+
+        for block_number in from_block..=to_block {
+            self.verify_block(block_number)?;
+        }
+
+        Ok(())
+    }
+
+    fn verify_block(&self, block_number: u64) -> Result<()> {
+        let db = self.store.begin_transaction();
+        log::info!("verify block #{}", block_number);
+
+        let block_hash: H256 = {
+            let maybe = db.get_block_hash_by_number(block_number)?;
+            maybe.ok_or_else(|| anyhow!("block #{} not found", block_number))?
+        };
+        let global_state = {
+            let maybe = db.get_block_post_global_state(&block_hash)?;
+            maybe.ok_or_else(|| anyhow!("block #{} global state not found", block_number))?
+        };
+        let block = {
+            let maybe = db.get_block(&block_hash)?;
+            maybe.ok_or_else(|| anyhow!("block #{} not found", block_number))?
+        };
+
+        self.verify_withdrawals(global_state.clone(), block_hash, block.withdrawals().len())?;
+        self.verify_txs(global_state.clone(), block_hash, block.transactions().len())?;
+
+        Ok(())
+    }
+
+    fn verify_withdrawals(
+        &self,
+        global_state: GlobalState,
+        block_hash: H256,
+        count: usize,
+    ) -> Result<()> {
+        for idx in 0..(count as u32) {
+            log::info!("verify withdrawal #{}", idx);
+            let target = build_challenge_target(block_hash, idx, ChallengeTargetType::Withdrawal);
+            self.verify(global_state.clone(), target)?;
+        }
+
+        Ok(())
+    }
+
+    fn verify_txs(&self, global_state: GlobalState, block_hash: H256, count: usize) -> Result<()> {
+        for idx in 0..(count as u32) {
+            log::info!("verify tx #{}", idx);
+            let target = build_challenge_target(block_hash, idx, ChallengeTargetType::TxSignature);
+            self.verify(global_state.clone(), target)?;
+
+            let target = build_challenge_target(block_hash, idx, ChallengeTargetType::TxExecution);
+            self.verify(global_state.clone(), target)?;
+        }
+
+        Ok(())
+    }
+
+    fn verify(&self, global_state: GlobalState, challenge_target: ChallengeTarget) -> Result<()> {
+        let db = self.store.begin_transaction();
+        let verify_context =
+            build_verify_context(Arc::clone(&self.generator), &db, &challenge_target)?;
+
+        let verify_with_strategy = |load_data_strategy: LoadDataStrategy| -> Result<()> {
+            let mock_output = mock_cancel_challenge_tx(
+                &self.mock_ctx.mock_rollup,
+                &self.mock_ctx.mock_poa,
+                global_state.clone(),
+                challenge_target.clone(),
+                verify_context.clone(),
+                Some(load_data_strategy),
+            )?;
+
+            verify_tx(
+                &self.mock_ctx.rollup_cell_deps,
+                TxWithContext::from(mock_output),
+                MAX_CYCLES,
+            )?;
+
+            Ok(())
+        };
+
+        if verify_with_strategy(LoadDataStrategy::Witness).is_err() {
+            verify_with_strategy(LoadDataStrategy::CellDep)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn build_challenge_target(
+    block_hash: H256,
+    target_index: u32,
+    target_type: ChallengeTargetType,
+) -> ChallengeTarget {
+    let target_type: u8 = target_type.into();
+    ChallengeTarget::new_builder()
+        .block_hash(block_hash.pack())
+        .target_index(target_index.pack())
+        .target_type(target_type.into())
+        .build()
+}

--- a/crates/block-producer/src/history_validator.rs
+++ b/crates/block-producer/src/history_validator.rs
@@ -159,6 +159,13 @@ fn build_validator(config: Config) -> Result<HistoryCancelChallengeValidator> {
         sighash_dep: ckb_genesis_info.sighash_dep(),
     };
 
+    let replaced_scripts = {
+        let config = config.history_validator.clone().unwrap_or_default();
+        let convert_hash = |(hash, path): (ckb_types::H256, PathBuf)| (H256::from(hash.0), path);
+        let to_scripts = config.replaced_scripts;
+        to_scripts.map(|scripts| scripts.into_iter().map(convert_hash).collect())
+    };
+
     let offchain_mock_context = smol::block_on(async {
         let wallet = {
             let config = &block_producer_config.wallet_config;
@@ -174,6 +181,7 @@ fn build_validator(config: Config) -> Result<HistoryCancelChallengeValidator> {
             block_producer_config.clone(),
             ckb_genesis_info,
             builtin_load_data.clone(),
+            replaced_scripts,
         )
         .await
     })?;

--- a/crates/block-producer/src/history_validator.rs
+++ b/crates/block-producer/src/history_validator.rs
@@ -306,11 +306,17 @@ impl HistoryCancelChallengeValidator {
 
             match result {
                 Ok(used_cycles) if used_cycles > MAX_CYCLES => {
-                    return Err(anyhow!(
+                    self.dump_tx_to_file(
+                        load_data_strategy,
+                        &challenge_target,
+                        TxWithContext::from(mock_output),
+                    );
+
+                    Err(anyhow!(
                         "exceeded max cycles, used {} expect <= {}",
                         used_cycles,
                         MAX_CYCLES
-                    ));
+                    ))
                 }
                 Err(err) => {
                     self.dump_tx_to_file(

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -3,6 +3,7 @@ pub mod challenger;
 pub mod cleaner;
 pub mod debugger;
 pub mod deposit;
+pub mod history_validator;
 pub mod poller;
 pub mod produce_block;
 pub mod runner;

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod block_producer;
 pub mod challenger;
 pub mod cleaner;
+pub mod db_block_validator;
 pub mod debugger;
 pub mod deposit;
-pub mod history_validator;
 pub mod poller;
 pub mod produce_block;
 pub mod runner;

--- a/crates/block-producer/src/main.rs
+++ b/crates/block-producer/src/main.rs
@@ -1,16 +1,18 @@
 use anyhow::{Context, Result};
 use clap::{App, Arg, SubCommand};
-use gw_block_producer::{history_validator, runner};
+use gw_block_producer::{db_block_validator, runner};
 use gw_config::Config;
 use gw_version::Version;
 use std::{fs, path::Path};
 
 const COMMAND_RUN: &str = "run";
 const COMMAND_EXAMPLE_CONFIG: &str = "generate-example-config";
-const COMMAND_VERIFY_DB_HISTORY: &str = "verify-db-history";
+const COMMAND_VERIFY_DB_BLOCK: &str = "verify-db-block";
 const ARG_OUTPUT_PATH: &str = "output-path";
 const ARG_CONFIG: &str = "config";
 const ARG_SKIP_CONFIG_CHECK: &str = "skip-config-check";
+const ARG_FROM_BLOCK: &str = "from-block";
+const ARG_TO_BLOCK: &str = "to-block";
 
 fn read_config<P: AsRef<Path>>(path: P) -> Result<Config> {
     let content = fs::read(&path)
@@ -65,7 +67,7 @@ fn run_cli() -> Result<()> {
                 .display_order(1),
         )
         .subcommand(
-            SubCommand::with_name(COMMAND_VERIFY_DB_HISTORY)
+            SubCommand::with_name(COMMAND_VERIFY_DB_BLOCK)
                 .about("Verify history blocks in db")
                 .arg(
                     Arg::with_name(ARG_CONFIG)
@@ -76,13 +78,13 @@ fn run_cli() -> Result<()> {
                         .help("The config file path"),
                 )
                 .arg(
-                    Arg::with_name("from-block")
+                    Arg::with_name(ARG_FROM_BLOCK)
                         .short("f")
                         .takes_value(true)
                         .help("From block number"),
                 )
                 .arg(
-                    Arg::with_name("to-block")
+                    Arg::with_name(ARG_TO_BLOCK)
                         .short("t")
                         .takes_value(true)
                         .help("To block number"),
@@ -102,12 +104,12 @@ fn run_cli() -> Result<()> {
             let path = m.value_of(ARG_OUTPUT_PATH).unwrap();
             generate_example_config(path)?;
         }
-        (COMMAND_VERIFY_DB_HISTORY, Some(m)) => {
+        (COMMAND_VERIFY_DB_BLOCK, Some(m)) => {
             let config_path = m.value_of(ARG_CONFIG).unwrap();
             let config = read_config(&config_path)?;
-            let from_block: Option<u64> = m.value_of("from-block").map(str::parse).transpose()?;
-            let to_block: Option<u64> = m.value_of("to-block").map(str::parse).transpose()?;
-            history_validator::verify(config, from_block, to_block)?;
+            let from_block: Option<u64> = m.value_of(ARG_FROM_BLOCK).map(str::parse).transpose()?;
+            let to_block: Option<u64> = m.value_of(ARG_TO_BLOCK).map(str::parse).transpose()?;
+            db_block_validator::verify(config, from_block, to_block)?;
         }
         _ => {
             // default command: start a Godwoken node

--- a/crates/block-producer/src/main.rs
+++ b/crates/block-producer/src/main.rs
@@ -75,6 +75,18 @@ fn run_cli() -> Result<()> {
                         .default_value("./config.toml")
                         .help("The config file path"),
                 )
+                .arg(
+                    Arg::with_name("from-block")
+                        .short("f")
+                        .takes_value(true)
+                        .help("From block number"),
+                )
+                .arg(
+                    Arg::with_name("to-block")
+                        .short("t")
+                        .takes_value(true)
+                        .help("To block number"),
+                )
                 .display_order(2),
         );
 
@@ -93,7 +105,9 @@ fn run_cli() -> Result<()> {
         (COMMAND_VERIFY_DB_HISTORY, Some(m)) => {
             let config_path = m.value_of(ARG_CONFIG).unwrap();
             let config = read_config(&config_path)?;
-            history_validator::verify(config, None, None)?;
+            let from_block: Option<u64> = m.value_of("from-block").map(str::parse).transpose()?;
+            let to_block: Option<u64> = m.value_of("to-block").map(str::parse).transpose()?;
+            history_validator::verify(config, from_block, to_block)?;
         }
         _ => {
             // default command: start a Godwoken node

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -319,7 +319,6 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
                     block_producer_config.clone(),
                     ckb_genesis_info,
                     builtin_load_data.clone(),
-                    None,
                 )
                 .await
             })?;

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -319,6 +319,7 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
                     block_producer_config.clone(),
                     ckb_genesis_info,
                     builtin_load_data.clone(),
+                    None,
                 )
                 .await
             })?;

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -23,7 +23,6 @@ use gw_poa::PoA;
 use gw_rpc_client::rpc_client::RPCClient;
 use gw_rpc_server::{registry::Registry, server::start_jsonrpc_server};
 use gw_store::Store;
-use gw_types::packed::CellDep;
 use gw_types::{
     bytes::Bytes,
     offchain::RollupContext,
@@ -189,12 +188,12 @@ impl BaseInitComponents {
             let ckb_client = HttpClient::new(config.rpc_client.ckb_url.to_owned())?;
             let rollup_type_script =
                 ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
-            RPCClient {
+            RPCClient::new(
                 rollup_type_script,
-                rollup_context: rollup_context.clone(),
-                indexer_client,
+                rollup_context.clone(),
                 ckb_client,
-            }
+                indexer_client,
+            )
         };
 
         if !skip_config_check {

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -23,11 +23,11 @@ use gw_poa::PoA;
 use gw_rpc_client::rpc_client::RPCClient;
 use gw_rpc_server::{registry::Registry, server::start_jsonrpc_server};
 use gw_store::Store;
-use gw_types::prelude::{Pack, Unpack};
+use gw_types::packed::CellDep;
 use gw_types::{
     bytes::Bytes,
     offchain::RollupContext,
-    packed::{NumberHash, RollupConfig, Script},
+    packed::{CellDep, NumberHash, RollupConfig, Script},
     prelude::*,
 };
 use gw_utils::{genesis_info::CKBGenesisInfo, wallet::Wallet};
@@ -161,6 +161,186 @@ async fn poll_loop(
     }
 }
 
+pub struct BaseInitComponents {
+    pub rollup_config: RollupConfig,
+    pub rollup_config_hash: H256,
+    pub rollup_context: RollupContext,
+    pub rollup_type_script: Script,
+    pub builtin_load_data: HashMap<H256, CellDep>,
+    pub ckb_genesis_info: CKBGenesisInfo,
+    pub rpc_client: RPCClient,
+    pub store: Store,
+    pub generator: Arc<Generator>,
+}
+
+impl BaseInitComponents {
+    pub fn init(config: &Config, skip_config_check: bool) -> Result<Self> {
+        let rollup_config: RollupConfig = config.genesis.rollup_config.clone().into();
+        let rollup_context = RollupContext {
+            rollup_config: rollup_config.clone(),
+            rollup_script_hash: {
+                let rollup_script_hash: [u8; 32] = config.genesis.rollup_type_hash.clone().into();
+                rollup_script_hash.into()
+            },
+        };
+        let rollup_type_script: Script = config.chain.rollup_type_script.clone().into();
+        let rpc_client = {
+            let indexer_client = HttpClient::new(config.rpc_client.indexer_url.to_owned())?;
+            let ckb_client = HttpClient::new(config.rpc_client.ckb_url.to_owned())?;
+            let rollup_type_script =
+                ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
+            RPCClient {
+                rollup_type_script,
+                rollup_context: rollup_context.clone(),
+                indexer_client,
+                ckb_client,
+            }
+        };
+
+        if !skip_config_check {
+            check_ckb_version(&rpc_client)?;
+            // TODO: check ckb indexer version
+            if NodeMode::ReadOnly != config.node_mode {
+                let block_producer_config = config
+                    .block_producer
+                    .clone()
+                    .ok_or_else(|| anyhow!("not set block producer"))?;
+                check_rollup_config_cell(&block_producer_config, &rollup_config, &rpc_client)?;
+                check_locks(&block_producer_config, &rollup_config)?;
+            }
+        }
+
+        // Open store
+        let store = if config.store.path.as_os_str().is_empty() {
+            log::warn!("config.store.path is blank, using temporary store");
+            Store::open_tmp().with_context(|| "init store")?
+        } else {
+            let db_config = DBConfig {
+                path: config.store.path.to_owned(),
+                options: Default::default(),
+                options_file: Default::default(),
+            };
+            Store::new(RocksDB::open(&db_config, COLUMNS))
+        };
+
+        let secp_data: Bytes = {
+            let out_point = config.genesis.secp_data_dep.out_point.clone();
+            smol::block_on(rpc_client.get_transaction(out_point.tx_hash.0.into()))?
+                .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?
+                .raw()
+                .outputs_data()
+                .get(out_point.index.value() as usize)
+                .expect("get secp output data")
+                .raw_data()
+        };
+
+        init_genesis(
+            &store,
+            &config.genesis,
+            config.chain.genesis_committed_info.clone().into(),
+            secp_data.clone(),
+        )
+        .with_context(|| "init genesis")?;
+
+        let rollup_config_hash: H256 = rollup_config.hash().into();
+        let generator = {
+            let backend_manage = BackendManage::from_config(config.backends.clone())
+                .with_context(|| "config backends")?;
+            let mut account_lock_manage = AccountLockManage::default();
+            let eth_lock_script_type_hash = rollup_config
+                .allowed_eoa_type_hashes()
+                .get(0)
+                .ok_or_else(|| anyhow!("Eth: No allowed EoA type hashes in the rollup config"))?;
+            account_lock_manage.register_lock_algorithm(
+                eth_lock_script_type_hash.unpack(),
+                Box::new(Secp256k1Eth::default()),
+            );
+            let tron_lock_script_type_hash = rollup_config.allowed_eoa_type_hashes().get(1);
+            if let Some(code_hash) = tron_lock_script_type_hash {
+                account_lock_manage
+                    .register_lock_algorithm(code_hash.unpack(), Box::new(Secp256k1Tron::default()))
+            }
+            Arc::new(Generator::new(
+                backend_manage,
+                account_lock_manage,
+                rollup_context.clone(),
+            ))
+        };
+
+        let ckb_genesis_info = {
+            let ckb_genesis = smol::block_on(async { rpc_client.get_block_by_number(0).await })?
+                .ok_or_else(|| anyhow!("can't found CKB genesis block"))?;
+            CKBGenesisInfo::from_block(&ckb_genesis)?
+        };
+
+        let to_hash = |data| -> [u8; 32] {
+            let mut hasher = new_blake2b();
+            hasher.update(data);
+            let mut hash = [0u8; 32];
+            hasher.finalize(&mut hash);
+            hash
+        };
+        let mut builtin_load_data = HashMap::new();
+        builtin_load_data.insert(
+            to_hash(secp_data.as_ref()).into(),
+            config.genesis.secp_data_dep.clone().into(),
+        );
+
+        let base = BaseInitComponents {
+            rollup_config,
+            rollup_config_hash,
+            rollup_context,
+            rollup_type_script,
+            builtin_load_data,
+            ckb_genesis_info,
+            rpc_client,
+            store,
+            generator,
+        };
+
+        Ok(base)
+    }
+
+    pub fn init_poa(
+        &self,
+        wallet: &Wallet,
+        block_producer_config: &BlockProducerConfig,
+    ) -> Arc<Mutex<PoA>> {
+        let poa = PoA::new(
+            self.rpc_client.clone(),
+            wallet.lock_script().to_owned(),
+            block_producer_config.poa_lock_dep.clone().into(),
+            block_producer_config.poa_state_dep.clone().into(),
+        );
+        Arc::new(smol::lock::Mutex::new(poa))
+    }
+
+    pub async fn init_offchain_mock_context(
+        &self,
+        poa: &PoA,
+        block_producer_config: &BlockProducerConfig,
+    ) -> Result<OffChainMockContext> {
+        let ckb_genesis_info = gw_challenge::offchain::CKBGenesisInfo {
+            sighash_dep: self.ckb_genesis_info.sighash_dep(),
+        };
+        let wallet = {
+            let config = &block_producer_config.wallet_config;
+            Wallet::from_config(config).with_context(|| "init wallet")?
+        };
+
+        OffChainMockContext::build(
+            &self.rpc_client,
+            poa,
+            self.rollup_context.clone(),
+            wallet,
+            block_producer_config.clone(),
+            ckb_genesis_info,
+            self.builtin_load_data.clone(),
+        )
+        .await
+    }
+}
+
 pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
     // Enable smol threads before smol::spawn
     let runtime_threads = match std::env::var(SMOL_THREADS_ENV_VAR) {
@@ -177,150 +357,16 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
         SMOL_THREADS_ENV_VAR
     );
 
-    let rollup_config: RollupConfig = config.genesis.rollup_config.clone().into();
-    let rollup_context = RollupContext {
-        rollup_config: rollup_config.clone(),
-        rollup_script_hash: {
-            let rollup_script_hash: [u8; 32] = config.genesis.rollup_type_hash.clone().into();
-            rollup_script_hash.into()
-        },
-    };
-    let rollup_type_script: Script = config.chain.rollup_type_script.clone().into();
-    let rpc_client = {
-        let indexer_client = HttpClient::new(config.rpc_client.indexer_url)?;
-        let ckb_client = HttpClient::new(config.rpc_client.ckb_url)?;
-        let rollup_type_script =
-            ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
-        RPCClient::new(
-            rollup_type_script,
-            rollup_context.clone(),
-            ckb_client,
-            indexer_client,
-        )
-    };
-
-    if !skip_config_check {
-        check_ckb_version(&rpc_client)?;
-        // TODO: check ckb indexer version
-        if NodeMode::ReadOnly != config.node_mode {
-            let block_producer_config = config
-                .block_producer
-                .clone()
-                .ok_or_else(|| anyhow!("not set block producer"))?;
-            check_rollup_config_cell(&block_producer_config, &rollup_config, &rpc_client)?;
-            check_locks(&block_producer_config, &rollup_config)?;
-        }
-    }
-
-    // Open store
-    let store = if config.store.path.as_os_str().is_empty() {
-        log::warn!("config.store.path is blank, using temporary store");
-        Store::open_tmp().with_context(|| "init store")?
-    } else {
-        let db_config = DBConfig {
-            path: config.store.path,
-            options: Default::default(),
-            options_file: Default::default(),
-        };
-        Store::new(RocksDB::open(&db_config, COLUMNS))
-    };
-    let secp_data: Bytes = {
-        let out_point = config.genesis.secp_data_dep.out_point.clone();
-        smol::block_on(rpc_client.get_transaction(out_point.tx_hash.0.into()))?
-            .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?
-            .raw()
-            .outputs_data()
-            .get(out_point.index.value() as usize)
-            .expect("get secp output data")
-            .raw_data()
-    };
-    init_genesis(
-        &store,
-        &config.genesis,
-        config.chain.genesis_committed_info.clone().into(),
-        secp_data.clone(),
-    )
-    .with_context(|| "init genesis")?;
-
-    let rollup_config_hash: H256 = rollup_config.hash().into();
-    let generator = {
-        let backend_manage = BackendManage::from_config(config.backends.clone())
-            .with_context(|| "config backends")?;
-        let mut account_lock_manage = AccountLockManage::default();
-        let eth_lock_script_type_hash = rollup_config
-            .allowed_eoa_type_hashes()
-            .get(0)
-            .ok_or_else(|| anyhow!("Eth: No allowed EoA type hashes in the rollup config"))?;
-        account_lock_manage.register_lock_algorithm(
-            eth_lock_script_type_hash.unpack(),
-            Box::new(Secp256k1Eth::default()),
-        );
-        let tron_lock_script_type_hash = rollup_config.allowed_eoa_type_hashes().get(1);
-        if let Some(code_hash) = tron_lock_script_type_hash {
-            account_lock_manage
-                .register_lock_algorithm(code_hash.unpack(), Box::new(Secp256k1Tron::default()))
-        }
-        Arc::new(Generator::new(
-            backend_manage,
-            account_lock_manage,
-            rollup_context.clone(),
-        ))
-    };
-
-    let ckb_genesis_info = {
-        let ckb_genesis = smol::block_on(async { rpc_client.get_block_by_number(0).await })?
-            .ok_or_else(|| anyhow!("can't found CKB genesis block"))?;
-        CKBGenesisInfo::from_block(&ckb_genesis)?
-    };
-
-    let to_hash = |data| -> [u8; 32] {
-        let mut hasher = new_blake2b();
-        hasher.update(data);
-        let mut hash = [0u8; 32];
-        hasher.finalize(&mut hash);
-        hash
-    };
-    let mut builtin_load_data = HashMap::new();
-    builtin_load_data.insert(
-        to_hash(secp_data.as_ref()).into(),
-        config.genesis.secp_data_dep.clone().into(),
-    );
-
+    let base = BaseInitComponents::init(&config, skip_config_check)?;
     let (mem_pool, wallet, poa, offchain_mock_context) = match config.block_producer.clone() {
         Some(block_producer_config) => {
             let wallet = Wallet::from_config(&block_producer_config.wallet_config)
                 .with_context(|| "init wallet")?;
-
-            let poa = {
-                let poa = PoA::new(
-                    rpc_client.clone(),
-                    wallet.lock_script().to_owned(),
-                    block_producer_config.poa_lock_dep.clone().into(),
-                    block_producer_config.poa_state_dep.clone().into(),
-                );
-                Arc::new(smol::lock::Mutex::new(poa))
-            };
-
-            let ckb_genesis_info = gw_challenge::offchain::CKBGenesisInfo {
-                sighash_dep: ckb_genesis_info.sighash_dep(),
-            };
+            let poa = base.init_poa(&wallet, &block_producer_config);
             let offchain_mock_context = smol::block_on(async {
-                let wallet = {
-                    let config = &block_producer_config.wallet_config;
-                    Wallet::from_config(config).with_context(|| "init wallet")?
-                };
                 let poa = poa.lock().await;
-
-                OffChainMockContext::build(
-                    &rpc_client,
-                    &poa,
-                    rollup_context.clone(),
-                    wallet,
-                    block_producer_config.clone(),
-                    ckb_genesis_info,
-                    builtin_load_data.clone(),
-                )
-                .await
+                base.init_offchain_mock_context(&poa, &block_producer_config)
+                    .await
             })?;
 
             let mut offchain_validator_context = None;
@@ -337,11 +383,11 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
             }
 
             let mem_pool_provider =
-                DefaultMemPoolProvider::new(rpc_client.clone(), Arc::clone(&poa));
+                DefaultMemPoolProvider::new(base.rpc_client.clone(), Arc::clone(&poa));
             let mem_pool = Arc::new(Mutex::new(
                 MemPool::create(
-                    store.clone(),
-                    generator.clone(),
+                    base.store.clone(),
+                    base.generator.clone(),
                     Box::new(mem_pool_provider),
                     offchain_validator_context,
                     config.mem_pool.clone(),
@@ -357,6 +403,18 @@ pub fn run(config: Config, skip_config_check: bool) -> Result<()> {
         }
         None => (None, None, None, None),
     };
+
+    let BaseInitComponents {
+        rollup_config,
+        rollup_config_hash,
+        rollup_context,
+        rollup_type_script,
+        builtin_load_data,
+        ckb_genesis_info,
+        rpc_client,
+        store,
+        generator,
+    } = base;
 
     let chain = Arc::new(Mutex::new(
         Chain::create(

--- a/crates/challenge/src/cancel_challenge.rs
+++ b/crates/challenge/src/cancel_challenge.rs
@@ -80,6 +80,10 @@ impl CancelChallengeOutput {
         };
         let has_dep = allowed_script_deps.find(|(code_hash, _)| code_hash.0 == lock_code_hash);
         let to_dep = has_dep.map(|(_, dep)| dep.clone().into());
+        if to_dep.is_none() {
+            let lock_code_hash = ckb_types::H256::from(lock_code_hash);
+            log::error!("lock code {} not found", lock_code_hash);
+        }
         to_dep.ok_or_else(|| anyhow!("verifier lock dep not found"))
     }
 }

--- a/crates/challenge/src/context.rs
+++ b/crates/challenge/src/context.rs
@@ -610,7 +610,7 @@ mod tests {
             assert!(root.is_ok());
 
             // verify
-            assert_eq!(proof.verify(&root.unwrap(), &proof_leaves), true);
+            assert!(proof.verify(&root.unwrap(), &proof_leaves));
         }
     }
 }

--- a/crates/challenge/src/offchain.rs
+++ b/crates/challenge/src/offchain.rs
@@ -14,6 +14,7 @@ use gw_types::offchain::{CellInfo, InputCellInfo, RollupContext, RunResult};
 use gw_types::packed::{
     CellDep, CellInput, L2Block, L2Transaction, OutPoint, OutPointVec, Uint32, WithdrawalRequest,
 };
+use gw_types::prelude::{Builder, Entity};
 use gw_utils::wallet::Wallet;
 
 use std::{

--- a/crates/challenge/src/offchain.rs
+++ b/crates/challenge/src/offchain.rs
@@ -9,17 +9,16 @@ use gw_config::{BlockProducerConfig, DebugConfig, OffChainValidatorConfig};
 use gw_poa::PoA;
 use gw_rpc_client::rpc_client::RPCClient;
 use gw_store::{state_db::StateDBTransaction, transaction::StoreTransaction};
+use gw_types::core::DepType;
 use gw_types::offchain::{CellInfo, InputCellInfo, RollupContext, RunResult};
 use gw_types::packed::{
     CellDep, CellInput, L2Block, L2Transaction, OutPoint, OutPointVec, Uint32, WithdrawalRequest,
 };
-use gw_types::prelude::*;
-use gw_types::{bytes::Bytes, core::DepType};
 use gw_utils::wallet::Wallet;
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::{create_dir_all, read, write},
+    fs::{create_dir_all, write},
     path::PathBuf,
     sync::Arc,
 };
@@ -59,7 +58,6 @@ pub struct OffChainMockContext {
 }
 
 impl OffChainMockContext {
-    #[allow(clippy::too_many_arguments)]
     pub async fn build(
         rpc_client: &RPCClient,
         poa: &PoA,
@@ -68,7 +66,6 @@ impl OffChainMockContext {
         config: BlockProducerConfig,
         ckb_genesis_info: CKBGenesisInfo,
         builtin_load_data: HashMap<H256, CellDep>,
-        replaced_scripts: Option<HashMap<H256, PathBuf>>,
     ) -> Result<Self> {
         let rollup_cell = {
             let query = rpc_client.query_rollup_cell().await?;
@@ -109,16 +106,23 @@ impl OffChainMockContext {
 
             deps
         };
-        let mut resolved_rollup_deps = resolve_cell_deps(rpc_client, rollup_deps).await?;
-        if let Some(replaced_scripts) = replaced_scripts {
-            replace_scripts(&mut resolved_rollup_deps, replaced_scripts)?;
-        }
+        let resolved_rollup_deps = resolve_cell_deps(rpc_client, rollup_deps).await?;
         let rollup_cell_deps = RollupCellDeps::new(resolved_rollup_deps);
 
         let mock_context = OffChainMockContext {
             rollup_cell_deps,
             mock_rollup,
             mock_poa,
+        };
+
+        Ok(mock_context)
+    }
+
+    pub fn replace_scripts(&self, scripts: &HashMap<ckb_types::H256, PathBuf>) -> Result<Self> {
+        let mock_context = OffChainMockContext {
+            rollup_cell_deps: self.rollup_cell_deps.replace_scripts(scripts)?,
+            mock_rollup: Arc::clone(&self.mock_rollup),
+            mock_poa: Arc::clone(&self.mock_poa),
         };
 
         Ok(mock_context)
@@ -574,28 +578,6 @@ async fn resolve_dep_group(rpc_client: &RPCClient, dep: &CellDep) -> Result<Vec<
     };
 
     Ok(out_points.into_iter().map(into_dep).collect())
-}
-
-fn replace_scripts(
-    dep_cells: &mut Vec<InputCellInfo>,
-    replaced_scripts: HashMap<H256, PathBuf>,
-) -> Result<()> {
-    for info in dep_cells.iter_mut() {
-        let type_script = match info.cell.output.type_().to_opt() {
-            Some(script) => script,
-            None => continue,
-        };
-
-        let replaced_script_path = match replaced_scripts.get(&type_script.hash().into()) {
-            Some(path) => path,
-            None => continue,
-        };
-
-        let replaced_script = read(replaced_script_path)?;
-        info.cell.data = Bytes::from(replaced_script);
-    }
-
-    Ok(())
 }
 
 fn into_input_cell_info(cell_info: CellInfo) -> InputCellInfo {

--- a/crates/common/src/merkle_utils.rs
+++ b/crates/common/src/merkle_utils.rs
@@ -99,9 +99,9 @@ mod tests {
             .map(|(i, hash)| crate::merkle_utils::ckb_merkle_leaf_hash(i, &hash))
             .collect::<Vec<_>>();
 
-        assert_eq!(proof.verify(&root, &proof_leaves), true);
+        assert!(proof.verify(&root, &proof_leaves));
 
         let proof_leaves = vec![[1u8; 32].into(), [3u8; 32].into()];
-        assert_eq!(proof.verify(&root, &proof_leaves), false);
+        assert!(!proof.verify(&root, &proof_leaves));
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub offchain_validator: Option<OffChainValidatorConfig>,
     #[serde(default)]
     pub mem_pool: MemPoolConfig,
+    #[serde(default)]
     pub db_block_validator: Option<DBBlockValidatorConfig>,
 }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub offchain_validator: Option<OffChainValidatorConfig>,
     #[serde(default)]
     pub mem_pool: MemPoolConfig,
+    pub history_validator: Option<HistoryValidatorConfig>,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
@@ -184,5 +185,20 @@ pub enum NodeMode {
 impl Default for NodeMode {
     fn default() -> Self {
         NodeMode::ReadOnly
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HistoryValidatorConfig {
+    pub verify_max_cycles: u64,
+    pub replaced_scripts: Option<HashMap<H256, PathBuf>>,
+}
+
+impl Default for HistoryValidatorConfig {
+    fn default() -> Self {
+        Self {
+            verify_max_cycles: 70_000_000,
+            replaced_scripts: None,
+        }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,10 +1,13 @@
 use ckb_fixed_hash::H256;
 use gw_jsonrpc_types::{
     blockchain::{CellDep, Script},
-    godwoken::{L2BlockCommittedInfo, RollupConfig},
+    godwoken::{ChallengeTargetType, L2BlockCommittedInfo, RollupConfig},
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
@@ -23,7 +26,7 @@ pub struct Config {
     pub offchain_validator: Option<OffChainValidatorConfig>,
     #[serde(default)]
     pub mem_pool: MemPoolConfig,
-    pub history_validator: Option<HistoryValidatorConfig>,
+    pub db_block_validator: Option<DBBlockValidatorConfig>,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
@@ -189,18 +192,18 @@ impl Default for NodeMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct HistoryValidatorConfig {
+pub struct DBBlockValidatorConfig {
     pub verify_max_cycles: u64,
-    pub replaced_scripts: Option<HashMap<H256, PathBuf>>,
-    pub skips: Vec<(u64, u32)>,
+    pub replace_scripts: Option<HashMap<H256, PathBuf>>,
+    pub skip_targets: Option<HashSet<(u64, ChallengeTargetType, u32)>>,
 }
 
-impl Default for HistoryValidatorConfig {
+impl Default for DBBlockValidatorConfig {
     fn default() -> Self {
         Self {
-            verify_max_cycles: 70_000_000,
-            replaced_scripts: None,
-            skips: vec![],
+            verify_max_cycles: 7000_0000,
+            replace_scripts: None,
+            skip_targets: None,
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -196,6 +196,7 @@ pub struct DBBlockValidatorConfig {
     pub verify_max_cycles: u64,
     pub replace_scripts: Option<HashMap<H256, PathBuf>>,
     pub skip_targets: Option<HashSet<(u64, ChallengeTargetType, u32)>>,
+    pub parallel_verify_blocks: bool,
 }
 
 impl Default for DBBlockValidatorConfig {
@@ -204,6 +205,7 @@ impl Default for DBBlockValidatorConfig {
             verify_max_cycles: 7000_0000,
             replace_scripts: None,
             skip_targets: None,
+            parallel_verify_blocks: true,
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -192,6 +192,7 @@ impl Default for NodeMode {
 pub struct HistoryValidatorConfig {
     pub verify_max_cycles: u64,
     pub replaced_scripts: Option<HashMap<H256, PathBuf>>,
+    pub skips: Vec<(u64, u32)>,
 }
 
 impl Default for HistoryValidatorConfig {
@@ -199,6 +200,7 @@ impl Default for HistoryValidatorConfig {
         Self {
             verify_max_cycles: 70_000_000,
             replaced_scripts: None,
+            skips: vec![],
         }
     }
 }

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -208,6 +208,16 @@ impl From<ChallengeTargetType> for packed::Byte {
     }
 }
 
+impl From<gw_types::core::ChallengeTargetType> for ChallengeTargetType {
+    fn from(core: gw_types::core::ChallengeTargetType) -> ChallengeTargetType {
+        match core {
+            gw_types::core::ChallengeTargetType::Withdrawal => ChallengeTargetType::Withdrawal,
+            gw_types::core::ChallengeTargetType::TxSignature => ChallengeTargetType::TxSignature,
+            gw_types::core::ChallengeTargetType::TxExecution => ChallengeTargetType::TxExecution,
+        }
+    }
+}
+
 impl TryFrom<packed::Byte> for ChallengeTargetType {
     type Error = JsonError;
 

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -310,6 +310,7 @@ pub fn generate_config(
         debug: Default::default(),
         offchain_validator: Default::default(),
         mem_pool: Default::default(),
+        history_validator: Default::default(),
     };
 
     let output_content = toml::to_string_pretty(&config).expect("serde toml to string pretty");

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -310,7 +310,7 @@ pub fn generate_config(
         debug: Default::default(),
         offchain_validator: Default::default(),
         mem_pool: Default::default(),
-        history_validator: Default::default(),
+        db_block_validator: Default::default(),
     };
 
     let output_content = toml::to_string_pretty(&config).expect("serde toml to string pretty");


### PR DESCRIPTION
- feat:  new ```verify-db-block [-c config] [-f from-block] [-t to-block]``` command
- feat: support replace code hash binary, only support type
for example:
```
[db_block_validator.replace_scripts]
0xd6d4b52ed2882cb0b2e1f802817c0ab05bd27da89a41ceddb25e0e347689ce69 = '../godwoken-scripts/c/build/meta-contract-validator'
0xb6d6a2882d3d08cea565047bfe901cb2afe0cb790ea5e1b61e0532ef237c4a02 = '../godwoken-scripts/c/build/sudt-validator'
0xbeb77e49c6506182ec0c02546aee9908aafc1561ec13beb488d14184c6cd1b79 = '../godwoken-polyjuice/build/validator'
0xb761c2e77a9f7090ccb9d864ca6136e883257498230fb096ccbfd56e30c142f4 = '../godwoken-scripts/build/release/challenge-lock'
```
- feat: support skips block and target
for example:
```
[db_block_validator]
skip_targets = [
    [35195, 'tx_execution', 0],
    [35198, 'tx_execution', 0],
    [35218, 'tx_execution', 4],
]
```
- feat: dump tx on failure

- [x] todo: refactor init code
- [x] todo: performance