### PR TITLE
feat(rpc): error tx receipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,7 +445,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
 dependencies = [
  "funty",
- "radium",
+ "radium 0.5.3",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium 0.6.2",
  "tap",
  "wyz",
 ]
@@ -545,6 +563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0796d76a983651b4a0ddda16203032759f2fd9103d9181f7c65c06ee8872e6"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,9 +576,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -958,7 +982,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tiny-keccak",
+ "tiny-keccak 1.5.0",
  "tokio",
  "tokio-util",
  "uuid",
@@ -1458,6 +1482,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76ef192b63e8a44b3d08832acebbb984c3fba154b5c26f70037c860202a0d4b"
+dependencies = [
+ "anyhow",
+ "ethereum-types",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1592,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.2",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2250,12 +2329,14 @@ dependencies = [
  "anyhow",
  "ckb-hash",
  "ckb-types",
+ "ethabi",
  "faster-hex 0.5.0",
  "gw-chain",
  "gw-common",
  "gw-config",
  "gw-db",
  "gw-generator",
+ "gw-mem-pool",
  "gw-store",
  "gw-traits",
  "gw-types",
@@ -2264,6 +2345,7 @@ dependencies = [
  "rlp",
  "rust_decimal",
  "sha3",
+ "smol",
  "sqlx",
  "thiserror",
 ]
@@ -2340,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -2497,6 +2579,44 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2691,7 +2811,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",
@@ -2918,7 +3038,7 @@ version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
- "bitvec",
+ "bitvec 0.19.5",
  "funty",
  "lexical-core",
  "memchr",
@@ -3092,6 +3212,32 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+dependencies = [
+ "arrayvec 0.7.1",
+ "bitvec 0.20.4",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3282,6 +3428,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,6 +3485,12 @@ name = "radium"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -3653,7 +3828,7 @@ version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca515aafa02c92f4d3c69b2f4c408f839b51b1aa938d00b15e8c0966bd22d73"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "num-traits",
  "serde",
 ]
@@ -4353,18 +4528,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4424,6 +4599,15 @@ name = "tiny-keccak"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
@@ -4561,6 +4745,18 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "uint"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicase"

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -1027,3 +1027,23 @@ pub struct BackendInfo {
     pub generator_code_hash: H256,
     pub validator_script_type_hash: H256,
 }
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Default)]
+#[serde(rename_all = "snake_case")]
+pub struct ErrorTxReceipt {
+    pub tx_hash: H256,
+    pub block_number: Uint64,
+    pub return_data: JsonBytes,
+    pub last_log: Option<LogItem>,
+}
+
+impl From<offchain::ErrorTxReceipt> for ErrorTxReceipt {
+    fn from(receipt: offchain::ErrorTxReceipt) -> Self {
+        ErrorTxReceipt {
+            tx_hash: H256::from(Into::<[u8; 32]>::into(receipt.tx_hash)),
+            block_number: receipt.block_number.into(),
+            return_data: JsonBytes::from_vec(receipt.return_data),
+            last_log: receipt.last_log.map(Into::into),
+        }
+    }
+}

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -1078,7 +1078,7 @@ impl MemPool {
                 return_data: run_result.return_data,
                 last_log: run_result.logs.last().cloned(),
             };
-            if let Some(ref error_tx_handler) = self.error_tx_handler {
+            if let Some(ref mut error_tx_handler) = self.error_tx_handler {
                 error_tx_handler.handle_error_receipt(receipt).detach();
             }
 

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -28,7 +28,7 @@ use gw_store::{
     Store,
 };
 use gw_types::{
-    offchain::{BlockParam, CollectedCustodianCells, DepositInfo, RunResult},
+    offchain::{BlockParam, CollectedCustodianCells, DepositInfo, ErrorTxReceipt, RunResult},
     packed::{
         AccountMerkleState, BlockInfo, L2Block, L2Transaction, RawL2Transaction, Script, TxReceipt,
         WithdrawalRequest,
@@ -45,7 +45,7 @@ use crate::{
     constants::{MAX_MEM_BLOCK_TXS, MAX_MEM_BLOCK_WITHDRAWALS, MAX_TX_SIZE, MAX_WITHDRAWAL_SIZE},
     custodian::AvailableCustodians,
     mem_block::MemBlock,
-    traits::MemPoolProvider,
+    traits::{MemPoolErrorTxHandler, MemPoolProvider},
     types::EntryList,
 };
 
@@ -79,6 +79,8 @@ pub struct MemPool {
     current_tip: (H256, u64),
     /// generator instance
     generator: Arc<Generator>,
+    /// error tx handler,
+    error_tx_handler: Option<Box<dyn MemPoolErrorTxHandler + Send>>,
     /// pending queue, contains executable contents(can be pacakged into block)
     pending: HashMap<u32, EntryList>,
     /// memory block
@@ -96,6 +98,7 @@ impl MemPool {
         store: Store,
         generator: Arc<Generator>,
         provider: Box<dyn MemPoolProvider + Send>,
+        error_tx_handler: Option<Box<dyn MemPoolErrorTxHandler + Send>>,
         offchain_validator_context: Option<OffChainValidatorContext>,
         config: MemPoolConfig,
     ) -> Result<Self> {
@@ -124,6 +127,7 @@ impl MemPool {
             store,
             current_tip: tip,
             generator,
+            error_tx_handler,
             pending,
             mem_block,
             provider,
@@ -1065,6 +1069,19 @@ impl MemPool {
         }
 
         if run_result.exit_code != 0 {
+            let tx_hash: H256 = tx.hash().into();
+            let block_number = self.mem_block.block_info().number().unpack();
+
+            let receipt = ErrorTxReceipt {
+                tx_hash,
+                block_number,
+                return_data: run_result.return_data,
+                last_log: run_result.logs.last().cloned(),
+            };
+            if let Some(ref error_tx_handler) = self.error_tx_handler {
+                error_tx_handler.handle_error_receipt(receipt).detach();
+            }
+
             return Err(TransactionError::InvalidExitCode(run_result.exit_code).into());
         }
 

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -227,10 +227,10 @@ impl MemPool {
         Ok(())
     }
 
-    /// Execute tx without push it into pool
-    pub fn execute_transaction(
+    /// Execute tx without push it into pool and check exit code
+    pub fn unchecked_execute_transaction(
         &self,
-        tx: L2Transaction,
+        tx: &L2Transaction,
         block_info: &BlockInfo,
     ) -> Result<RunResult> {
         let db = self.store.begin_transaction();
@@ -239,12 +239,12 @@ impl MemPool {
         let tip_block_hash = self.store.get_tip_block_hash()?;
         let chain_view = ChainView::new(&db, tip_block_hash);
         // verify tx signature
-        self.generator.check_transaction_signature(&state, &tx)?;
+        self.generator.check_transaction_signature(&state, tx)?;
         // tx basic verification
-        self.generator.verify_transaction(&state, &tx)?;
+        self.generator.verify_transaction(&state, tx)?;
         // execute tx
         let raw_tx = tx.raw();
-        let run_result = self.generator.execute_transaction(
+        let run_result = self.generator.unchecked_execute_transaction(
             &chain_view,
             &state,
             block_info,

--- a/crates/mem-pool/src/traits.rs
+++ b/crates/mem-pool/src/traits.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use gw_types::{
-    offchain::{CollectedCustodianCells, DepositInfo, RollupContext},
+    offchain::{CollectedCustodianCells, DepositInfo, ErrorTxReceipt, RollupContext},
     packed::WithdrawalRequest,
 };
 use smol::Task;
@@ -16,4 +16,8 @@ pub trait MemPoolProvider {
         last_finalized_block_number: u64,
         rollup_context: RollupContext,
     ) -> Task<Result<CollectedCustodianCells>>;
+}
+
+pub trait MemPoolErrorTxHandler {
+    fn handle_error_receipt(&self, receipt: ErrorTxReceipt) -> Task<Result<()>>;
 }

--- a/crates/mem-pool/src/traits.rs
+++ b/crates/mem-pool/src/traits.rs
@@ -19,5 +19,5 @@ pub trait MemPoolProvider {
 }
 
 pub trait MemPoolErrorTxHandler {
-    fn handle_error_receipt(&self, receipt: ErrorTxReceipt) -> Task<Result<()>>;
+    fn handle_error_receipt(&mut self, receipt: ErrorTxReceipt) -> Task<Result<()>>;
 }

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -139,6 +139,7 @@ pub fn setup_chain_with_account_lock_manage(
         Arc::clone(&generator),
         Box::new(provider),
         None,
+        None,
         Default::default(),
     )
     .unwrap();

--- a/crates/types/src/offchain/error_receipt.rs
+++ b/crates/types/src/offchain/error_receipt.rs
@@ -1,0 +1,10 @@
+use crate::packed::LogItem;
+
+use sparse_merkle_tree::H256;
+
+pub struct ErrorTxReceipt {
+    pub tx_hash: H256,
+    pub block_number: u64,
+    pub return_data: Vec<u8>,
+    pub last_log: Option<LogItem>,
+}

--- a/crates/types/src/offchain/mod.rs
+++ b/crates/types/src/offchain/mod.rs
@@ -1,9 +1,11 @@
+mod error_receipt;
 mod extension;
 mod pool;
 mod rollup_context;
 mod rpc;
 mod run_result;
 
+pub use error_receipt::*;
 pub use extension::global_state_from_slice;
 pub use pool::*;
 pub use rollup_context::*;

--- a/crates/web3-indexer/Cargo.toml
+++ b/crates/web3-indexer/Cargo.toml
@@ -15,9 +15,11 @@ gw-config = { path = "../config" }
 gw-common = { path = "../common" }
 gw-generator = { path = "../generator" }
 gw-traits = { path = "../traits" }
+gw-mem-pool = { path = "../mem-pool" }
 ckb-hash = "0.100.0"
 ckb-types = "0.100.0"
 anyhow = "1.0"
+smol = "1.2.5"
 thiserror = "1.0"
 sqlx = { version = "0.5", features = [ "runtime-async-std-native-tls", "postgres", "sqlite", "chrono", "decimal" ] }
 rust_decimal = "1.10.3"
@@ -26,3 +28,4 @@ faster-hex = "0.5.0"
 log = "0.4"
 rlp = "0.5"
 sha3 = "0.9.1"
+ethabi = "15.0.0"

--- a/crates/web3-indexer/migrations/20211015154325_create_error_transactions.sql
+++ b/crates/web3-indexer/migrations/20211015154325_create_error_transactions.sql
@@ -6,7 +6,7 @@ CREATE TABLE error_transactions (
     cumulative_gas_used NUMERIC,
     gas_used NUMERIC,
     status_code NUMERIC NOT NULL,
-    status_reason TEXT NOT NULL
+    status_reason bytea NOT NULL
 );
 
 CREATE INDEX ON error_transactions (block_number);

--- a/crates/web3-indexer/migrations/20211015154325_create_error_transactions.sql
+++ b/crates/web3-indexer/migrations/20211015154325_create_error_transactions.sql
@@ -1,0 +1,13 @@
+-- Add migration script here
+CREATE TABLE error_transactions (
+    id BIGSERIAL PRIMARY KEY,
+    hash TEXT UNIQUE NOT NULL,
+    block_number NUMERIC NOT NULL,
+    cumulative_gas_used NUMERIC,
+    gas_used NUMERIC,
+    status_code NUMERIC NOT NULL,
+    status_reason TEXT NOT NULL
+);
+
+CREATE INDEX ON error_transactions (block_number);
+CREATE INDEX ON error_transactions (hash);

--- a/crates/web3-indexer/src/error_receipt_indexer.rs
+++ b/crates/web3-indexer/src/error_receipt_indexer.rs
@@ -9,14 +9,19 @@ use sqlx::PgPool;
 use crate::helper::{hex, parse_log, GwLog};
 
 pub const MAX_RETURN_DATA: usize = 32;
+pub const MAX_ERROR_TX_RECEIPT_BLOCKS: u64 = 3;
 
 pub struct ErrorReceiptIndexer {
     pool: PgPool,
+    latest_block: u64,
 }
 
 impl ErrorReceiptIndexer {
     pub fn new(pool: PgPool) -> Self {
-        ErrorReceiptIndexer { pool }
+        ErrorReceiptIndexer {
+            pool,
+            latest_block: 0,
+        }
     }
 
     async fn insert_error_tx_receipt(pool: PgPool, receipt: ErrorTxReceipt) -> Result<()> {
@@ -37,12 +42,40 @@ impl ErrorReceiptIndexer {
         db.commit().await?;
         Ok(())
     }
+
+    async fn clear_expired_block_error_receipt(pool: PgPool, block_number: u64) -> Result<()> {
+        let mut db = pool.begin().await?;
+        let result = sqlx::query("DELETE FROM error_transactions WHERE block_number <= $1")
+            .bind(Decimal::from(block_number))
+            .execute(&mut db)
+            .await?;
+
+        db.commit().await?;
+        log::info!("delete error tx receipt {}", result.rows_affected());
+
+        Ok(())
+    }
 }
 
 impl MemPoolErrorTxHandler for ErrorReceiptIndexer {
-    fn handle_error_receipt(&self, receipt: ErrorTxReceipt) -> Task<Result<()>> {
-        let pool = self.pool.clone();
+    fn handle_error_receipt(&mut self, receipt: ErrorTxReceipt) -> Task<Result<()>> {
+        if self.latest_block < receipt.block_number {
+            self.latest_block = receipt.block_number;
 
+            let pool = self.pool.clone();
+            let expired_block = self
+                .latest_block
+                .saturating_sub(MAX_ERROR_TX_RECEIPT_BLOCKS);
+            smol::spawn(async move {
+                if let Err(err) = Self::clear_expired_block_error_receipt(pool, expired_block).await
+                {
+                    log::error!("clear expired block error receipt {}", err);
+                }
+            })
+            .detach();
+        }
+
+        let pool = self.pool.clone();
         smol::spawn(async move {
             if let Err(err) = Self::insert_error_tx_receipt(pool, receipt).await {
                 log::error!("insert error tx receipt {}", err);

--- a/crates/web3-indexer/src/error_receipt_indexer.rs
+++ b/crates/web3-indexer/src/error_receipt_indexer.rs
@@ -1,0 +1,115 @@
+use anyhow::Result;
+use gw_common::H256;
+use gw_mem_pool::traits::MemPoolErrorTxHandler;
+use gw_types::offchain::ErrorTxReceipt;
+use rust_decimal::Decimal;
+use smol::Task;
+use sqlx::PgPool;
+
+use crate::helper::{hex, parse_log, GwLog};
+
+pub const MAX_RETURN_DATA: usize = 32;
+
+pub struct ErrorReceiptIndexer {
+    pool: PgPool,
+}
+
+impl ErrorReceiptIndexer {
+    pub fn new(pool: PgPool) -> Self {
+        ErrorReceiptIndexer { pool }
+    }
+}
+
+impl MemPoolErrorTxHandler for ErrorReceiptIndexer {
+    fn handle_error_receipt(&self, receipt: ErrorTxReceipt) -> Task<Result<()>> {
+        let record = ErrorReceiptRecord::from(receipt);
+        let pool = self.pool.clone();
+
+        smol::spawn(async move {
+            let mut db = pool.begin().await?;
+            sqlx::query("INSERT INTO error_transactions (hash, block_number, cumulative_gas_used, gas_used, status_code, status_reason) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)")
+            .bind(hex(record.tx_hash.as_slice())?)
+            .bind(Decimal::from(record.block_number))
+            .bind(Decimal::from(record.cumulative_gas_used))
+            .bind(Decimal::from(record.gas_used))
+            .bind(Decimal::from(record.status_code))
+            .bind(record.status_reason)
+            .execute(&mut db)
+            .await?;
+
+            db.commit().await?;
+            Ok(())
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ErrorReceiptRecord {
+    tx_hash: H256,
+    block_number: u64,
+    cumulative_gas_used: u64,
+    gas_used: u64,
+    status_code: u32,
+    status_reason: String,
+}
+
+impl From<ErrorTxReceipt> for ErrorReceiptRecord {
+    fn from(receipt: ErrorTxReceipt) -> Self {
+        let basic_record = ErrorReceiptRecord {
+            tx_hash: receipt.tx_hash,
+            block_number: receipt.block_number,
+            cumulative_gas_used: 0,
+            gas_used: 0,
+            status_code: 0,
+            status_reason: Default::default(),
+        };
+
+        match receipt.last_log.map(|log| parse_log(&log)).transpose() {
+            Ok(Some(GwLog::PolyjuiceSystem {
+                gas_used,
+                cumulative_gas_used,
+                created_address: _,
+                status_code,
+            })) => {
+                let isnt_string = |t: &ethabi::token::Token| -> bool {
+                    !matches!(t, ethabi::token::Token::String(_))
+                };
+
+                // First 4 bytes are func signature
+                let status_reason =
+                    match ethabi::decode(&[ethabi::ParamType::String], &receipt.return_data[4..]) {
+                        Ok(tokens) if !tokens.iter().any(isnt_string) => {
+                            let mut reason = tokens
+                                .into_iter()
+                                .flat_map(ethabi::token::Token::into_string)
+                                .collect::<Vec<String>>()
+                                .join("");
+
+                            reason.truncate(MAX_RETURN_DATA);
+                            reason
+                        }
+                        _ => {
+                            log::warn!(
+                                "unsupported polyjuice status reason {:?}",
+                                receipt.return_data
+                            );
+                            basic_record.status_reason
+                        }
+                    };
+
+                ErrorReceiptRecord {
+                    gas_used,
+                    cumulative_gas_used,
+                    status_code,
+                    status_reason,
+                    ..basic_record
+                }
+            }
+            Err(err) => {
+                log::error!("[error receipt]: parse log error {}", err);
+                basic_record
+            }
+            _ => basic_record,
+        }
+    }
+}

--- a/crates/web3-indexer/src/lib.rs
+++ b/crates/web3-indexer/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod error_receipt_indexer;
 pub mod helper;
 pub mod indexer;
 pub mod types;
 
+pub use error_receipt_indexer::ErrorReceiptIndexer;
 pub use indexer::Web3Indexer;


### PR DESCRIPTION
- for ```execute_l2transaction``` and ```execute_raw_l2transaction```, response error receipt in jsonrpc error data field
- for ```submit_l2transaction```, save error receipt to web3 indexer database and clear them after expiration blocks