### PR TITLE
feat: validate sudt proxy contract creator by adding whitelist in [rpc] config

### DIFF
--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -85,7 +85,12 @@ fn run_contract_get_result<S: State + CodeStore>(
         rollup_config: rollup_config.clone(),
         rollup_script_hash: [42u8; 32].into(),
     };
-    let generator = Generator::new(backend_manage, account_lock_manage, rollup_ctx);
+    let generator = Generator::new(
+        backend_manage,
+        account_lock_manage,
+        rollup_ctx,
+        Default::default(),
+    );
     let chain_view = DummyChainStore;
     let run_result =
         generator.execute_transaction(&chain_view, tree, block_info, &raw_tx, L2TX_MAX_CYCLES)?;

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -273,6 +273,7 @@ impl BaseInitComponents {
                 backend_manage,
                 account_lock_manage,
                 rollup_context.clone(),
+                config.rpc,
             ))
         };
 

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -273,7 +273,7 @@ impl BaseInitComponents {
                 backend_manage,
                 account_lock_manage,
                 rollup_context.clone(),
-                config.rpc,
+                config.rpc.clone(),
             ))
         };
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub chain: ChainConfig,
     pub rpc_client: RPCClientConfig,
     pub rpc_server: RPCServerConfig,
+    pub rpc: RPCConfig,
     #[serde(default)]
     pub debug: DebugConfig,
     pub block_producer: Option<BlockProducerConfig>,
@@ -39,6 +40,12 @@ pub struct RPCServerConfig {
 pub struct RPCClientConfig {
     pub indexer_url: String,
     pub ckb_url: String,
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RPCConfig {
+    pub allowed_sudt_proxy_creator_account_id: Vec<u32>,
+    pub sudt_proxy_code_hashes: Vec<H256>,
 }
 
 /// Onchain rollup cell config

--- a/crates/generator/src/account_whitelist.rs
+++ b/crates/generator/src/account_whitelist.rs
@@ -1,0 +1,53 @@
+use gw_common::H256;
+use gw_types::offchain::RunResult;
+use log::debug;
+
+pub struct SUDTProxyAccountWhitelist {
+    allowed_sudt_proxy_creator_account_id: Vec<u32>,
+    sudt_proxy_code_hashes: Vec<H256>,
+}
+
+impl SUDTProxyAccountWhitelist {
+    pub fn new(
+        allowed_sudt_proxy_creator_account_id: Vec<u32>,
+        sudt_proxy_code_hashes: Vec<H256>,
+    ) -> Self {
+        Self {
+            allowed_sudt_proxy_creator_account_id,
+            sudt_proxy_code_hashes,
+        }
+    }
+
+    /// Only accounts in white list could create sUDT proxy contract.
+    pub fn validate(&self, run_result: &RunResult, from_id: u32) -> bool {
+        for k in run_result.write_data.keys() {
+            debug!(
+                "whiltelist: from_id: {:?}, code_hash: {:?}",
+                &from_id,
+                hex::encode(k.as_slice())
+            );
+
+            // Contract create syscall stores code in write_data.
+            // check code hash is sudt proxy contract
+            if self.sudt_proxy_code_hashes.contains(k) {
+                // check account id from whitelist
+                if !self
+                    .allowed_sudt_proxy_creator_account_id
+                    .contains(&from_id)
+                {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+impl Default for SUDTProxyAccountWhitelist {
+    fn default() -> Self {
+        Self {
+            allowed_sudt_proxy_creator_account_id: vec![],
+            sudt_proxy_code_hashes: vec![],
+        }
+    }
+}

--- a/crates/generator/src/erc20_creator_whitelist.rs
+++ b/crates/generator/src/erc20_creator_whitelist.rs
@@ -20,6 +20,22 @@ impl SUDTProxyAccountWhitelist {
 
     /// Only accounts in white list could create sUDT proxy contract.
     pub fn validate(&self, run_result: &RunResult, from_id: u32) -> bool {
+        if self.allowed_sudt_proxy_creator_account_id.is_empty()
+            || self.sudt_proxy_code_hashes.is_empty()
+        {
+            return true;
+        }
+        if self
+            .allowed_sudt_proxy_creator_account_id
+            .contains(&from_id)
+        {
+            return true;
+        }
+
+        if run_result.new_scripts.is_empty() {
+            return true;
+        }
+
         for k in run_result.write_data.keys() {
             debug!(
                 "whiltelist: from_id: {:?}, code_hash: {:?}",
@@ -30,13 +46,7 @@ impl SUDTProxyAccountWhitelist {
             // Contract create syscall stores code in write_data.
             // check code hash is sudt proxy contract
             if self.sudt_proxy_code_hashes.contains(k) {
-                // check account id from whitelist
-                if !self
-                    .allowed_sudt_proxy_creator_account_id
-                    .contains(&from_id)
-                {
-                    return false;
-                }
+                return false;
             }
         }
         true

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -124,6 +124,8 @@ pub enum TransactionError {
     ExceededMaxReadData { max_bytes: usize, used_bytes: usize },
     #[error("Exceeded maximum write data: max bytes {max_bytes}, writen bytes {used_bytes}")]
     ExceededMaxWriteData { max_bytes: usize, used_bytes: usize },
+    #[error("Cannot create sUDT proxy contract from account id: {account_id}.")]
+    InvalidSUDTProxyCreatorAccount { account_id: u32 },
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -2,9 +2,9 @@ use std::collections::HashSet;
 
 use crate::{
     account_lock_manage::AccountLockManage,
-    account_whitelist::SUDTProxyAccountWhitelist,
     backend_manage::BackendManage,
     constants::{L2TX_MAX_CYCLES, MAX_READ_DATA_BYTES_LIMIT, MAX_WRITE_DATA_BYTES_LIMIT},
+    erc20_creator_whitelist::SUDTProxyAccountWhitelist,
     error::{BlockError, TransactionValidateError, WithdrawalError},
     vm_cost_model::instruction_cycles,
 };

--- a/crates/generator/src/lib.rs
+++ b/crates/generator/src/lib.rs
@@ -2,10 +2,10 @@
 //! and generate new status that can be committed to layer1
 
 pub mod account_lock_manage;
-pub mod account_whitelist;
 pub mod backend_manage;
 pub mod constants;
 pub mod dummy_state;
+pub mod erc20_creator_whitelist;
 pub mod error;
 pub mod generator;
 pub mod genesis;

--- a/crates/generator/src/lib.rs
+++ b/crates/generator/src/lib.rs
@@ -2,6 +2,7 @@
 //! and generate new status that can be committed to layer1
 
 pub mod account_lock_manage;
+pub mod account_whitelist;
 pub mod backend_manage;
 pub mod constants;
 pub mod dummy_state;

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -124,6 +124,7 @@ pub fn setup_chain_with_account_lock_manage(
         backend_manage,
         account_lock_manage,
         rollup_context,
+        Default::default(),
     ));
     init_genesis(
         &store,

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -305,6 +305,7 @@ pub fn generate_config(
         chain,
         rpc_client,
         rpc_server,
+        rpc: Default::default(),
         block_producer,
         web3_indexer,
         node_mode: NodeMode::ReadOnly,


### PR DESCRIPTION
## new config [rpc]

```toml
[rpc]
allowed_sudt_proxy_creator_account_id = [1] ## only account_id = 1 can create sudt proxy contract
sudt_proxy_code_hashes = ["0x43a008ec973b648bd71ad67e6b66f2be8a6fa88e89c7dad046c948b00aa866aa"] ## supported sudt proxy contract code hashes
```



