### PR TITLE
fix: search stake cell with minimum capacity

### DIFF
--- a/crates/block-producer/src/stake.rs
+++ b/crates/block-producer/src/stake.rs
@@ -47,8 +47,17 @@ pub async fn generate(
         .args(lock_args.pack())
         .build();
 
+    let required_staking_capacity = rollup_context
+        .rollup_config
+        .required_staking_capacity()
+        .unpack();
     if let Some(unlocked_stake) = rpc_client
-        .query_stake(rollup_context, owner_lock_hash, None)
+        .query_stake(
+            rollup_context,
+            owner_lock_hash,
+            required_staking_capacity,
+            None,
+        )
         .await?
     {
         let stake_lock_dep = block_producer_config.stake_cell_lock_dep.clone();

--- a/crates/rpc-client/src/rpc_client.rs
+++ b/crates/rpc-client/src/rpc_client.rs
@@ -491,6 +491,7 @@ impl RPCClient {
         &self,
         rollup_context: &RollupContext,
         owner_lock_hash: [u8; 32],
+        required_staking_capacity: u64,
         last_finalized_block_number: Option<u64>,
     ) -> Result<Option<CellInfo>> {
         let lock = Script::new_builder()
@@ -508,7 +509,7 @@ impl RPCClient {
             filter: Some(SearchKeyFilter {
                 script: None,
                 output_data_len_range: None,
-                output_capacity_range: None,
+                output_capacity_range: Some([required_staking_capacity.into(), u64::MAX.into()]),
                 block_range: None,
             }),
         };


### PR DESCRIPTION
If there are multiple stake cells we would blindly choose the frist returned cell. But the cell's capacity may not enough for the rollup staking, this causes the block producer failed to submit a block.