### PR TITLE
Support submit local block

### DIFF
--- a/crates/block-producer/src/block_producer.rs
+++ b/crates/block-producer/src/block_producer.rs
@@ -4,13 +4,13 @@ use crate::{
     produce_block::{produce_block, ProduceBlockParam, ProduceBlockResult},
     test_mode_control::TestModeControl,
     types::ChainEvent,
-    utils,
+    utils::{self, extract_deposit_requests},
 };
 use anyhow::{anyhow, bail, Context, Result};
 use ckb_chain_spec::consensus::MAX_BLOCK_BYTES;
 use ckb_types::prelude::Unpack as CKBUnpack;
 use futures::{future::select_all, FutureExt};
-use gw_chain::chain::{Chain, SyncEvent};
+use gw_chain::chain::{Chain, L1ActionContext, LocalAction, SyncEvent, SyncParam, UpdateAction};
 use gw_common::{h256_ext::H256Ext, H256};
 use gw_config::{BlockProducerConfig, DebugConfig};
 use gw_generator::Generator;
@@ -254,13 +254,31 @@ impl BlockProducer {
                 }
             }
 
-            let (block_number, tx) = self.produce_next_block(median_time, rollup_cell).await?;
+            let (block_number, block, tx) =
+                self.produce_next_block(median_time, rollup_cell).await?;
             if expected_next_block_number != block_number {
                 log::warn!("produce unexpected next block, expect {} produce {}, wait until chain is synced to latest block", expected_next_block_number, block_number);
                 return Ok(());
             }
 
-            self.last_submitted_block = self.submit_block_tx(block_number, tx).await?;
+            self.last_submitted_block = self.submit_block_tx(block_number, tx.clone()).await?;
+
+            // fast sync new tx to local chain
+            // insert to chain
+            let mut chain = self.chain.lock().await;
+
+            let (deposit_requests, deposit_asset_scripts) =
+                extract_deposit_requests(&self.rpc_client, &self.generator.rollup_context(), &tx)
+                    .await?;
+            chain.sync(SyncParam::Update(UpdateAction::Local(LocalAction {
+                transaction: tx,
+                context: L1ActionContext::SubmitBlock {
+                    /// deposit requests
+                    l2block: block,
+                    deposit_requests,
+                    deposit_asset_scripts,
+                },
+            })))?;
         }
         Ok(())
     }
@@ -269,7 +287,7 @@ impl BlockProducer {
         &mut self,
         median_time: Duration,
         rollup_cell: CellInfo,
-    ) -> Result<(u64, Transaction)> {
+    ) -> Result<(u64, L2Block, Transaction)> {
         if let Some(ref tests_control) = self.tests_control {
             match tests_control.payload().await {
                 Some(TestModePayload::None) => tests_control.clear_none().await?,
@@ -337,7 +355,7 @@ impl BlockProducer {
                 .complete_tx_skeleton(
                     deposit_cells,
                     finalized_custodians,
-                    block,
+                    block.clone(),
                     global_state,
                     median_time,
                     rollup_cell.clone(),
@@ -356,7 +374,7 @@ impl BlockProducer {
             };
 
             if tx.as_slice().len() <= MAX_BLOCK_BYTES as usize {
-                return Ok((number, tx));
+                return Ok((number, block, tx));
             }
 
             retry_count += 1;

--- a/crates/block-producer/src/poller.rs
+++ b/crates/block-producer/src/poller.rs
@@ -9,7 +9,7 @@ use async_jsonrpc_client::{Params as ClientParams, Transport};
 use ckb_fixed_hash::H256;
 use gw_chain::chain::{
     Chain, ChallengeCell, L1Action, L1ActionContext, RevertL1ActionContext, RevertedAction,
-    RevertedL1Action, SyncParam, UpdateAction,
+    RevertedL1Action, RevertedLocalAction, SyncParam, UpdateAction,
 };
 use gw_jsonrpc_types::ckb_jsonrpc_types::{BlockNumber, HeaderView, TransactionWithStatus, Uint32};
 use gw_rpc_client::{
@@ -74,40 +74,38 @@ impl ChainUpdater {
         }
 
         // Check l1 fork
-        let local_tip_committed_info = {
-            self.chain
-                .lock()
-                .await
-                .local_state()
-                .last_synced()
-                .to_owned()
+        let local_last_committed_info = {
+            let chain = self.chain.lock().await;
+            match chain.local_state().last_synced().to_owned() {
+                Some(last_synced) => last_synced,
+                None => {
+                    let db = chain.store().begin_transaction();
+                    db.get_l2block_committed_info(
+                        &chain.local_state().tip().raw().parent_block_hash().unpack(),
+                    )?
+                    .expect("last committed info")
+                }
+            }
         };
-        if !self.find_l2block_on_l1(local_tip_committed_info).await? {
+        if !self.find_l2block_on_l1(local_last_committed_info).await? {
             self.revert_to_valid_tip_on_l1().await?;
 
-            let (
-                local_tip_block_number,
-                local_tip_block_hash,
-                committed_l1_block_number,
-                committed_l1_block_hash,
-            ) = {
+            let (local_tip_block_number, local_tip_block_hash, local_tip_committed_info) = {
                 let chain = self.chain.lock().await;
                 let local_tip_block = chain.local_state().tip().raw();
-                let local_tip_committed_info = chain.local_state().last_synced();
+                let local_tip_committed_info = chain.local_state().last_synced().to_owned();
                 (
                     Unpack::<u64>::unpack(&local_tip_block.number()),
                     Into::<ckb_types::H256>::into(local_tip_block.hash()),
-                    Unpack::<u64>::unpack(&local_tip_committed_info.number()),
-                    ckb_types::H256(local_tip_committed_info.block_hash().unpack()),
+                    local_tip_committed_info,
                 )
             };
 
             log::warn!(
-                "revert to l2 block number {} hash {} on l1 block number {} hash {}",
+                "revert to l2 block number {} hash {} on l1 {:?}",
                 local_tip_block_number,
                 local_tip_block_hash,
-                committed_l1_block_number,
-                committed_l1_block_hash
+                local_tip_committed_info
             );
         }
 
@@ -116,26 +114,47 @@ impl ChainUpdater {
         // Double check that we are synced to latest block
         // TODO: remove
         if let Some(rollup_cell) = self.rpc_client.query_rollup_cell().await? {
-            let local_tip_block_number: u64 = {
+            let (local_tip_block_number, is_pending): (u64, bool) = {
                 let chain = self.chain.lock().await;
-                chain.local_state().tip().raw().number().unpack()
+                (
+                    chain.local_state().tip().raw().number().unpack(),
+                    chain.local_state().is_pending(),
+                )
             };
             let tip_block_number = {
                 let global_state = global_state_from_slice(&rollup_cell.data)?;
                 Unpack::<u64>::unpack(&global_state.block().count()).saturating_sub(1)
             };
-            assert!(
-                tip_block_number >= local_tip_block_number,
-                "tip: {}, local tip: {}",
-                tip_block_number,
-                local_tip_block_number
-            );
 
-            if local_tip_block_number.saturating_add(1) == tip_block_number {
-                log::info!("single update to latest l2 block {}", tip_block_number);
+            if is_pending {
+                assert!(
+                    tip_block_number >= local_tip_block_number.saturating_sub(1),
+                    "tip: {}, local tip: {}",
+                    tip_block_number,
+                    local_tip_block_number
+                );
 
-                let tx_hash = rollup_cell.out_point.tx_hash().unpack();
-                self.update_single(&tx_hash).await?;
+                // the new block is potentially a pending block
+                if local_tip_block_number == tip_block_number {
+                    log::info!("single update to latest l2 block {}", tip_block_number);
+
+                    let tx_hash = rollup_cell.out_point.tx_hash().unpack();
+                    self.update_single(&tx_hash).await?;
+                }
+            } else {
+                assert!(
+                    tip_block_number >= local_tip_block_number,
+                    "tip: {}, local tip: {}",
+                    tip_block_number,
+                    local_tip_block_number
+                );
+
+                if local_tip_block_number.saturating_add(1) == tip_block_number {
+                    log::info!("single update to latest l2 block {}", tip_block_number);
+
+                    let tx_hash = rollup_cell.out_point.tx_hash().unpack();
+                    self.update_single(&tx_hash).await?;
+                }
             }
         }
 
@@ -151,7 +170,19 @@ impl ChainUpdater {
         let valid_tip_l1_block_number = {
             let chain = self.chain.lock().await;
             let local_tip_block: u64 = chain.local_state().tip().raw().number().unpack();
-            let local_committed_l1_block: u64 = chain.local_state().last_synced().number().unpack();
+            let local_committed_l1_block: u64 = match chain.local_state().last_synced() {
+                Some(last_synced) => last_synced.number().unpack(),
+                None => {
+                    // pending block, return it's parent's committed info
+                    let db = chain.store().begin_transaction();
+                    let committed_info = db
+                        .get_l2block_committed_info(
+                            &chain.local_state().tip().raw().parent_block_hash().unpack(),
+                        )?
+                        .expect("get parent committed info");
+                    committed_info.number().unpack()
+                }
+            };
 
             log::debug!(
                 "try sync from l2 block {} (l1 block {})",
@@ -339,23 +370,29 @@ impl ChainUpdater {
         let last_valid_tip_global_state = db
             .get_block_post_global_state(&last_valid_tip_block_hash)?
             .expect("valid tip global status should exists");
-        let last_valid_tip_committed_info = db
-            .get_l2block_committed_info(&last_valid_tip_block_hash)?
-            .expect("valid tip committed info should exists");
-        let rewind_to_last_valid_tip = RevertedL1Action {
-            prev_global_state: last_valid_tip_global_state,
-            l2block_committed_info: last_valid_tip_committed_info.clone(),
-            context: RevertL1ActionContext::RewindToLastValidTip,
+        let last_valid_tip_committed_info_opt =
+            db.get_l2block_committed_info(&last_valid_tip_block_hash)?;
+        let rewind_to_last_valid_tip = match last_valid_tip_committed_info_opt.clone() {
+            Some(last_valid_tip_committed_info) => RevertedAction::L1(RevertedL1Action {
+                prev_global_state: last_valid_tip_global_state,
+                l2block_committed_info: last_valid_tip_committed_info.clone(),
+                context: RevertL1ActionContext::RewindToLastValidTip,
+            }),
+            None => RevertedAction::Local(RevertedLocalAction {
+                prev_global_state: last_valid_tip_global_state,
+                context: RevertL1ActionContext::RewindToLastValidTip,
+            }),
         };
         revert_l1_actions.push(rewind_to_last_valid_tip);
 
         // Revert until last valid block on l1 found
-        let mut local_valid_committed_info = last_valid_tip_committed_info;
+        let mut local_valid_committed_info_opt = last_valid_tip_committed_info_opt;
         let mut local_valid_block = db.get_last_valid_tip_block()?;
         loop {
-            if self
-                .find_l2block_on_l1(local_valid_committed_info.clone())
-                .await?
+            if local_valid_committed_info_opt.is_some()
+                && self
+                    .find_l2block_on_l1(local_valid_committed_info_opt.clone().unwrap())
+                    .await?
             {
                 break;
             }
@@ -368,26 +405,37 @@ impl ChainUpdater {
             let parent_valid_committed_info = db
                 .get_l2block_committed_info(&parent_valid_block_hash.into())?
                 .expect("valid block l2 committed info should exists");
-            let revert_submit_valid_block = RevertedL1Action {
-                prev_global_state: parent_valid_global_state,
-                l2block_committed_info: parent_valid_committed_info.clone(),
-                context: RevertL1ActionContext::SubmitValidBlock {
-                    l2block: local_valid_block,
-                },
+
+            let block_is_committed = local_valid_committed_info_opt.is_some();
+
+            let revert_submit_valid_block = if block_is_committed {
+                // revert committed block
+                RevertedAction::L1(RevertedL1Action {
+                    prev_global_state: parent_valid_global_state,
+                    l2block_committed_info: parent_valid_committed_info.clone(),
+                    context: RevertL1ActionContext::SubmitValidBlock {
+                        l2block: local_valid_block,
+                    },
+                })
+            } else {
+                // revert pending block
+                RevertedAction::Local(RevertedLocalAction {
+                    prev_global_state: parent_valid_global_state,
+                    context: RevertL1ActionContext::SubmitValidBlock {
+                        l2block: local_valid_block,
+                    },
+                })
             };
             revert_l1_actions.push(revert_submit_valid_block);
 
-            local_valid_committed_info = parent_valid_committed_info;
+            local_valid_committed_info_opt = Some(parent_valid_committed_info);
             local_valid_block = db
                 .get_block(&parent_valid_block_hash.into())?
                 .expect("valid block should exists");
         }
 
         for action in revert_l1_actions {
-            self.chain
-                .lock()
-                .await
-                .sync(SyncParam::Revert(RevertedAction::L1(action)))?;
+            self.chain.lock().await.sync(SyncParam::Revert(action))?;
         }
 
         // Also revert last tx hash

--- a/crates/block-producer/src/utils.rs
+++ b/crates/block-producer/src/utils.rs
@@ -1,12 +1,36 @@
 use crate::debugger;
 use anyhow::{anyhow, Result};
 use async_jsonrpc_client::Output;
+use async_jsonrpc_client::{Params as ClientParams, Transport};
+use ckb_fixed_hash::H256;
+use gw_chain::chain::{
+    Chain, ChallengeCell, L1Action, L1ActionContext, RevertL1ActionContext, RevertedAction,
+    RevertedL1Action, SyncParam, UpdateAction,
+};
 use gw_config::DebugConfig;
+use gw_jsonrpc_types::ckb_jsonrpc_types::TransactionWithStatus;
+use gw_jsonrpc_types::ckb_jsonrpc_types::{BlockNumber, HeaderView, Uint32};
+use gw_rpc_client::indexer_types::{Order, Pagination, ScriptType, SearchKey, SearchKeyFilter, Tx};
 use gw_rpc_client::rpc_client::RPCClient;
-use gw_types::packed::Transaction;
+use gw_types::packed::{CellOutput, DepositRequest, Script, Transaction};
+use gw_types::{
+    bytes::Bytes,
+    core::ScriptHashType,
+    offchain::{global_state_from_slice, RollupContext, TxStatus},
+    packed::{
+        CellInput, ChallengeLockArgs, ChallengeLockArgsReader, DepositLockArgs,
+        L2BlockCommittedInfo, OutPoint, RollupAction, RollupActionUnion, WitnessArgs,
+        WitnessArgsReader,
+    },
+    prelude::*,
+};
+use gw_web3_indexer::indexer::Web3Indexer;
 use serde::de::DeserializeOwned;
 use serde_json::from_value;
+use serde_json::json;
+use smol::lock::Mutex;
 use std::path::Path;
+use std::{collections::HashSet, sync::Arc};
 
 // convert json output to result
 pub fn to_result<T: DeserializeOwned>(output: Output) -> Result<T> {
@@ -52,4 +76,99 @@ pub async fn dump_transaction<P: AsRef<Path>>(dir: P, rpc_client: &RPCClient, tx
             err
         );
     }
+}
+
+pub async fn extract_deposit_requests(
+    rpc_client: &RPCClient,
+    rollup_context: &RollupContext,
+    tx: &Transaction,
+) -> Result<(Vec<DepositRequest>, HashSet<Script>)> {
+    let mut results = vec![];
+    let mut asset_type_scripts = HashSet::new();
+    for input in tx.raw().inputs().into_iter() {
+        // Load cell denoted by the transaction input
+        let tx_hash: H256 = input.previous_output().tx_hash().unpack();
+        let index = input.previous_output().index().unpack();
+        let tx: Option<TransactionWithStatus> = to_result(
+            rpc_client
+                .ckb
+                .request(
+                    "get_transaction",
+                    Some(ClientParams::Array(vec![json!(tx_hash)])),
+                )
+                .await?,
+        )?;
+        let tx_with_status =
+            tx.ok_or_else(|| anyhow::anyhow!("Cannot locate transaction: {:x}", tx_hash))?;
+        let tx = {
+            let tx: ckb_types::packed::Transaction = tx_with_status.transaction.inner.into();
+            Transaction::new_unchecked(tx.as_bytes())
+        };
+        let cell_output = tx
+            .raw()
+            .outputs()
+            .get(index)
+            .ok_or_else(|| anyhow::anyhow!("OutPoint index out of bound"))?;
+        let cell_data = tx
+            .raw()
+            .outputs_data()
+            .get(index)
+            .ok_or_else(|| anyhow::anyhow!("OutPoint index out of bound"))?;
+
+        // Check if loaded cell is a deposit request
+        if let Some(deposit_request) =
+            try_parse_deposit_request(&cell_output, &cell_data.unpack(), &rollup_context)
+        {
+            results.push(deposit_request);
+            if let Some(type_) = &cell_output.type_().to_opt() {
+                asset_type_scripts.insert(type_.clone());
+            }
+        }
+    }
+    Ok((results, asset_type_scripts))
+}
+
+fn try_parse_deposit_request(
+    cell_output: &CellOutput,
+    cell_data: &Bytes,
+    rollup_context: &RollupContext,
+) -> Option<DepositRequest> {
+    if cell_output.lock().code_hash() != rollup_context.rollup_config.deposit_script_type_hash()
+        || cell_output.lock().hash_type() != ScriptHashType::Type.into()
+    {
+        return None;
+    }
+    let args = cell_output.lock().args().raw_data();
+    if args.len() < 32 {
+        return None;
+    }
+    let rollup_type_script_hash: [u8; 32] = rollup_context.rollup_script_hash.into();
+    if args.slice(0..32) != rollup_type_script_hash[..] {
+        return None;
+    }
+    let lock_args = match DepositLockArgs::from_slice(&args.slice(32..)) {
+        Ok(lock_args) => lock_args,
+        Err(_) => return None,
+    };
+    // NOTE: In readoly mode, we are only loading on chain data here, timeout validation
+    // can be skipped. For generator part, timeout validation needs to be introduced.
+    let (amount, sudt_script_hash) = match cell_output.type_().to_opt() {
+        Some(script) => {
+            if cell_data.len() < 16 {
+                return None;
+            }
+            let mut data = [0u8; 16];
+            data.copy_from_slice(&cell_data[0..16]);
+            (u128::from_le_bytes(data), script.hash())
+        }
+        None => (0u128, [0u8; 32]),
+    };
+    let capacity: u64 = cell_output.capacity().unpack();
+    let deposit_request = DepositRequest::new_builder()
+        .capacity(capacity.pack())
+        .amount(amount.pack())
+        .sudt_script_hash(sudt_script_hash.pack())
+        .script(lock_args.layer2_lock())
+        .build();
+    Some(deposit_request)
 }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -24,7 +24,7 @@ use gw_types::{
     prelude::{Builder as GWBuilder, Entity as GWEntity, Pack as GWPack, Unpack as GWUnpack},
 };
 use smol::lock::Mutex;
-use std::{collections::HashSet, convert::TryFrom, sync::Arc};
+use std::{collections::HashSet, convert::TryFrom, hash::Hash, sync::Arc};
 
 #[derive(Debug, Clone)]
 pub struct ChallengeCell {
@@ -35,11 +35,11 @@ pub struct ChallengeCell {
 
 /// sync params
 #[derive(Clone)]
-pub struct SyncParam {
-    /// contains transitions from tip to fork point
-    pub reverts: Vec<RevertedL1Action>,
+pub enum SyncParam {
     /// contains transitions from fork point to new tips
-    pub updates: Vec<L1Action>,
+    Update(UpdateAction),
+    /// contains transitions from tip to fork point
+    Revert(RevertedAction),
 }
 
 #[derive(Debug, Clone)]
@@ -61,6 +61,21 @@ pub enum L1ActionContext {
     },
 }
 
+#[derive(Clone)]
+pub enum UpdateAction {
+    // layer1 update
+    L1(L1Action),
+    // local fast update
+    Local(LocalAction),
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalAction {
+    /// transaction
+    pub transaction: Transaction,
+    pub context: L1ActionContext,
+}
+
 #[derive(Debug, Clone)]
 pub struct L1Action {
     /// transaction
@@ -74,6 +89,21 @@ pub struct L1Action {
 pub enum RevertL1ActionContext {
     SubmitValidBlock { l2block: L2Block },
     RewindToLastValidTip,
+}
+
+#[derive(Clone)]
+pub enum RevertedAction {
+    // layer1 update
+    L1(RevertedL1Action),
+    // local fast update
+    Local(RevertedLocalAction),
+}
+
+#[derive(Debug, Clone)]
+pub struct RevertedLocalAction {
+    /// input global state
+    pub prev_global_state: GlobalState,
+    pub context: RevertL1ActionContext,
 }
 
 #[derive(Debug, Clone)]
@@ -115,6 +145,13 @@ impl SyncEvent {
 /// concrete type aliases
 pub type StateStore = sparse_merkle_tree::default_store::DefaultStore<sparse_merkle_tree::H256>;
 
+/// Represent fast path state: synced from local block producer, so we do not have L2BlockCommittedInfo
+#[derive(Debug, Clone)]
+pub struct LocalPendingBlock {
+    block: L2Block,
+    prev_global_state: GlobalState,
+}
+
 pub struct LocalState {
     tip: L2Block,
     last_synced: L2BlockCommittedInfo,
@@ -147,6 +184,7 @@ pub struct Chain {
     challenge_target: Option<ChallengeTarget>,
     last_sync_event: SyncEvent,
     local_state: LocalState,
+    local_pending_block: Option<LocalPendingBlock>,
     generator: Arc<Generator>,
     mem_pool: Option<Arc<Mutex<MemPool>>>,
     complete_initial_syncing: bool,
@@ -174,10 +212,34 @@ impl Chain {
             chain_id, rollup_type_script_hash,
             "Database chain_id must equals to rollup_script_hash"
         );
-        let tip = store.get_tip_block()?;
-        let last_synced = store
-            .get_l2block_committed_info(&tip.hash().into())?
-            .ok_or_else(|| anyhow!("can't find last synced committed info"))?;
+
+        // resume pending block
+        let mut tip = store.get_tip_block()?;
+        let mut local_pending_block = None;
+        let last_synced;
+        match store.get_l2block_committed_info(&tip.hash().into())? {
+            Some(committed_info) => {
+                last_synced = committed_info;
+            }
+            None => {
+                // tip is pending local block, use it's parent as tip
+                let pending_block = tip.clone();
+                tip = store
+                    .get_block(&tip.raw().parent_block_hash().unpack())?
+                    .expect("get block");
+                last_synced = store
+                    .get_l2block_committed_info(&tip.hash().into())?
+                    .ok_or(anyhow!("can't find last synced committed info"))?;
+                let prev_global_state = store
+                    .get_block_post_global_state(&tip.hash().into())?
+                    .expect("get pending block global state");
+                local_pending_block = Some(LocalPendingBlock {
+                    block: pending_block,
+                    prev_global_state,
+                });
+            }
+        };
+
         let last_global_state = store
             .get_block_post_global_state(&tip.hash().into())?
             .ok_or_else(|| anyhow!("can't find last global state"))?;
@@ -201,6 +263,7 @@ impl Chain {
             challenge_target: None,
             last_sync_event: SyncEvent::Success,
             local_state,
+            local_pending_block,
             generator,
             mem_pool,
             rollup_type_script_hash,
@@ -293,30 +356,38 @@ impl Chain {
         )
     }
 
-    /// update a layer1 action
-    fn update_l1action(&mut self, db: &StoreTransaction, action: L1Action) -> Result<()> {
-        let L1Action {
-            transaction,
-            l2block_committed_info,
-            context,
-        } = action;
+    /// apply an action
+    fn apply_action(&mut self, db: &StoreTransaction, update: UpdateAction) -> Result<()> {
+        let (transaction, context) = match &update {
+            UpdateAction::L1(L1Action {
+                transaction,
+                l2block_committed_info,
+                context,
+            }) => {
+                assert!(
+                    {
+                        let number: u64 = l2block_committed_info.number().unpack();
+                        number
+                    } >= {
+                        let number: u64 = self.local_state.last_synced.number().unpack();
+                        number
+                    },
+                    "must be greater than or equalled to last synced number"
+                );
+                (transaction, context)
+            }
+            UpdateAction::Local(LocalAction {
+                transaction,
+                context,
+            }) => (transaction, context),
+        };
         let global_state = parse_global_state(&transaction, &self.rollup_type_script_hash)?;
-        assert!(
-            {
-                let number: u64 = l2block_committed_info.number().unpack();
-                number
-            } >= {
-                let number: u64 = self.local_state.last_synced.number().unpack();
-                number
-            },
-            "must be greater than or equalled to last synced number"
-        );
         let status = {
             let status: u8 = self.local_state.last_global_state.status().into();
             Status::try_from(status).expect("invalid status")
         };
 
-        let update = || -> Result<SyncEvent> {
+        let mut apply_update = || -> Result<SyncEvent> {
             match (status, context) {
                 (
                     Status::Running,
@@ -345,55 +416,103 @@ impl Chain {
                         self.challenge_target = challenge_target;
                     }
 
-                    if let Some(ref target) = self.challenge_target {
-                        db.insert_bad_block(&l2block, &l2block_committed_info, &global_state)?;
-                        log::info!("insert bad block 0x{}", hex::encode(l2block.hash()));
+                    match &update {
+                        UpdateAction::L1(L1Action {
+                            l2block_committed_info,
+                            ..
+                        }) => {
+                            if let Some(ref target) = self.challenge_target {
+                                db.insert_bad_block(
+                                    &l2block,
+                                    &l2block_committed_info,
+                                    &global_state,
+                                )?;
+                                log::info!("insert bad block 0x{}", hex::encode(l2block.hash()));
 
-                        let global_block_root: H256 = global_state.block().merkle_root().unpack();
-                        let local_block_root = db.get_block_smt_root()?;
-                        assert_eq!(local_block_root, global_block_root, "block root fork");
+                                let global_block_root: H256 =
+                                    global_state.block().merkle_root().unpack();
+                                let local_block_root = db.get_block_smt_root()?;
+                                assert_eq!(local_block_root, global_block_root, "block root fork");
 
-                        self.local_state.tip = l2block;
+                                self.local_state.tip = l2block.to_owned();
 
-                        let context =
-                            gw_challenge::context::build_challenge_context(db, target.to_owned())?;
-                        return Ok(SyncEvent::BadBlock { context });
+                                let context = gw_challenge::context::build_challenge_context(
+                                    db,
+                                    target.to_owned(),
+                                )?;
+                                return Ok(SyncEvent::BadBlock { context });
+                            }
+                        }
+                        UpdateAction::Local(LocalAction { .. }) => {
+                            assert!(
+                                self.challenge_target.is_none(),
+                                "Shouldn't produce new local block if a bad block is found"
+                            );
+                        }
                     }
 
-                    if let Some(challenge_target) = self.process_block(
+                    match self.process_block(
                         db,
                         l2block.clone(),
-                        l2block_committed_info.clone(),
                         global_state.clone(),
-                        deposit_requests,
-                        deposit_asset_scripts,
+                        deposit_requests.to_owned(),
+                        deposit_asset_scripts.to_owned(),
                     )? {
-                        db.rollback()?;
-                        log::warn!("bad block found, rollback db");
+                        Some(challenge_target) => {
+                            db.rollback()?;
+                            log::warn!("bad block found, rollback db");
 
-                        db.insert_bad_block(&l2block, &l2block_committed_info, &global_state)?;
-                        log::info!("insert bad block 0x{}", hex::encode(l2block.hash()));
+                            let l2block_committed_info = match &update {
+                                UpdateAction::L1(L1Action {
+                                    l2block_committed_info,
+                                    ..
+                                }) => l2block_committed_info,
+                                UpdateAction::Local(..) => {
+                                    panic!("Local block is bad");
+                                }
+                            };
 
-                        let global_block_root: H256 = global_state.block().merkle_root().unpack();
-                        let local_block_root = db.get_block_smt_root()?;
-                        assert_eq!(local_block_root, global_block_root, "block root fork");
+                            db.insert_bad_block(&l2block, &l2block_committed_info, &global_state)?;
+                            log::info!("insert bad block 0x{}", hex::encode(l2block.hash()));
 
-                        assert!(self.challenge_target.is_none());
-                        db.set_bad_block_challenge_target(
-                            &l2block.hash().into(),
-                            &challenge_target,
-                        )?;
-                        self.challenge_target = Some(challenge_target.clone());
-                        self.local_state.tip = l2block;
+                            let global_block_root: H256 =
+                                global_state.block().merkle_root().unpack();
+                            let local_block_root = db.get_block_smt_root()?;
+                            assert_eq!(local_block_root, global_block_root, "block root fork");
 
-                        let context =
-                            gw_challenge::context::build_challenge_context(db, challenge_target)?;
-                        Ok(SyncEvent::BadBlock { context })
-                    } else {
-                        let block_number = l2block.raw().number().unpack();
-                        log::info!("sync new block #{} success", block_number);
+                            assert!(self.challenge_target.is_none());
+                            db.set_bad_block_challenge_target(
+                                &l2block.hash().into(),
+                                &challenge_target,
+                            )?;
+                            self.challenge_target = Some(challenge_target.clone());
+                            self.local_state.tip = l2block.to_owned();
 
-                        Ok(SyncEvent::Success)
+                            let context = gw_challenge::context::build_challenge_context(
+                                db,
+                                challenge_target,
+                            )?;
+                            Ok(SyncEvent::BadBlock { context })
+                        }
+                        None => {
+                            // process is successed
+                            self.local_state.tip = l2block.to_owned();
+                            // insert block committed info if update is from layer1
+                            if let UpdateAction::L1(L1Action {
+                                l2block_committed_info,
+                                ..
+                            }) = &update
+                            {
+                                db.insert_block_committed_info(
+                                    &l2block.hash().into(),
+                                    l2block_committed_info.to_owned(),
+                                )?;
+                            }
+                            let block_number = l2block.raw().number().unpack();
+                            log::info!("sync new block #{} success", block_number);
+
+                            Ok(SyncEvent::Success)
+                        }
                     }
                 }
                 (
@@ -434,7 +553,10 @@ impl Chain {
                             generator, db, &target,
                         )?);
 
-                        return Ok(SyncEvent::BadChallenge { cell, context });
+                        return Ok(SyncEvent::BadChallenge {
+                            cell: cell.to_owned(),
+                            context,
+                        });
                     }
 
                     if self.challenge_target.is_none()
@@ -454,7 +576,10 @@ impl Chain {
                     db.rollback()?;
                     log::info!("rollback db after prepare context for revert");
 
-                    Ok(SyncEvent::WaitChallenge { cell, context })
+                    Ok(SyncEvent::WaitChallenge {
+                        cell: cell.to_owned(),
+                        context,
+                    })
                 }
                 (Status::Halting, L1ActionContext::CancelChallenge) => {
                     let status: u8 = global_state.status().into();
@@ -464,17 +589,11 @@ impl Chain {
                     match self.challenge_target {
                         // Previous challenge miss right target, we should challenge it
                         Some(ref target) => {
-                            // let context = gw_challenge::context::build_challenge_context(
-                            //     db,
-                            //     target.to_owned(),
-                            // )?;
-                            panic!(
-                                "found bad block after challenge cancelled: {}, index: {}, type: {:?}",
-                                target.block_hash(),
-                                target.target_index(),
-                                target.target_type()
-                            );
-                            // Ok(SyncEvent::BadBlock { context })
+                            let context = gw_challenge::context::build_challenge_context(
+                                db,
+                                target.to_owned(),
+                            )?;
+                            Ok(SyncEvent::BadBlock { context })
                         }
                         None => Ok(SyncEvent::Success),
                     }
@@ -571,17 +690,11 @@ impl Chain {
                     // If our bad block isn't reverted, just challenge it
                     match self.challenge_target {
                         Some(ref target) => {
-                            // let context = gw_challenge::context::build_challenge_context(
-                            //     db,
-                            //     target.to_owned(),
-                            // )?;
-                            panic!(
-                                "found bad block: {}, index: {}, type: {:?}",
-                                target.block_hash(),
-                                target.target_index(),
-                                target.target_type()
-                            );
-                            // Ok(SyncEvent::BadBlock { context })
+                            let context = gw_challenge::context::build_challenge_context(
+                                db,
+                                target.to_owned(),
+                            )?;
+                            Ok(SyncEvent::BadBlock { context })
                         }
                         None => Ok(SyncEvent::Success),
                     }
@@ -595,31 +708,49 @@ impl Chain {
             }
         };
 
-        self.last_sync_event = update()?;
-        self.local_state.last_global_state = global_state;
-        self.local_state.last_synced = l2block_committed_info;
+        self.last_sync_event = apply_update()?;
+        match update {
+            UpdateAction::L1(L1Action {
+                l2block_committed_info,
+                ..
+            }) => {
+                self.local_state.last_global_state = global_state;
+                self.local_state.last_synced = l2block_committed_info;
+            }
+            UpdateAction::Local(..) => {
+                // ignores
+            }
+        }
         log::debug!("last sync event {:?}", self.last_sync_event);
 
         Ok(())
     }
 
     /// revert a layer1 action
-    fn revert_l1action(&mut self, db: &StoreTransaction, action: RevertedL1Action) -> Result<()> {
-        let RevertedL1Action {
-            prev_global_state,
-            l2block_committed_info,
-            context,
-        } = action;
-        assert!(
-            {
-                let number: u64 = l2block_committed_info.number().unpack();
-                number
-            } <= {
-                let number: u64 = self.local_state.last_synced.number().unpack();
-                number
-            },
-            "must be smaller than or equalled to last synced number"
-        );
+    fn revert_action(&mut self, db: &StoreTransaction, action: RevertedAction) -> Result<()> {
+        let (prev_global_state, context) = match action {
+            RevertedAction::L1(RevertedL1Action {
+                prev_global_state,
+                l2block_committed_info,
+                context,
+            }) => {
+                assert!(
+                    {
+                        let number: u64 = l2block_committed_info.number().unpack();
+                        number
+                    } <= {
+                        let number: u64 = self.local_state.last_synced.number().unpack();
+                        number
+                    },
+                    "must be smaller than or equalled to last synced number"
+                );
+                (prev_global_state, context)
+            }
+            RevertedAction::Local(RevertedLocalAction {
+                prev_global_state,
+                context,
+            }) => (prev_global_state, context),
+        };
 
         let revert = || -> Result<()> {
             match context {
@@ -805,24 +936,88 @@ impl Chain {
         Ok(())
     }
 
+    fn update(&mut self, db: &StoreTransaction, update: UpdateAction) -> Result<()> {
+        match &update {
+            UpdateAction::L1(L1Action {
+                l2block_committed_info,
+                context,
+                ..
+            }) => {
+                // layer1 committed block
+                if let Some(LocalPendingBlock {
+                    block,
+                    prev_global_state,
+                }) = self.local_pending_block.clone()
+                {
+                    // check fast path
+                    if let L1ActionContext::SubmitBlock { l2block, .. } = context {
+                        let pending_block_hash = block.hash();
+                        if l2block.hash() == pending_block_hash {
+                            db.insert_block_committed_info(
+                                &pending_block_hash.into(),
+                                l2block_committed_info.to_owned(),
+                            )?;
+                        }
+                        // clear pending block
+                        self.local_pending_block = None;
+                        return Ok(());
+                    }
+                    // failed fast path, revert pending block
+                    self.revert_action(
+                        db,
+                        RevertedAction::Local(RevertedLocalAction {
+                            prev_global_state: prev_global_state.to_owned(),
+                            context: RevertL1ActionContext::SubmitValidBlock {
+                                l2block: block.to_owned(),
+                            },
+                        }),
+                    )?;
+                    // then apply new l1 block
+                    self.apply_action(db, update)?;
+                } else {
+                    // update
+                    self.apply_action(db, update)?;
+                }
+                // clear
+                self.local_pending_block = None;
+            }
+            UpdateAction::Local(action) => {
+                // fast path - block from local block-producer
+                if self.local_pending_block.is_some() {
+                    return Err(anyhow!(
+                        "Already has a local pending block, waiting for it committed"
+                    ));
+                }
+                let block = match &action.context {
+                    L1ActionContext::SubmitBlock { l2block, .. } => l2block.to_owned(),
+                    _ => {
+                        panic!("local action shouldn't be other than submit block")
+                    }
+                };
+                // layer1 update
+                self.apply_action(db, update)?;
+                self.local_pending_block = Some(LocalPendingBlock {
+                    block,
+                    prev_global_state: self.local_state().last_global_state().to_owned(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Sync chain from layer1
     pub fn sync(&mut self, param: SyncParam) -> Result<()> {
         let db = self.store.begin_transaction();
-        let is_revert_happend = !param.reverts.is_empty();
-        // revert layer1 actions
-        if !param.reverts.is_empty() {
-            // revert
-            for reverted_action in param.reverts {
-                self.revert_l1action(&db, reverted_action)?;
+        let mut is_revert_happend = false;
+        match param {
+            SyncParam::Update(action) => {
+                // update layer1 actions
+                self.update(&db, action)?;
             }
-        }
-
-        // update layer1 actions
-        for action in param.updates {
-            self.update_l1action(&db, action)?;
-            match self.last_sync_event() {
-                SyncEvent::Success => (),
-                _ => db.commit()?,
+            SyncParam::Revert(reverted_action) => {
+                // revert layer1 actions
+                self.revert_action(&db, reverted_action)?;
+                is_revert_happend = true;
             }
         }
 
@@ -866,7 +1061,6 @@ impl Chain {
         &mut self,
         db: &StoreTransaction,
         l2block: L2Block,
-        l2block_committed_info: L2BlockCommittedInfo,
         global_state: GlobalState,
         deposit_requests: Vec<DepositRequest>,
         deposit_asset_scripts: HashSet<Script>,
@@ -932,7 +1126,6 @@ impl Chain {
         // update chain
         db.insert_block(
             l2block.clone(),
-            l2block_committed_info,
             global_state,
             withdrawal_receipts,
             prev_txs_state,
@@ -953,7 +1146,6 @@ impl Chain {
                 "post account merkle root must be consistent"
             );
         }
-        self.local_state.tip = l2block;
         Ok(None)
     }
 }

--- a/crates/generator/src/genesis.rs
+++ b/crates/generator/src/genesis.rs
@@ -208,13 +208,13 @@ pub fn init_genesis(
     let prev_txs_state = genesis.as_reader().raw().post_account().to_entity();
     db.insert_block(
         genesis.clone(),
-        genesis_committed_info,
         global_state,
         Vec::new(),
         prev_txs_state,
         Vec::new(),
         Vec::new(),
     )?;
+    db.insert_block_committed_info(&genesis.hash().into(), genesis_committed_info)?;
     db.attach_block(genesis)?;
     db.commit()?;
     Ok(())

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -413,9 +413,10 @@ impl MemPool {
     /// this method update current state of mem pool
     pub fn notify_new_tip(&mut self, new_tip: H256) -> Result<()> {
         // reset pool state
+        log::info!("[mem-pool] handling notify_new_tip");
         let t = Instant::now();
         self.reset(Some(self.current_tip().0), Some(new_tip))?;
-        log::info!("[mem-pool] notify_now_tip ({}ms)", t.elapsed().as_millis());
+        log::info!("[mem-pool] notify_new_tip ({}ms)", t.elapsed().as_millis());
         Ok(())
     }
 


### PR DESCRIPTION
Submit local produced block to chain instantly, this behavior should reduce the number of re-run txs in mem-pool.