### PR TITLE
Fix fast path sync

### DIFF
--- a/crates/challenge/src/offchain/mock_poa.rs
+++ b/crates/challenge/src/offchain/mock_poa.rs
@@ -45,7 +45,7 @@ impl MockPoA {
     }
 
     fn ensure_unlockable(mut context: PoAContext, poa: &PoA, median_time: Duration) -> PoAContext {
-        let next_round_start_time = poa.estimate_next_round_start_time(context.clone());
+        let next_round_start_time = poa.estimate_next_round_start_time(context.clone(), None);
         // Already unlocked
         if median_time >= next_round_start_time {
             return context;

--- a/crates/mem-pool/src/default_provider.rs
+++ b/crates/mem-pool/src/default_provider.rs
@@ -35,7 +35,7 @@ impl DefaultMemPoolProvider {
 }
 
 impl MemPoolProvider for DefaultMemPoolProvider {
-    fn estimate_next_blocktime(&self) -> Task<Result<Duration>> {
+    fn estimate_next_blocktime(&self, last_blocktime: Option<Duration>) -> Task<Result<Duration>> {
         // estimate next l2block timestamp
         let poa = Arc::clone(&self.poa);
         let rpc_client = self.rpc_client.clone();
@@ -53,7 +53,7 @@ impl MemPoolProvider for DefaultMemPoolProvider {
             };
             let ctx = poa.query_poa_context(&input_cell).await?;
             // TODO how to estimate a more accurate timestamp?
-            let timestamp = poa.estimate_next_round_start_time(ctx);
+            let timestamp = poa.estimate_next_round_start_time(ctx, last_blocktime);
             Ok(timestamp)
         })
     }

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -412,6 +412,10 @@ impl MemPool {
     /// Notify new tip
     /// this method update current state of mem pool
     pub fn notify_new_tip(&mut self, new_tip: H256) -> Result<()> {
+        if self.current_tip().0 == new_tip {
+            log::debug!("[mem-pool] fast return from notify_new_tip");
+            return Ok(());
+        }
         // reset pool state
         log::info!("[mem-pool] handling notify_new_tip");
         let t = Instant::now();

--- a/crates/mem-pool/src/traits.rs
+++ b/crates/mem-pool/src/traits.rs
@@ -8,7 +8,7 @@ use gw_types::{
 use smol::Task;
 
 pub trait MemPoolProvider {
-    fn estimate_next_blocktime(&self) -> Task<Result<Duration>>;
+    fn estimate_next_blocktime(&self, last_blocktime: Option<Duration>) -> Task<Result<Duration>>;
     fn collect_deposit_cells(&self) -> Task<Result<Vec<DepositInfo>>>;
     fn query_available_custodians(
         &self,

--- a/crates/tests/src/testing_tool/mem_pool_provider.rs
+++ b/crates/tests/src/testing_tool/mem_pool_provider.rs
@@ -16,7 +16,7 @@ pub struct DummyMemPoolProvider {
 }
 
 impl MemPoolProvider for DummyMemPoolProvider {
-    fn estimate_next_blocktime(&self) -> Task<Result<Duration>> {
+    fn estimate_next_blocktime(&self, _: Option<Duration>) -> Task<Result<Duration>> {
         let fake_blocktime = self.fake_blocktime;
         smol::spawn(async move { Ok(fake_blocktime) })
     }

--- a/crates/tests/src/tests/chain.rs
+++ b/crates/tests/src/tests/chain.rs
@@ -117,7 +117,6 @@ fn test_produce_blocks() {
     // check state
     {
         let db = chain.store().begin_transaction();
-        let tip_block_hash = db.get_tip_block_hash().unwrap();
         let tree = db.state_tree(StateContext::ReadOnly).unwrap();
         let script_hash_a: H256 = user_script_a.hash().into();
         let script_hash_b: H256 = user_script_b.hash().into();

--- a/crates/tests/src/tests/deposit_withdrawal.rs
+++ b/crates/tests/src/tests/deposit_withdrawal.rs
@@ -191,7 +191,6 @@ fn test_deposit_and_withdrawal() {
     )
     .unwrap();
     // check status
-    let tip_block_hash = chain.store().get_tip_block_hash().unwrap();
     let db = chain.store().begin_transaction();
     let tree = db.state_tree(StateContext::ReadOnly).unwrap();
     let ckb_balance2 = tree
@@ -202,8 +201,6 @@ fn test_deposit_and_withdrawal() {
     assert_eq!(nonce, 1);
     // check tx pool state
     {
-        let mem_pool = chain.mem_pool().as_ref().unwrap();
-        let mem_pool = smol::block_on(mem_pool.lock());
         let state = db.mem_pool_state_tree().unwrap();
         assert_eq!(
             state
@@ -270,8 +267,6 @@ fn test_overdraft() {
     // check tx pool state
     {
         let db = chain.store().begin_transaction();
-        let mem_pool = chain.mem_pool().as_ref().unwrap();
-        let mem_pool = smol::block_on(mem_pool.lock());
         let state = db.mem_pool_state_tree().unwrap();
         assert_eq!(
             state


### PR DESCRIPTION
1. prevent produce new block if current tip is a pending block(not committed to a layer1 block yet).
2. skip duplicated mem-pool reset.
3. fix block timestamp introduced by 2