### PR TITLE
feat(RPC): check if the fee or gasPrice is enough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,6 +2124,7 @@ name = "gw-config"
 version = "0.1.0"
 dependencies = [
  "ckb-fixed-hash 0.100.0",
+ "gw-common",
  "gw-jsonrpc-types",
  "serde",
 ]
@@ -2282,6 +2283,7 @@ dependencies = [
  "gw-store",
  "gw-traits",
  "gw-types",
+ "gw-utils",
  "gw-version",
  "hyper",
  "jsonrpc-v2",
@@ -2428,9 +2430,11 @@ dependencies = [
  "faster-hex 0.4.1",
  "gw-common",
  "gw-config",
+ "gw-generator",
  "gw-poa",
  "gw-rpc-client",
  "gw-types",
+ "log",
 ]
 
 [[package]]

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -127,13 +127,13 @@ impl BenchExecutionEnvironment {
         let backend_manage = {
             let configs = vec![
                 BackendConfig {
-                    backend_type: "meta".to_string(),
+                    backend_type: BackendType::Meta,
                     validator_path: META_VALIDATOR_PATH.into(),
                     generator_path: META_GENERATOR_PATH.into(),
                     validator_script_type_hash: META_VALIDATOR_SCRIPT_TYPE_HASH.into(),
                 },
                 BackendConfig {
-                    backend_type: "sudt".to_string(),
+                    backend_type: BackendType::Sudt,
                     validator_path: SUDT_VALIDATOR_PATH.into(),
                     generator_path: SUDT_GENERATOR_PATH.into(),
                     validator_script_type_hash: SUDT_VALIDATOR_SCRIPT_TYPE_HASH.into(),

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -127,11 +127,13 @@ impl BenchExecutionEnvironment {
         let backend_manage = {
             let configs = vec![
                 BackendConfig {
+                    backend_type: "meta".to_string(),
                     validator_path: META_VALIDATOR_PATH.into(),
                     generator_path: META_GENERATOR_PATH.into(),
                     validator_script_type_hash: META_VALIDATOR_SCRIPT_TYPE_HASH.into(),
                 },
                 BackendConfig {
+                    backend_type: "sudt".to_string(),
                     validator_path: SUDT_VALIDATOR_PATH.into(),
                     generator_path: SUDT_GENERATOR_PATH.into(),
                     validator_script_type_hash: SUDT_VALIDATOR_SCRIPT_TYPE_HASH.into(),

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -34,13 +34,13 @@ fn build_backend_manage(rollup_config: &RollupConfig) -> BackendManage {
         rollup_config.l2_sudt_validator_script_type_hash().unpack();
     let configs = vec![
         BackendConfig {
-            backend_type: "meta".to_string(),
+            backend_type: BackendType::Meta,
             validator_path: META_VALIDATOR_PATH.into(),
             generator_path: META_GENERATOR_PATH.into(),
             validator_script_type_hash: META_VALIDATOR_SCRIPT_TYPE_HASH.into(),
         },
         BackendConfig {
-            backend_type: "sudt".to_string(),
+            backend_type: BackendType::Sudt,
             validator_path: SUDT_VALIDATOR_PATH.into(),
             generator_path: SUDT_GENERATOR_PATH.into(),
             validator_script_type_hash: sudt_validator_script_type_hash.into(),

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -34,11 +34,13 @@ fn build_backend_manage(rollup_config: &RollupConfig) -> BackendManage {
         rollup_config.l2_sudt_validator_script_type_hash().unpack();
     let configs = vec![
         BackendConfig {
+            backend_type: "meta".to_string(),
             validator_path: META_VALIDATOR_PATH.into(),
             generator_path: META_GENERATOR_PATH.into(),
             validator_script_type_hash: META_VALIDATOR_SCRIPT_TYPE_HASH.into(),
         },
         BackendConfig {
+            backend_type: "sudt".to_string(),
             validator_path: SUDT_VALIDATOR_PATH.into(),
             generator_path: SUDT_GENERATOR_PATH.into(),
             validator_script_type_hash: sudt_validator_script_type_hash.into(),

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -17,6 +17,8 @@ cfg_if::cfg_if! {
             Store,
             #[error("Invalid short address error")]
             InvalidShortAddress,
+            #[error("The sudt is not supported to used as fee")]
+            UnsupportedFeeSudt,
         }
     } else {
         #[derive(Debug, Eq, PartialEq, Clone)]
@@ -27,6 +29,7 @@ cfg_if::cfg_if! {
             MissingKey,
             Store,
             InvalidShortAddress,
+            UnsupportedFeeSudt,
         }
     }
 }

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
             Store,
             #[error("Invalid short address error")]
             InvalidShortAddress,
-            #[error("The sudt is not supported to used as fee")]
+            #[error("Do not support pay fee with the current Simple UDT")]
             UnsupportedFeeSudt,
         }
     } else {

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+gw-common = { path = "../common" }
 gw-jsonrpc-types = { path = "../jsonrpc-types" }
 ckb-fixed-hash = "0.100.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -201,12 +201,17 @@ pub struct FeeConfig {
     sudt_transfer_fee_weight: u8,
     withdraw_fee_weight: u8,
 }
-const DEFAULT_CKB_FEE_RATE: u64 = 500;
 impl FeeConfig {
     pub fn is_supported_sudt(&self, sudt_id: u32) -> bool {
+        if self.fee_rates.is_empty() {
+            return true;
+        }
         self.fee_rates.contains_key(&sudt_id)
     }
     pub fn get_fee_rate(&self, sudt_id: u32) -> Result<u128, Error> {
+        if self.fee_rates.is_empty() {
+            return Ok(0);
+        }
         let fee_rate = self
             .fee_rates
             .get(&sudt_id)
@@ -235,14 +240,10 @@ impl FeeConfig {
 }
 impl Default for FeeConfig {
     fn default() -> Self {
-        let mut fee_rates = HashMap::new();
-        // CKB_SUDT_ID -> 500 shannons
-        fee_rates.insert(
-            gw_common::builtins::CKB_SUDT_ACCOUNT_ID,
-            DEFAULT_CKB_FEE_RATE,
-        );
         Self {
-            fee_rates,
+            // suggested config is (CKB_SUDT_ID -> 500 shannons)
+            // const DEFAULT_CKB_FEE_RATE: u64 = 500;
+            fee_rates: Default::default(),
             meta_contract_fee_weight: 2,
             sudt_transfer_fee_weight: 2,
             withdraw_fee_weight: 2,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -202,7 +202,7 @@ impl Default for OffChainValidatorConfig {
 }
 
 /// Config the base/minimal fee rules
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct FeeConfig {
     meta_contract_fee_weight: u8,
     sudt_transfer_fee_weight: u8,
@@ -253,27 +253,6 @@ impl FeeConfig {
     /// Get the minimal gasPrice of Polyjuice contract
     pub fn polyjuice_base_gas_price(&self, sudt_id: u32) -> Result<u128, Error> {
         self.get_fee_rate(sudt_id)
-    }
-}
-impl Default for FeeConfig {
-    /// The suggested configs:
-    /// ```toml
-    /// [mem_pool.fee_config]
-    /// meta_contract_fee_weight = 2
-    /// sudt_transfer_fee_weight = 2
-    /// withdraw_fee_weight = 2
-    ///
-    /// [mem_pool.fee_config.fee_rates]
-    /// 0x1 = 500
-    /// ```
-    fn default() -> Self {
-        Self {
-            meta_contract_fee_weight: 2,
-            sudt_transfer_fee_weight: 2,
-            withdraw_fee_weight: 2,
-            /// The suggested default config is (CKB_SUDT_ID -> 500 shannons)
-            fee_rates: Default::default(),
-        }
     }
 }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -121,6 +121,7 @@ pub struct BlockProducerConfig {
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BackendConfig {
+    pub backend_type: String,
     pub validator_path: PathBuf,
     pub generator_path: PathBuf,
     pub validator_script_type_hash: H256,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -120,9 +120,24 @@ pub struct BlockProducerConfig {
     pub wallet_config: WalletConfig,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BackendType {
+    Meta,
+    Sudt,
+    Polyjuice,
+    Unknown,
+}
+
+impl Default for BackendType {
+    fn default() -> Self {
+        BackendType::Unknown
+    }
+}
+
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BackendConfig {
-    pub backend_type: String,
+    pub backend_type: BackendType,
     pub validator_path: PathBuf,
     pub generator_path: PathBuf,
     pub validator_script_type_hash: H256,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -236,22 +236,22 @@ impl FeeConfig {
         Ok(fee_rate.to_owned().into())
     }
     /// Get the minimal fee of meta contract
-    pub fn meta_contract_base_fee(&self, sudt_id: u32) -> Result<u128, Error> {
+    pub fn meta_contract_minimum_fee(&self, sudt_id: u32) -> Result<u128, Error> {
         let fee_rate = self.get_fee_rate(sudt_id)?;
         Ok(fee_rate * u128::from(self.meta_contract_fee_weight))
     }
     /// Get the minimal fee of a native sudt transfer transaction
-    pub fn sudt_transfer_base_fee(&self, sudt_id: u32) -> Result<u128, Error> {
+    pub fn sudt_transfer_minimum_fee(&self, sudt_id: u32) -> Result<u128, Error> {
         let fee_rate = self.get_fee_rate(sudt_id)?;
         Ok(fee_rate * u128::from(self.sudt_transfer_fee_weight))
     }
     /// Get the minimal fee of a withdrawal request
-    pub fn withdrawal_base_fee(&self, sudt_id: u32) -> Result<u128, Error> {
+    pub fn withdrawal_minimum_fee(&self, sudt_id: u32) -> Result<u128, Error> {
         let fee_rate = self.get_fee_rate(sudt_id)?;
         Ok(fee_rate * u128::from(self.withdraw_fee_weight))
     }
     /// Get the minimal gasPrice of Polyjuice contract
-    pub fn polyjuice_base_gas_price(&self, sudt_id: u32) -> Result<u128, Error> {
+    pub fn polyjuice_minimum_gas_price(&self, sudt_id: u32) -> Result<u128, Error> {
         self.get_fee_rate(sudt_id)
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -184,6 +184,45 @@ impl Default for OffChainValidatorConfig {
     }
 }
 
+/// Fee rules:
+///   TODO
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FeeConfig {
+    /// known as gasPrice in Ethereum
+    fee_rate: u128,
+    meta_contract_fee_weight: u8,
+    sudt_transfer_fee_weight: u8,
+    withdraw_fee_weight: u8,
+}
+impl FeeConfig {
+    /// Get the base fee of meta contract
+    pub fn meta_contract_base_fee(&self) -> u128 {
+        self.fee_rate * u128::from(self.meta_contract_fee_weight)
+    }
+    /// Get the base fee of meta contract
+    pub fn sudt_transfer_base_fee(&self) -> u128 {
+        self.fee_rate * u128::from(self.sudt_transfer_fee_weight)
+    }
+    /// Get the base fee of a withdrawal request
+    pub fn withdrawal_base_fee(&self) -> u128 {
+        self.fee_rate * u128::from(self.withdraw_fee_weight)
+    }
+    /// Get the base gasPrice of Polyjuice contract
+    pub fn polyjuice_base_gas_price(&self) -> u128 {
+        self.fee_rate
+    }
+}
+impl Default for FeeConfig {
+    fn default() -> Self {
+        Self {
+            fee_rate: 1,
+            meta_contract_fee_weight: 1,
+            sudt_transfer_fee_weight: 1,
+            withdraw_fee_weight: 1,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MemPoolConfig {
     pub execute_l2tx_max_cycles: u64,
@@ -192,6 +231,8 @@ pub struct MemPoolConfig {
     pub max_batch_tx_withdrawal_size: usize,
     #[serde(default = "default_restore_path")]
     pub restore_path: PathBuf,
+    #[serde(default)]
+    pub fee_config: FeeConfig,
 }
 
 // Field default value for backward config file compitability
@@ -209,6 +250,7 @@ impl Default for MemPoolConfig {
             max_batch_channel_buffer_size: 2000,
             max_batch_tx_withdrawal_size: 200,
             restore_path: default_restore_path(),
+            fee_config: Default::default(),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -184,41 +184,43 @@ impl Default for OffChainValidatorConfig {
     }
 }
 
-/// Fee rules:
-///   TODO
+/// Config the base/minimal fee rules
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FeeConfig {
     /// known as gasPrice in Ethereum
-    fee_rate: u128,
+    ///
+    ///   denoted in shannons, which itself is a fractional denomination of CKBytes.
+    ///   1 CKByte = 100,000,000 Shannons
+    fee_rate: u64,
     meta_contract_fee_weight: u8,
     sudt_transfer_fee_weight: u8,
     withdraw_fee_weight: u8,
 }
 impl FeeConfig {
-    /// Get the base fee of meta contract
+    /// Get the minimal fee of meta contract
     pub fn meta_contract_base_fee(&self) -> u128 {
-        self.fee_rate * u128::from(self.meta_contract_fee_weight)
+        self.fee_rate as u128 * u128::from(self.meta_contract_fee_weight)
     }
-    /// Get the base fee of meta contract
+    /// Get the minimal fee of a native sudt transfer transaction
     pub fn sudt_transfer_base_fee(&self) -> u128 {
-        self.fee_rate * u128::from(self.sudt_transfer_fee_weight)
+        self.fee_rate as u128 * u128::from(self.sudt_transfer_fee_weight)
     }
-    /// Get the base fee of a withdrawal request
+    /// Get the minimal fee of a withdrawal request
     pub fn withdrawal_base_fee(&self) -> u128 {
-        self.fee_rate * u128::from(self.withdraw_fee_weight)
+        self.fee_rate as u128 * u128::from(self.withdraw_fee_weight)
     }
-    /// Get the base gasPrice of Polyjuice contract
+    /// Get the minimal gasPrice of Polyjuice contract
     pub fn polyjuice_base_gas_price(&self) -> u128 {
-        self.fee_rate
+        self.fee_rate as u128
     }
 }
 impl Default for FeeConfig {
     fn default() -> Self {
         Self {
-            fee_rate: 1,
-            meta_contract_fee_weight: 1,
-            sudt_transfer_fee_weight: 1,
-            withdraw_fee_weight: 1,
+            fee_rate: 500, // Shannons
+            meta_contract_fee_weight: 2,
+            sudt_transfer_fee_weight: 2,
+            withdraw_fee_weight: 2,
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -187,6 +187,7 @@ impl Default for OffChainValidatorConfig {
 /// Config the base/minimal fee rules
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FeeConfig {
+    supported_fee_sudt_ids: Vec<u32>,
     /// known as gasPrice in Ethereum
     ///
     ///   denoted in shannons, which itself is a fractional denomination of CKBytes.
@@ -197,6 +198,9 @@ pub struct FeeConfig {
     withdraw_fee_weight: u8,
 }
 impl FeeConfig {
+    pub fn is_supported_sudt(&self, sudt_id: u32) -> bool {
+        self.supported_fee_sudt_ids.contains(&sudt_id)
+    }
     /// Get the minimal fee of meta contract
     pub fn meta_contract_base_fee(&self) -> u128 {
         self.fee_rate as u128 * u128::from(self.meta_contract_fee_weight)
@@ -217,6 +221,7 @@ impl FeeConfig {
 impl Default for FeeConfig {
     fn default() -> Self {
         Self {
+            supported_fee_sudt_ids: vec![gw_common::builtins::CKB_SUDT_ACCOUNT_ID],
             fee_rate: 500, // Shannons
             meta_contract_fee_weight: 2,
             sudt_transfer_fee_weight: 2,

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, fs};
 
 #[derive(Clone)]
 pub struct Backend {
+    pub name: String,
     pub validator: Bytes,
     pub generator: Bytes,
     pub validator_script_type_hash: H256,
@@ -14,6 +15,19 @@ pub struct Backend {
 #[derive(Clone)]
 pub struct BackendManage {
     backends: HashMap<H256, Backend>,
+}
+
+/// Get backend name from the validator path
+fn get_backend_name(validator_path: &str) -> String {
+    if validator_path.contains("meta") {
+        String::from("meta")
+    } else if validator_path.contains("sudt") {
+        String::from("sudt")
+    } else if validator_path.contains("polyjuice") {
+        String::from("polyjuice")
+    } else {
+        String::new()
+    }
 }
 
 impl BackendManage {
@@ -35,6 +49,7 @@ impl BackendManage {
             generator_path,
             validator_script_type_hash,
         } = config;
+        let name = get_backend_name(validator_path.to_str().unwrap());
         let validator = fs::read(validator_path)?.into();
         let generator = fs::read(generator_path)?.into();
         let validator_script_type_hash = {
@@ -42,6 +57,7 @@ impl BackendManage {
             hash.into()
         };
         let backend = Backend {
+            name,
             validator,
             generator,
             validator_script_type_hash,

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use gw_common::H256;
 use gw_config::BackendConfig;
 use gw_types::bytes::Bytes;
@@ -9,6 +9,17 @@ pub enum BackendType {
     Meta,
     Sudt,
     Polyjuice,
+}
+
+impl From<&str> for BackendType {
+    fn from(backend_type_str: &str) -> Self {
+        match backend_type_str {
+            "meta" => Self::Meta,
+            "sudt" => Self::Sudt,
+            "polyjuice" => Self::Polyjuice,
+            _ => panic!("Unsupported Backend"),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -22,15 +33,6 @@ pub struct Backend {
 #[derive(Clone)]
 pub struct BackendManage {
     backends: HashMap<H256, Backend>,
-}
-
-fn get_backend_type(validator_path: &str) -> Result<BackendType> {
-    match validator_path {
-        "meta" => Ok(BackendType::Meta),
-        "sudt" => Ok(BackendType::Sudt),
-        "polyjuice" => Ok(BackendType::Polyjuice),
-        _ => Err(anyhow!("Unsupported Backend")),
-    }
 }
 
 impl BackendManage {
@@ -53,7 +55,6 @@ impl BackendManage {
             generator_path,
             validator_script_type_hash,
         } = config;
-        let backend_type = get_backend_type(&backend_type)?;
         let validator = fs::read(validator_path)?.into();
         let generator = fs::read(generator_path)?.into();
         let validator_script_type_hash = {
@@ -61,7 +62,7 @@ impl BackendManage {
             hash.into()
         };
         let backend = Backend {
-            backend_type,
+            backend_type: BackendType::from(backend_type.as_str()),
             validator,
             generator,
             validator_script_type_hash,

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -1,26 +1,8 @@
 use anyhow::Result;
 use gw_common::H256;
-use gw_config::BackendConfig;
+use gw_config::{BackendConfig, BackendType};
 use gw_types::bytes::Bytes;
 use std::{collections::HashMap, fs};
-
-#[derive(Debug, Clone, Copy)]
-pub enum BackendType {
-    Meta,
-    Sudt,
-    Polyjuice,
-}
-
-impl From<&str> for BackendType {
-    fn from(backend_type_str: &str) -> Self {
-        match backend_type_str {
-            "meta" => Self::Meta,
-            "sudt" => Self::Sudt,
-            "polyjuice" => Self::Polyjuice,
-            _ => panic!("Unsupported Backend"),
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct Backend {
@@ -62,7 +44,7 @@ impl BackendManage {
             hash.into()
         };
         let backend = Backend {
-            backend_type: BackendType::from(backend_type.as_str()),
+            backend_type,
             validator,
             generator,
             validator_script_type_hash,

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -4,9 +4,16 @@ use gw_config::BackendConfig;
 use gw_types::bytes::Bytes;
 use std::{collections::HashMap, fs};
 
+#[derive(Debug, Clone, Copy)]
+pub enum BackendName {
+    Meta,
+    Sudt,
+    Polyjuice,
+}
+
 #[derive(Clone)]
 pub struct Backend {
-    pub name: String,
+    pub name: Option<BackendName>,
     pub validator: Bytes,
     pub generator: Bytes,
     pub validator_script_type_hash: H256,
@@ -18,15 +25,15 @@ pub struct BackendManage {
 }
 
 /// Get backend name from the validator path
-fn get_backend_name(validator_path: &str) -> String {
+fn get_backend_name(validator_path: &str) -> Option<BackendName> {
     if validator_path.contains("meta") {
-        String::from("meta")
+        Some(BackendName::Meta)
     } else if validator_path.contains("sudt") {
-        String::from("sudt")
+        Some(BackendName::Sudt)
     } else if validator_path.contains("polyjuice") {
-        String::from("polyjuice")
+        Some(BackendName::Polyjuice)
     } else {
-        String::new()
+        None
     }
 }
 

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -28,7 +28,7 @@ use gw_common::{
     state::{build_account_field_key, to_short_address, State, GW_ACCOUNT_NONCE_TYPE},
     H256,
 };
-use gw_config::{BackendType, RPCConfig};
+use gw_config::RPCConfig;
 use gw_store::{state::state_db::StateContext, transaction::StoreTransaction};
 use gw_traits::{ChainStore, CodeStore};
 use gw_tx_filter::polyjuice_contract_creator_allowlist::PolyjuiceContractCreatorAllowList;
@@ -561,35 +561,11 @@ impl Generator {
         }
     }
 
-    /// Get backend type by script_hash
-    pub fn get_backend_type<S: State + CodeStore>(
+    pub fn load_backend<S: State + CodeStore>(
         &self,
         state: &S,
         script_hash: &H256,
-    ) -> Option<BackendType> {
-        log::debug!(
-            "get_backend_type for script_hash: {}",
-            hex::encode(script_hash.as_slice())
-        );
-        state.get_script(script_hash).and_then(|script| {
-            // only accept type script hash type for now
-            if script.hash_type() == ScriptHashType::Type.into() {
-                let code_hash: [u8; 32] = script.code_hash().unpack();
-                log::debug!("load_backend by code_hash: {}", hex::encode(code_hash));
-                self.backend_manage
-                    .get_backend(&code_hash.into())
-                    .map(|backend| backend.backend_type)
-            } else {
-                log::error!(
-                    "Found a invalid account script which hash_type is data: {:?}",
-                    script
-                );
-                None
-            }
-        })
-    }
-
-    fn load_backend<S: State + CodeStore>(&self, state: &S, script_hash: &H256) -> Option<Backend> {
+    ) -> Option<Backend> {
         log::debug!(
             "load_backend for script_hash: {}",
             hex::encode(script_hash.as_slice())

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     account_lock_manage::AccountLockManage,
-    backend_manage::{BackendManage, BackendName},
+    backend_manage::{BackendManage, BackendType},
     constants::{MAX_READ_DATA_BYTES_LIMIT, MAX_WRITE_DATA_BYTES_LIMIT},
     erc20_creator_allowlist::SUDTProxyAccountAllowlist,
     error::{BlockError, TransactionValidateError, WithdrawalError},
@@ -562,13 +562,13 @@ impl Generator {
     }
 
     /// Get backend name by script_hash
-    pub fn get_backend_name<S: State + CodeStore>(
+    pub fn get_backend_type<S: State + CodeStore>(
         &self,
         state: &S,
         script_hash: &H256,
-    ) -> Option<Option<BackendName>> {
+    ) -> Option<BackendType> {
         log::debug!(
-            "get_backend_name for script_hash: {}",
+            "get_backend_type for script_hash: {}",
             hex::encode(script_hash.as_slice())
         );
         state.get_script(script_hash).and_then(|script| {
@@ -578,7 +578,7 @@ impl Generator {
                 log::debug!("load_backend by code_hash: {}", hex::encode(code_hash));
                 self.backend_manage
                     .get_backend(&code_hash.into())
-                    .map(|backend| backend.name)
+                    .map(|backend| backend.backend_type)
             } else {
                 log::error!(
                     "Found a invalid account script which hash_type is data: {:?}",

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     account_lock_manage::AccountLockManage,
-    backend_manage::BackendManage,
+    backend_manage::{BackendManage, BackendName},
     constants::{MAX_READ_DATA_BYTES_LIMIT, MAX_WRITE_DATA_BYTES_LIMIT},
     erc20_creator_allowlist::SUDTProxyAccountAllowlist,
     error::{BlockError, TransactionValidateError, WithdrawalError},
@@ -566,7 +566,7 @@ impl Generator {
         &self,
         state: &S,
         script_hash: &H256,
-    ) -> Option<String> {
+    ) -> Option<Option<BackendName>> {
         log::debug!(
             "get_backend_name for script_hash: {}",
             hex::encode(script_hash.as_slice())
@@ -578,7 +578,7 @@ impl Generator {
                 log::debug!("load_backend by code_hash: {}", hex::encode(code_hash));
                 self.backend_manage
                     .get_backend(&code_hash.into())
-                    .map(|backend| backend.name.clone())
+                    .map(|backend| backend.name)
             } else {
                 log::error!(
                     "Found a invalid account script which hash_type is data: {:?}",

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -561,7 +561,7 @@ impl Generator {
         }
     }
 
-    /// Get backend name by script_hash
+    /// Get backend type by script_hash
     pub fn get_backend_type<S: State + CodeStore>(
         &self,
         state: &S,

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     account_lock_manage::AccountLockManage,
-    backend_manage::{BackendManage, BackendType},
+    backend_manage::BackendManage,
     constants::{MAX_READ_DATA_BYTES_LIMIT, MAX_WRITE_DATA_BYTES_LIMIT},
     erc20_creator_allowlist::SUDTProxyAccountAllowlist,
     error::{BlockError, TransactionValidateError, WithdrawalError},
@@ -28,7 +28,7 @@ use gw_common::{
     state::{build_account_field_key, to_short_address, State, GW_ACCOUNT_NONCE_TYPE},
     H256,
 };
-use gw_config::RPCConfig;
+use gw_config::{BackendType, RPCConfig};
 use gw_store::{state::state_db::StateContext, transaction::StoreTransaction};
 use gw_traits::{ChainStore, CodeStore};
 use gw_tx_filter::polyjuice_contract_creator_allowlist::PolyjuiceContractCreatorAllowList;

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -864,6 +864,15 @@ impl From<packed::Fee> for Fee {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct FeeConfig {
+    pub fee_rates: std::collections::HashMap<Uint32, Uint64>,
+    pub meta_contract_fee_weight: Uint32,
+    pub sudt_transfer_fee_weight: Uint32,
+    pub withdraw_fee_weight: Uint32,
+}
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct L2BlockCommittedInfo {

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -1,7 +1,8 @@
 use crate::blockchain::Script;
 use anyhow::{anyhow, Error as JsonError};
 use ckb_fixed_hash::H256;
-use ckb_jsonrpc_types::{JsonBytes, Uint128, Uint32, Uint64};
+pub use ckb_jsonrpc_types::Uint32;
+use ckb_jsonrpc_types::{JsonBytes, Uint128, Uint64};
 use gw_types::{bytes::Bytes, offchain, packed, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 gw-challenge = { path = "../challenge" }
 gw-common = { path = "../common" }
+gw-utils = { path = "../utils" }
 gw-config = { path = "../config" }
 gw-chain = { path = "../chain" }
 gw-types = { path = "../types" }

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -4,7 +4,7 @@ use ckb_types::prelude::{Builder, Entity};
 use gw_chain::chain::Chain;
 use gw_challenge::offchain::OffChainMockContext;
 use gw_common::{blake2b::new_blake2b, state::State, H256};
-use gw_config::{DebugConfig, MemPoolConfig, NodeMode, RPCMethods, RPCServerConfig};
+use gw_config::{DebugConfig, FeeConfig, MemPoolConfig, NodeMode, RPCMethods, RPCServerConfig};
 use gw_generator::{error::TransactionError, sudt::build_l2_sudt_script, Generator};
 use gw_jsonrpc_types::{
     blockchain::Script,
@@ -180,7 +180,8 @@ impl Registry {
                 "gw_compute_l2_sudt_script_hash",
                 compute_l2_sudt_script_hash,
             )
-            .with_method("gw_get_node_info", get_node_info);
+            .with_method("gw_get_node_info", get_node_info)
+            .with_method("gw_get_fee_config", get_fee_config);
 
         if self.node_mode != NodeMode::ReadOnly {
             server = server
@@ -944,6 +945,10 @@ async fn get_node_info(backend_info: Data<Vec<BackendInfo>>) -> Result<NodeInfo>
         version: Version::current().to_string(),
         backends: backend_info.clone(),
     })
+}
+
+async fn get_fee_config(mem_pool_config: Data<MemPoolConfig>) -> Result<FeeConfig> {
+    Ok(mem_pool_config.fee_config.clone())
 }
 
 async fn tests_produce_block(

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -584,7 +584,7 @@ fn get_backend_type(
         .ok_or(RpcError::Full {
             code: INVALID_PARAM_ERR_CODE,
             message: TransactionError::BackendNotFound { script_hash }.to_string(),
-            data: Some(Box::new("Please check to_id")),
+            data: Some(Box::new("Can't find backend for receiver account")),
         })?;
     Ok(backend_type)
 }
@@ -681,7 +681,7 @@ async fn submit_withdrawal_request(
         .withdrawal_minimum_fee(fee_sudt_id)?;
     if fee < withdrawal_minimum_fee {
         let err_msg = format!(
-            "The fee is too low for acceptance, should more than withdrawal_minimum_fee({}).",
+            "Fee isn't enough, required fee for withdrawal: {}.",
             withdrawal_minimum_fee
         );
         log::warn!("[check withdrawal_request fee] {}", err_msg);

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -726,6 +726,7 @@ async fn submit_withdrawal_request(
     };
     let withdrawal_bytes = withdrawal_request.into_bytes();
     let withdrawal = packed::WithdrawalRequest::from_slice(&withdrawal_bytes)?;
+    log::debug!("{}", withdrawal);
 
     // Check Fee
     let fee = withdrawal.raw().fee().amount().unpack();

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -673,8 +673,11 @@ async fn submit_withdrawal_request(
     let withdrawal = packed::WithdrawalRequest::from_slice(&withdrawal_bytes)?;
 
     // Check Fee
+    let fee_sudt_id = withdrawal.raw().fee().sudt_id().unpack();
     let fee = withdrawal.raw().fee().amount().unpack();
-    let withdrawal_base_fee = mem_pool_config.fee_config.withdrawal_base_fee();
+    let withdrawal_base_fee = mem_pool_config
+        .fee_config
+        .withdrawal_base_fee(fee_sudt_id)?;
     if fee < withdrawal_base_fee {
         log::warn!(
             "The fee is too low for acceptance, should more than withdrawal_base_fee({} shannons).",

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -4,7 +4,7 @@ use ckb_types::prelude::{Builder, Entity};
 use gw_chain::chain::Chain;
 use gw_challenge::offchain::OffChainMockContext;
 use gw_common::{blake2b::new_blake2b, state::State, H256};
-use gw_config::{DebugConfig, MemPoolConfig, NodeMode, RPCMethods, RPCServerConfig};
+use gw_config::{BackendType, DebugConfig, MemPoolConfig, NodeMode, RPCMethods, RPCServerConfig};
 use gw_generator::{error::TransactionError, sudt::build_l2_sudt_script, Generator};
 use gw_jsonrpc_types::{
     blockchain::Script,
@@ -575,7 +575,7 @@ fn get_backend_type(
     state: gw_store::state::mem_pool_state_db::MemPoolStateTree,
     generator: Data<Generator>,
     raw_l2tx: &packed::RawL2Transaction,
-) -> Result<gw_generator::backend_manage::BackendType, RpcError> {
+) -> Result<BackendType, RpcError> {
     let to_id = raw_l2tx.to_id().unpack();
     let script_hash = state.get_script_hash(to_id)?;
     let backend_type = generator

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -579,7 +579,8 @@ fn get_backend_type(
     let to_id = raw_l2tx.to_id().unpack();
     let script_hash = state.get_script_hash(to_id)?;
     let backend_type = generator
-        .get_backend_type(&state, &script_hash)
+        .load_backend(&state, &script_hash)
+        .map(|backend| backend.backend_type)
         .ok_or(RpcError::Full {
             code: INVALID_PARAM_ERR_CODE,
             message: TransactionError::BackendNotFound { script_hash }.to_string(),

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -672,7 +672,6 @@ async fn submit_withdrawal_request(
     };
     let withdrawal_bytes = withdrawal_request.into_bytes();
     let withdrawal = packed::WithdrawalRequest::from_slice(&withdrawal_bytes)?;
-    log::debug!("{}", withdrawal);
 
     // Check Fee
     let fee = withdrawal.raw().fee().amount().unpack();

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -4,15 +4,16 @@ use ckb_types::prelude::{Builder, Entity};
 use gw_chain::chain::Chain;
 use gw_challenge::offchain::OffChainMockContext;
 use gw_common::{blake2b::new_blake2b, state::State, H256};
-use gw_config::{DebugConfig, FeeConfig, MemPoolConfig, NodeMode, RPCMethods, RPCServerConfig};
+use gw_config::{DebugConfig, MemPoolConfig, NodeMode, RPCMethods, RPCServerConfig};
 use gw_generator::{error::TransactionError, sudt::build_l2_sudt_script, Generator};
 use gw_jsonrpc_types::{
     blockchain::Script,
     ckb_jsonrpc_types::{JsonBytes, Uint128, Uint32},
     debugger::{DumpChallengeTarget, ReprMockTransaction},
     godwoken::{
-        BackendInfo, ErrorTxReceipt, GlobalState, L2BlockStatus, L2BlockView, L2BlockWithStatus,
-        L2TransactionStatus, L2TransactionWithStatus, NodeInfo, RunResult, TxReceipt,
+        BackendInfo, ErrorTxReceipt, FeeConfig, GlobalState, L2BlockStatus, L2BlockView,
+        L2BlockWithStatus, L2TransactionStatus, L2TransactionWithStatus, NodeInfo, RunResult,
+        TxReceipt,
     },
     test_mode::{ShouldProduceBlock, TestModePayload},
 };
@@ -892,7 +893,7 @@ async fn get_node_info(backend_info: Data<Vec<BackendInfo>>) -> Result<NodeInfo>
 }
 
 async fn get_fee_config(mem_pool_config: Data<MemPoolConfig>) -> Result<FeeConfig> {
-    Ok(mem_pool_config.fee_config.clone())
+    Ok(FeeConfig::from(mem_pool_config.fee_config.clone()))
 }
 
 async fn tests_produce_block(

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -635,7 +635,7 @@ async fn submit_l2transaction(
     let backend_type = get_backend_type(tree, generator, &raw_l2tx)?;
     gw_utils::fee::check_l2tx_fee(&mem_pool_config.fee_config, &raw_l2tx, backend_type).map_err(
         |err| {
-            log::warn!("check_fee_ret err: {}", err);
+            log::debug!("check_fee_ret err: {}", err);
             RpcError::Full {
                 code: INVALID_PARAM_ERR_CODE,
                 message: err.to_string(),
@@ -684,7 +684,6 @@ async fn submit_withdrawal_request(
             "Fee isn't enough, required fee for withdrawal: {}.",
             withdrawal_minimum_fee
         );
-        log::warn!("[check withdrawal_request fee] {}", err_msg);
         return Err(RpcError::Full {
             code: INVALID_PARAM_ERR_CODE,
             message: err_msg,

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -71,11 +71,13 @@ pub fn build_backend_manage(rollup_config: &RollupConfig) -> BackendManage {
         rollup_config.l2_sudt_validator_script_type_hash().unpack();
     let configs = vec![
         BackendConfig {
+            backend_type: "meta".to_string(),
             validator_path: META_VALIDATOR_PATH.into(),
             generator_path: META_GENERATOR_PATH.into(),
             validator_script_type_hash: META_VALIDATOR_SCRIPT_TYPE_HASH.into(),
         },
         BackendConfig {
+            backend_type: "sudt".to_string(),
             validator_path: SUDT_VALIDATOR_PATH.into(),
             generator_path: SUDT_GENERATOR_PATH.into(),
             validator_script_type_hash: sudt_validator_script_type_hash.into(),

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -3,7 +3,7 @@
 use gw_block_producer::produce_block::{produce_block, ProduceBlockParam, ProduceBlockResult};
 use gw_chain::chain::{Chain, L1Action, L1ActionContext, SyncParam, UpdateAction};
 use gw_common::{blake2b::new_blake2b, H256};
-use gw_config::{BackendConfig, ChainConfig, GenesisConfig};
+use gw_config::{BackendConfig, BackendType, ChainConfig, GenesisConfig};
 use gw_generator::{
     account_lock_manage::{always_success::AlwaysSuccess, AccountLockManage},
     backend_manage::BackendManage,

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -71,13 +71,13 @@ pub fn build_backend_manage(rollup_config: &RollupConfig) -> BackendManage {
         rollup_config.l2_sudt_validator_script_type_hash().unpack();
     let configs = vec![
         BackendConfig {
-            backend_type: "meta".to_string(),
+            backend_type: BackendType::Meta,
             validator_path: META_VALIDATOR_PATH.into(),
             generator_path: META_GENERATOR_PATH.into(),
             validator_script_type_hash: META_VALIDATOR_SCRIPT_TYPE_HASH.into(),
         },
         BackendConfig {
-            backend_type: "sudt".to_string(),
+            backend_type: BackendType::Sudt,
             validator_path: SUDT_VALIDATOR_PATH.into(),
             generator_path: SUDT_GENERATOR_PATH.into(),
             validator_script_type_hash: sudt_validator_script_type_hash.into(),

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -224,6 +224,7 @@ pub fn generate_node_config(args: GenerateNodeConfigArgs) -> Result<Config> {
 
     let backends: Vec<BackendConfig> = vec![
         BackendConfig {
+            backend_type: "meta".to_string(),
             validator_path: build_scripts_result.built_scripts["meta_contract_validator"].clone(),
             generator_path: build_scripts_result.built_scripts["meta_contract_generator"].clone(),
             validator_script_type_hash: scripts_deployment
@@ -232,6 +233,7 @@ pub fn generate_node_config(args: GenerateNodeConfigArgs) -> Result<Config> {
                 .clone(),
         },
         BackendConfig {
+            backend_type: "sudt".to_string(),
             validator_path: build_scripts_result.built_scripts["l2_sudt_validator"].clone(),
             generator_path: build_scripts_result.built_scripts["l2_sudt_generator"].clone(),
             validator_script_type_hash: scripts_deployment
@@ -240,6 +242,7 @@ pub fn generate_node_config(args: GenerateNodeConfigArgs) -> Result<Config> {
                 .clone(),
         },
         BackendConfig {
+            backend_type: "polyjuice".to_string(),
             validator_path: build_scripts_result.built_scripts["polyjuice_validator"].clone(),
             generator_path: build_scripts_result.built_scripts["polyjuice_generator"].clone(),
             validator_script_type_hash: scripts_deployment

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -7,8 +7,9 @@ use anyhow::{anyhow, Result};
 use ckb_sdk::HttpRpcClient;
 use ckb_types::prelude::{Builder, Entity};
 use gw_config::{
-    BackendConfig, BlockProducerConfig, ChainConfig, ChallengerConfig, Config, GenesisConfig,
-    NodeMode, RPCClientConfig, RPCServerConfig, StoreConfig, WalletConfig, Web3IndexerConfig,
+    BackendConfig, BackendType, BlockProducerConfig, ChainConfig, ChallengerConfig, Config,
+    GenesisConfig, NodeMode, RPCClientConfig, RPCServerConfig, StoreConfig, WalletConfig,
+    Web3IndexerConfig,
 };
 use gw_jsonrpc_types::godwoken::L2BlockCommittedInfo;
 use gw_types::{core::ScriptHashType, packed::Script, prelude::*};
@@ -224,7 +225,7 @@ pub fn generate_node_config(args: GenerateNodeConfigArgs) -> Result<Config> {
 
     let backends: Vec<BackendConfig> = vec![
         BackendConfig {
-            backend_type: "meta".to_string(),
+            backend_type: BackendType::Meta,
             validator_path: build_scripts_result.built_scripts["meta_contract_validator"].clone(),
             generator_path: build_scripts_result.built_scripts["meta_contract_generator"].clone(),
             validator_script_type_hash: scripts_deployment
@@ -233,7 +234,7 @@ pub fn generate_node_config(args: GenerateNodeConfigArgs) -> Result<Config> {
                 .clone(),
         },
         BackendConfig {
-            backend_type: "sudt".to_string(),
+            backend_type: BackendType::Sudt,
             validator_path: build_scripts_result.built_scripts["l2_sudt_validator"].clone(),
             generator_path: build_scripts_result.built_scripts["l2_sudt_generator"].clone(),
             validator_script_type_hash: scripts_deployment
@@ -242,7 +243,7 @@ pub fn generate_node_config(args: GenerateNodeConfigArgs) -> Result<Config> {
                 .clone(),
         },
         BackendConfig {
-            backend_type: "polyjuice".to_string(),
+            backend_type: BackendType::Polyjuice,
             validator_path: build_scripts_result.built_scripts["polyjuice_validator"].clone(),
             generator_path: build_scripts_result.built_scripts["polyjuice_generator"].clone(),
             validator_script_type_hash: scripts_deployment

--- a/crates/tools/src/get_balance.rs
+++ b/crates/tools/src/get_balance.rs
@@ -8,7 +8,11 @@ pub fn get_balance(godwoken_rpc_url: &str, account: &str, sudt_id: u32) -> Resul
     let short_address = parse_account_short_address(&mut godwoken_rpc_client, account)?;
     let addr = JsonBytes::from_bytes(short_address);
     let balance = godwoken_rpc_client.get_balance(addr, sudt_id)?;
-    log::info!("Balance: {}", balance);
+    log::info!(
+        "Balance: {} Shannons = {:#}",
+        balance,
+        ckb_sdk::HumanCapacity::from(balance as u64)
+    );
 
     Ok(())
 }

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -460,8 +460,8 @@ fn run_cli() -> Result<()> {
                         .long("fee")
                         .takes_value(true)
                         .required(false)
-                        .default_value("0")
-                        .help("transfer fee"),
+                        .default_value("10000")
+                        .help("transfer fee (unit: Shannon)"),
                 )
                 .arg(
                     Arg::with_name("sudt-id")

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -271,7 +271,7 @@ fn run_cli() -> Result<()> {
                         .long("capacity")
                         .takes_value(true)
                         .required(true)
-                        .help("CKB capacity to deposit"),
+                        .help("CKB capacity to deposit (unit: CKB, format: 123.335)"),
                 )
                 .arg(
                     Arg::with_name("eth-address")
@@ -304,7 +304,7 @@ fn run_cli() -> Result<()> {
                         .long("capacity")
                         .takes_value(true)
                         .required(true)
-                        .help("CKB capacity to withdrawal"),
+                        .help("CKB capacity to withdrawal (unit: CKB, format: 123.335)"),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -331,6 +331,14 @@ fn run_cli() -> Result<()> {
                             "0x0000000000000000000000000000000000000000000000000000000000000000",
                         )
                         .help("l1 sudt script hash, default for withdrawal CKB"),
+                )
+                .arg(
+                    Arg::with_name("fee")
+                        .short("f")
+                        .long("fee")
+                        .takes_value(true)
+                        .default_value("0.0001")
+                        .help("The fee of withdrawal request, default to 0.0001 CKB.")
                 ),
         )
         .subcommand(
@@ -412,7 +420,7 @@ fn run_cli() -> Result<()> {
                         .long("amount")
                         .takes_value(true)
                         .default_value("0")
-                        .help("sUDT amount to transfer, CKB in shannon"),
+                        .help("sUDT amount to transfer (unit: Shannon)"),
                 )
                 .arg(
                     Arg::with_name("fee")
@@ -420,7 +428,7 @@ fn run_cli() -> Result<()> {
                         .long("fee")
                         .takes_value(true)
                         .required(true)
-                        .help("transfer fee"),
+                        .help("transfer fee (unit: Shannon)"),
                 )
                 .arg(
                     Arg::with_name("to")
@@ -984,6 +992,7 @@ fn run_cli() -> Result<()> {
             let privkey_path = Path::new(m.value_of("privkey-path").unwrap());
             let capacity = m.value_of("capacity").unwrap();
             let amount = m.value_of("amount").unwrap();
+            let fee = m.value_of("fee").unwrap();
             let scripts_deployment_path = Path::new(m.value_of("scripts-deployment-path").unwrap());
             let config_path = Path::new(m.value_of("config-path").unwrap());
             let godwoken_rpc_url = m.value_of("godwoken-rpc-url").unwrap();
@@ -995,6 +1004,7 @@ fn run_cli() -> Result<()> {
                 privkey_path,
                 capacity,
                 amount,
+                fee,
                 sudt_script_hash,
                 owner_ckb_address,
                 config_path,

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -460,7 +460,7 @@ fn run_cli() -> Result<()> {
                         .long("fee")
                         .takes_value(true)
                         .required(false)
-                        .default_value("10000")
+                        .default_value("0")
                         .help("transfer fee (unit: Shannon)"),
                 )
                 .arg(

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -1152,7 +1152,7 @@ fn run_cli() -> Result<()> {
                 }
             };
             if quiet {
-                println!("{}", account_id);
+                println!("[create-sudt-account] {}", account_id);
             }
         }
         ("get-balance", Some(m)) => {

--- a/crates/tools/src/update_cell.rs
+++ b/crates/tools/src/update_cell.rs
@@ -120,7 +120,7 @@ pub fn update_cell<P: AsRef<Path>>(
         hex::encode(tx.hash()),
         tx.as_slice().len()
     );
-    println!("{}", update_message);
+    println!("[update_cell] {}", update_message);
     // send transaction
     println!("Unlock cell {}", existed_cell.lock());
     let tx_hash = rpc_client
@@ -131,7 +131,7 @@ pub fn update_cell<P: AsRef<Path>>(
         .map_err(|err| anyhow!("{}", err))?;
     println!("Send tx...");
     wait_for_tx(&mut rpc_client, &tx_hash, 180).map_err(|err| anyhow!("{}", err))?;
-    println!("{}", update_message);
+    println!("[update_cell] {}", update_message);
     println!("Cell is updated!");
     Ok(())
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -11,6 +11,8 @@ gw-poa = { path = "../poa" }
 gw-config = { path = "../config" }
 gw-common = { path = "../common" }
 gw-rpc-client = { path = "../rpc-client" }
+gw-generator = { path = "../generator" }
+log = "0.4"
 anyhow = "1.0"
 faster-hex = "0.4"
 ckb-crypto = "0.38.0"

--- a/crates/utils/src/fee.rs
+++ b/crates/utils/src/fee.rs
@@ -41,7 +41,7 @@ pub fn check_l2tx_fee(
             if fee_struct.amount().unpack() < meta_contract_base_fee {
                 let err_msg = format!("The fee is too low for acceptance, should more than meta_contract_base_fee({} shannons).",
                 meta_contract_base_fee);
-                log::warn!("{}", err_msg);
+                log::warn!("[check_l2tx_fee] {}", err_msg);
                 return Err(anyhow!(err_msg));
             }
             Ok(())
@@ -60,7 +60,7 @@ pub fn check_l2tx_fee(
             if fee_amount < sudt_transfer_base_fee {
                 let err_msg = format!("The fee is too low for acceptance, should more than sudt_transfer_base_fee({} shannons).",
                 sudt_transfer_base_fee);
-                log::warn!("{}", err_msg);
+                log::warn!("[check_l2tx_fee] {}", err_msg);
                 return Err(anyhow!(err_msg));
             }
             Ok(())

--- a/crates/utils/src/fee.rs
+++ b/crates/utils/src/fee.rs
@@ -36,9 +36,7 @@ pub fn check_l2tx_fee(
             let sudt_id = fee_struct.sudt_id().unpack();
             let meta_contract_base_fee = fee_config.meta_contract_minimum_fee(sudt_id)?;
             if fee_struct.amount().unpack() < meta_contract_base_fee {
-                let err_msg = format!("The fee is too low for acceptance, should more than meta_contract_minimum_fee({}).",
-                meta_contract_base_fee);
-                log::warn!("[check_l2tx_fee] {}", err_msg);
+                let err_msg = format!("Fee isn't enough, required meta_contract fee: {}.", meta_contract_base_fee);
                 return Err(anyhow!(err_msg));
             }
             Ok(())
@@ -46,7 +44,7 @@ pub fn check_l2tx_fee(
         BackendType::Sudt => {
             let sudt_id = raw_l2tx.to_id().unpack();
             if !fee_config.is_supported_sudt(sudt_id) {
-                return Err(anyhow!("This sudt is not supported to used as fee. Please use SudtERC20Proxy to transfer this sUDT instead."));
+                return Err(anyhow!("Simple UDT is unsupported. Please use ERC20 transfer to instead."));
             }
             let sudt_transfer_base_fee = fee_config.sudt_transfer_minimum_fee(sudt_id)?;
             let sudt_args = SUDTArgs::from_slice(raw_l2tx_args.as_ref())?;
@@ -55,9 +53,7 @@ pub fn check_l2tx_fee(
                 SUDTArgsUnion::SUDTTransfer(args) => args.fee().unpack(),
             };
             if fee_amount < sudt_transfer_base_fee {
-                let err_msg = format!("The fee is too low for acceptance, should more than sudt_transfer_minimum_fee({}).",
-                sudt_transfer_base_fee);
-                log::warn!("[check_l2tx_fee] {}", err_msg);
+                let err_msg = format!("Fee isn't enough, required sudt_transfer fee: {}.", sudt_transfer_base_fee);
                 return Err(anyhow!(err_msg));
             }
             Ok(())
@@ -74,9 +70,7 @@ pub fn check_l2tx_fee(
             let min_gas_price =
                 fee_config.polyjuice_minimum_gas_price(gw_common::builtins::CKB_SUDT_ACCOUNT_ID)?;
             if gas_price < min_gas_price {
-                let err_msg = format!("Gas Price too low for acceptance, should more than polyjuice_minimum_gas_price({} shannons).",
-                min_gas_price);
-                log::warn!("[check_l2tx_fee] {}", err_msg);
+                let err_msg = format!("Gas Price is too low, required gas_price {}.", min_gas_price);
                 return Err(anyhow!(err_msg));
             }
             Ok(())

--- a/crates/utils/src/fee.rs
+++ b/crates/utils/src/fee.rs
@@ -36,7 +36,10 @@ pub fn check_l2tx_fee(
             let sudt_id = fee_struct.sudt_id().unpack();
             let meta_contract_base_fee = fee_config.meta_contract_minimum_fee(sudt_id)?;
             if fee_struct.amount().unpack() < meta_contract_base_fee {
-                let err_msg = format!("Fee isn't enough, required meta_contract fee: {}.", meta_contract_base_fee);
+                let err_msg = format!(
+                    "Fee isn't enough, required meta_contract fee: {}.",
+                    meta_contract_base_fee
+                );
                 return Err(anyhow!(err_msg));
             }
             Ok(())
@@ -44,7 +47,9 @@ pub fn check_l2tx_fee(
         BackendType::Sudt => {
             let sudt_id = raw_l2tx.to_id().unpack();
             if !fee_config.is_supported_sudt(sudt_id) {
-                return Err(anyhow!("Simple UDT is unsupported. Please use ERC20 transfer to instead."));
+                return Err(anyhow!(
+                    "Simple UDT is unsupported. Please use ERC20 transfer to instead."
+                ));
             }
             let sudt_transfer_base_fee = fee_config.sudt_transfer_minimum_fee(sudt_id)?;
             let sudt_args = SUDTArgs::from_slice(raw_l2tx_args.as_ref())?;
@@ -53,7 +58,10 @@ pub fn check_l2tx_fee(
                 SUDTArgsUnion::SUDTTransfer(args) => args.fee().unpack(),
             };
             if fee_amount < sudt_transfer_base_fee {
-                let err_msg = format!("Fee isn't enough, required sudt_transfer fee: {}.", sudt_transfer_base_fee);
+                let err_msg = format!(
+                    "Fee isn't enough, required sudt_transfer fee: {}.",
+                    sudt_transfer_base_fee
+                );
                 return Err(anyhow!(err_msg));
             }
             Ok(())
@@ -70,7 +78,10 @@ pub fn check_l2tx_fee(
             let min_gas_price =
                 fee_config.polyjuice_minimum_gas_price(gw_common::builtins::CKB_SUDT_ACCOUNT_ID)?;
             if gas_price < min_gas_price {
-                let err_msg = format!("Gas Price is too low, required gas_price {}.", min_gas_price);
+                let err_msg = format!(
+                    "Gas Price is too low, required gas_price {}.",
+                    min_gas_price
+                );
                 return Err(anyhow!(err_msg));
             }
             Ok(())

--- a/crates/utils/src/fee.rs
+++ b/crates/utils/src/fee.rs
@@ -2,8 +2,7 @@
 
 use crate::transaction_skeleton::TransactionSkeleton;
 use anyhow::{anyhow, Result};
-use gw_config::FeeConfig;
-use gw_generator::backend_manage::BackendType;
+use gw_config::{BackendType, FeeConfig};
 use gw_rpc_client::indexer_client::CKBIndexerClient;
 use gw_types::{
     offchain::InputCellInfo,
@@ -83,6 +82,7 @@ pub fn check_l2tx_fee(
             }
             Ok(())
         }
+        BackendType::Unknown => Err(anyhow!("Found Unknown BackendType")),
     }
 }
 


### PR DESCRIPTION
## Changes
1. check if the fee or fee_rate/gasPrice of the L2Transaction is enough
- check the fee of MetaContract::CreateAccount
- check the fee of SUDTTransfer
- check the gasPrice of Polyjuice L2TX
    gasPrice: Value of the gas for a transaction

return： if the fee is too low for acceptance, return  RpcError, such as:
`{"jsonrpc":"2.0","id":57,"error":{"code":-32602,"message":"Gas Price too low for acceptance, should more than polyjuice_minimum_gas_price(500 shannons)."}}',
  error: Error: Gas Price too low for acceptance, should more than polyjuice_minimum_gas_price(500 shannons).`

2. check the fee of WithdrawalRequest

## Config
The default `fee_rates` HashMap is empty, which means that `check_fee` will always be successful.

### Config Example in gw-config.toml
```toml
# Example
[mem_pool.fee_config]
# the minimal fee of meta contract:
# meta_contract_minimum_fee = fee_rate * meta_contract_fee_weight
meta_contract_fee_weight = 2
# the minimal fee of a native sudt transfer transaction:
# sudt_transfer_minimum_fee = fee_rate * meta_contract_fee_weight
sudt_transfer_fee_weight = 2
# the minimal fee of a withdrawal request:
# withdrawal_minimum_fee = fee_rate * withdraw_fee_weight
withdraw_fee_weight = 2

# HashMap<fee_sudt_id, fee_rate>
[mem_pool.fee_config.fee_rates]
# (CKB_SUDT_ID -> 500)
0x1 = 500
# (Other_sUDT_ID -> fee_rate)
0x2 = 600
```

### Note: 
1. `fee_rate` is known as the minimum gasPrice in Ethereum.
2. Polyjuice backend uses CKB_SUDT(default to 0x1) to pay fee by default.
