### PR TITLE
feat: check and filter deposit cells by cancel timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "gw-store",
  "gw-traits",
  "gw-types",
+ "gw-utils",
  "hex",
  "log",
  "smol",

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -16,6 +16,7 @@ gw-traits = { path = "../traits" }
 gw-rpc-client = { path = "../rpc-client" }
 gw-poa = { path = "../poa" }
 gw-config = { path = "../config" }
+gw-utils = { path = "../utils" }
 smol = "1.2.5"
 anyhow = "1.0"
 log = "0.4"

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -17,8 +17,9 @@ use gw_types::{
     core::ScriptHashType,
     offchain::{CellInfo, CollectedCustodianCells, DepositInfo, RollupContext},
     packed::{
-        CellOutput, DepositRequest, L2BlockCommittedInfo, RawTransaction, RollupAction,
-        RollupActionUnion, RollupConfig, RollupSubmitBlock, Script, Transaction, WitnessArgs,
+        CellOutput, DepositLockArgs, DepositRequest, L2BlockCommittedInfo, RawTransaction,
+        RollupAction, RollupActionUnion, RollupConfig, RollupSubmitBlock, Script, Transaction,
+        WitnessArgs,
     },
     prelude::*,
 };
@@ -240,6 +241,17 @@ pub fn construct_block(
         .deposit_script_type_hash();
     let rollup_script_hash = generator.rollup_context().rollup_script_hash;
 
+    let lock_args = {
+        let cancel_timeout = 0xc0000000000004b0u64;
+        let mut buf: Vec<u8> = Vec::new();
+        let deposit_args = DepositLockArgs::new_builder()
+            .cancel_timeout(cancel_timeout.pack())
+            .build();
+        buf.extend(rollup_script_hash.as_slice());
+        buf.extend(deposit_args.as_slice());
+        buf
+    };
+
     let deposit_cells = deposit_requests
         .into_iter()
         .map(|deposit| DepositInfo {
@@ -250,7 +262,7 @@ pub fn construct_block(
                         Script::new_builder()
                             .code_hash(deposit_lock_type_hash.clone())
                             .hash_type(ScriptHashType::Type.into())
-                            .args(rollup_script_hash.as_slice().to_vec().pack())
+                            .args(lock_args.pack())
                             .build(),
                     )
                     .capacity(deposit.capacity())

--- a/crates/tests/src/tests/chain.rs
+++ b/crates/tests/src/tests/chain.rs
@@ -93,7 +93,7 @@ fn test_produce_blocks() {
 
     // block #2
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(user_script_a.clone())
         .build();
     produce_a_block(&mut chain, deposit, rollup_cell.clone(), 2);
@@ -137,7 +137,7 @@ fn test_produce_blocks() {
         let balance_b = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&script_hash_b))
             .unwrap();
-        assert_eq!(balance_a, 490 * CKB as u128);
+        assert_eq!(balance_a, 690 * CKB as u128);
         assert_eq!(balance_b, 500 * CKB as u128);
     }
 
@@ -166,7 +166,7 @@ fn test_layer1_fork() {
             })
             .build();
         let deposit = DepositRequest::new_builder()
-            .capacity((190u64 * CKB).pack())
+            .capacity((290u64 * CKB).pack())
             .script(charlie_script)
             .build();
         let chain = setup_chain(rollup_type_script);
@@ -197,7 +197,7 @@ fn test_layer1_fork() {
         })
         .build();
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(alice_script)
         .build();
     let block_result = {
@@ -351,7 +351,7 @@ fn test_layer1_revert() {
         })
         .build();
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(alice_script.clone())
         .build();
     let block_result = {
@@ -467,7 +467,7 @@ fn test_layer1_revert() {
         let alice_balance = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&alice_script_hash))
             .unwrap();
-        assert_eq!(alice_balance, 200 * CKB as u128);
+        assert_eq!(alice_balance, 400 * CKB as u128);
 
         let bob_id_opt = tree
             .get_account_id_by_script_hash(&bob_script.hash().into())
@@ -506,7 +506,7 @@ fn test_layer1_revert() {
         let alice_balance = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&alice_script_hash))
             .unwrap();
-        assert_eq!(alice_balance, 200 * CKB as u128);
+        assert_eq!(alice_balance, 400 * CKB as u128);
 
         let bob_script_hash: H256 = bob_script.hash().into();
         let bob_id = tree
@@ -545,7 +545,7 @@ fn test_sync_blocks() {
         .build();
     let sudt_script_hash: H256 = [42u8; 32].into();
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(user_script_a.clone())
         .sudt_script_hash(sudt_script_hash.pack())
         .build();
@@ -553,7 +553,7 @@ fn test_sync_blocks() {
 
     // block #2
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(user_script_a.clone())
         .build();
     let sync_2 = produce_a_block(&mut chain1, deposit, rollup_cell.clone(), 2);
@@ -615,7 +615,7 @@ fn test_sync_blocks() {
         let balance_b = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&script_hash_b))
             .unwrap();
-        assert_eq!(balance_a, 400 * CKB as u128);
+        assert_eq!(balance_a, 800 * CKB as u128);
         assert_eq!(balance_b, 500 * CKB as u128);
     }
 

--- a/crates/tools/src/deposit_ckb.rs
+++ b/crates/tools/src/deposit_ckb.rs
@@ -74,10 +74,10 @@ pub fn deposit_ckb(
     let l2_lock_hash_str = format!("0x{}", faster_hex::hex_string(l2_lock_hash.as_bytes())?);
     log::info!("layer2 script hash: {}", l2_lock_hash_str);
 
-    // cancel_timeout default to 2 days
+    // cancel_timeout default to 20 minutes
     let deposit_lock_args = DepositLockArgs::new_builder()
         .owner_lock_hash(owner_lock_hash)
-        .cancel_timeout(GwPack::pack(&0xc00000000002a300u64))
+        .cancel_timeout(GwPack::pack(&0xc0000000000004b0u64))
         .layer2_lock(l2_lock)
         .build();
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod fee;
 pub mod genesis_info;
+pub mod since;
 pub mod transaction_skeleton;
 pub mod wallet;

--- a/crates/utils/src/since.rs
+++ b/crates/utils/src/since.rs
@@ -1,0 +1,151 @@
+/// Transaction input's since field
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Since(u64);
+
+impl Since {
+    const LOCK_TYPE_FLAG: u64 = 1 << 63;
+    const METRIC_TYPE_FLAG_MASK: u64 = 0x6000_0000_0000_0000;
+    const FLAGS_MASK: u64 = 0xff00_0000_0000_0000;
+    const VALUE_MASK: u64 = 0x00ff_ffff_ffff_ffff;
+    const REMAIN_FLAGS_BITS: u64 = 0x1f00_0000_0000_0000;
+    const LOCK_BY_BLOCK_NUMBER_MASK: u64 = 0x0000_0000_0000_0000;
+    const LOCK_BY_EPOCH_MASK: u64 = 0x2000_0000_0000_0000;
+    const LOCK_BY_TIMESTAMP_MASK: u64 = 0x4000_0000_0000_0000;
+
+    pub fn new(v: u64) -> Self {
+        Since(v)
+    }
+
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    pub fn is_absolute(self) -> bool {
+        self.0 & Self::LOCK_TYPE_FLAG == 0
+    }
+
+    #[inline]
+    pub fn is_relative(self) -> bool {
+        !self.is_absolute()
+    }
+
+    pub fn flags_is_valid(self) -> bool {
+        (self.0 & Self::REMAIN_FLAGS_BITS == 0)
+            && ((self.0 & Self::METRIC_TYPE_FLAG_MASK) != Self::METRIC_TYPE_FLAG_MASK)
+    }
+
+    pub fn flags(self) -> u64 {
+        self.0 & Self::FLAGS_MASK
+    }
+
+    pub fn extract_lock_value(self) -> Option<LockValue> {
+        let value = self.0 & Self::VALUE_MASK;
+        match self.0 & Self::METRIC_TYPE_FLAG_MASK {
+            //0b0000_0000
+            Self::LOCK_BY_BLOCK_NUMBER_MASK => Some(LockValue::BlockNumber(value)),
+            //0b0010_0000
+            Self::LOCK_BY_EPOCH_MASK => Some(LockValue::EpochNumberWithFraction(
+                EpochNumberWithFraction::from_full_value(value),
+            )),
+            //0b0100_0000
+            Self::LOCK_BY_TIMESTAMP_MASK => Some(LockValue::Timestamp(value * 1000)),
+            _ => None,
+        }
+    }
+}
+
+pub enum LockValue {
+    BlockNumber(u64),
+    EpochNumberWithFraction(EpochNumberWithFraction),
+    Timestamp(u64),
+}
+
+impl LockValue {
+    pub fn block_number(&self) -> Option<u64> {
+        if let Self::BlockNumber(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    pub fn epoch(&self) -> Option<EpochNumberWithFraction> {
+        if let Self::EpochNumberWithFraction(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    pub fn timestamp(&self) -> Option<u64> {
+        if let Self::Timestamp(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct EpochNumberWithFraction(u64);
+
+impl EpochNumberWithFraction {
+    pub const NUMBER_OFFSET: usize = 0;
+    pub const NUMBER_BITS: usize = 24;
+    pub const NUMBER_MAXIMUM_VALUE: u64 = (1u64 << Self::NUMBER_BITS);
+    pub const NUMBER_MASK: u64 = (Self::NUMBER_MAXIMUM_VALUE - 1);
+    pub const INDEX_OFFSET: usize = Self::NUMBER_BITS;
+    pub const INDEX_BITS: usize = 16;
+    pub const INDEX_MAXIMUM_VALUE: u64 = (1u64 << Self::INDEX_BITS);
+    pub const INDEX_MASK: u64 = (Self::INDEX_MAXIMUM_VALUE - 1);
+    pub const LENGTH_OFFSET: usize = Self::NUMBER_BITS + Self::INDEX_BITS;
+    pub const LENGTH_BITS: usize = 16;
+    pub const LENGTH_MAXIMUM_VALUE: u64 = (1u64 << Self::LENGTH_BITS);
+    pub const LENGTH_MASK: u64 = (Self::LENGTH_MAXIMUM_VALUE - 1);
+
+    pub fn new(number: u64, index: u64, length: u64) -> EpochNumberWithFraction {
+        debug_assert!(number < Self::NUMBER_MAXIMUM_VALUE);
+        debug_assert!(index < Self::INDEX_MAXIMUM_VALUE);
+        debug_assert!(length < Self::LENGTH_MAXIMUM_VALUE);
+        debug_assert!(length > 0);
+        Self::new_unchecked(number, index, length)
+    }
+
+    pub const fn new_unchecked(number: u64, index: u64, length: u64) -> Self {
+        EpochNumberWithFraction(
+            (length << Self::LENGTH_OFFSET)
+                | (index << Self::INDEX_OFFSET)
+                | (number << Self::NUMBER_OFFSET),
+        )
+    }
+
+    pub fn number(self) -> u64 {
+        (self.0 >> Self::NUMBER_OFFSET) & Self::NUMBER_MASK
+    }
+
+    pub fn index(self) -> u64 {
+        (self.0 >> Self::INDEX_OFFSET) & Self::INDEX_MASK
+    }
+
+    pub fn length(self) -> u64 {
+        (self.0 >> Self::LENGTH_OFFSET) & Self::LENGTH_MASK
+    }
+
+    pub fn full_value(self) -> u64 {
+        self.0
+    }
+
+    // One caveat here, is that if the user specifies a zero epoch length either
+    // delibrately, or by accident, calling to_rational() after that might
+    // result in a division by zero panic. To prevent that, this method would
+    // automatically rewrite the value to epoch index 0 with epoch length to
+    // prevent panics
+    pub fn from_full_value(value: u64) -> Self {
+        let epoch = Self(value);
+        if epoch.length() == 0 {
+            Self::new(epoch.number(), 0, 1)
+        } else {
+            epoch
+        }
+    }
+}


### PR DESCRIPTION
Deposit lock can be unlock by user after `cancel_timeout` if the cell is not get packaged by sequencer.

To prevent conflict with user's unlock, we check and filter deposit cell's by `cancel_timeout`, only package cells with required `cancel_timeout`.

The current `cancel_timeout` fields must be relative time flag. We support three types of the time lock:

* if user set `cancel_timeout` to block numbers, the required number is 150 blocks.(~ 20 minutes)
* if user set `cancel_timeout` to timestamp, the required timestamp is 1200s. (20 minutes)
* if user set `cancel_timeout` to epoch, the required epoch is 1 epoch. (~ 4 hours, we recommended to use the first two)

See [tx since rfc](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0017-tx-valid-since/0017-tx-valid-since.md) for details.