### PR TITLE
feat: support query amount of layer2 custodian CKB in gw-tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ name = "gw-tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-jsonrpc-client",
  "bech32",
  "ckb-crypto 0.100.0",
  "ckb-fixed-hash 0.100.0",

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -35,6 +35,7 @@ gw-generator = { path = "../generator" }
 gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-utils = { path = "../utils" }
 gw-rpc-client = { path = "../rpc-client" }
+async-jsonrpc-client = { version = "0.3.0", default-features = false, features = ["http-async-std"] }
 url = "2.2"
 faster-hex = "0.5.0"
 rand = "0.8"

--- a/crates/tools/src/stat/mod.rs
+++ b/crates/tools/src/stat/mod.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use ckb_types::prelude::{Builder, Entity};
+use gw_common::H256;
+use gw_rpc_client::indexer_client::CKBIndexerClient;
+use gw_types::{core::ScriptHashType, packed::Script, prelude::Pack};
+
+/// Query custodian ckb from ckb-indexer
+pub fn query_custodian_ckb(
+    rpc_client: &CKBIndexerClient,
+    rollup_type_hash: &H256,
+    custodian_script_type_hash: &H256,
+) -> Result<u128> {
+    let script = Script::new_builder()
+        .code_hash(custodian_script_type_hash.pack())
+        .hash_type(ScriptHashType::Type.into())
+        .args(rollup_type_hash.as_slice().to_vec().pack())
+        .build();
+    smol::block_on(rpc_client.query_custodian_ckb(script))
+}


### PR DESCRIPTION
Example, query mainnet custodian CKB:

gw-tools stat-custodian-ckb --rollup-type-hash 0x40d73f0d3c561fcaae330eabc030d8d96a9d0af36d0c5114883658a350cb9e3b --custodian-script-type-hash 0x45c112df97daece27c4afa02b24b15f64403bdfd45ab2e0e88c9fb2a24796b1d --ckb-indexer-rpc https://mainnet.ckbapp.dev/indexer