### PR TITLE
Support passing optional block_number in execute_l2transaction

### DIFF
--- a/crates/tools/src/godwoken_rpc.rs
+++ b/crates/tools/src/godwoken_rpc.rs
@@ -91,8 +91,8 @@ impl GodwokenRpcClient {
             .map(Into::into)
     }
 
-    pub fn execute_l2transaction(&mut self, l2tx: JsonBytes) -> Result<RunResult, String> {
-        let params = serde_json::to_value((l2tx,)).map_err(|err| err.to_string())?;
+    pub fn execute_l2transaction(&mut self, l2tx: JsonBytes, block_number_opt: Option<u64>) -> Result<RunResult, String> {
+        let params = serde_json::to_value((l2tx,block_number_opt)).map_err(|err| err.to_string())?;
         self.rpc::<RunResult>("execute_l2transaction", params)
             .map(Into::into)
     }

--- a/crates/tools/src/godwoken_rpc.rs
+++ b/crates/tools/src/godwoken_rpc.rs
@@ -91,8 +91,13 @@ impl GodwokenRpcClient {
             .map(Into::into)
     }
 
-    pub fn execute_l2transaction(&mut self, l2tx: JsonBytes, block_number_opt: Option<u64>) -> Result<RunResult, String> {
-        let params = serde_json::to_value((l2tx,block_number_opt)).map_err(|err| err.to_string())?;
+    pub fn execute_l2transaction(
+        &mut self,
+        l2tx: JsonBytes,
+        block_number_opt: Option<u64>,
+    ) -> Result<RunResult, String> {
+        let params =
+            serde_json::to_value((l2tx, block_number_opt)).map_err(|err| err.to_string())?;
         self.rpc::<RunResult>("execute_l2transaction", params)
             .map(Into::into)
     }


### PR DESCRIPTION
This is my attempt at fixing #347. For a start it supports passing block number. No block hash support yet.

I have started godwoken-kicker with this configuration and it seems like I can deploy contract and call read/set methods just fine.