### PR TITLE
Fix revert txs and inconsistent state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "gw-store",
  "gw-traits",
  "gw-types",
+ "gw-utils",
  "hex",
  "log",
  "smol",

--- a/crates/block-producer/src/block_producer.rs
+++ b/crates/block-producer/src/block_producer.rs
@@ -76,6 +76,7 @@ async fn resolve_tx_deps(rpc_client: &RPCClient, tx_hash: [u8; 32]) -> Result<Ve
         let cell = rpc_client
             .get_cell(dep.out_point())
             .await?
+            .and_then(|cell_status| cell_status.cell)
             .ok_or_else(|| anyhow!("can't find dep group cell"))?;
         let out_points =
             OutPointVec::from_slice(&cell.data).map_err(|_| anyhow!("invalid dep group"))?;
@@ -120,6 +121,7 @@ async fn resolve_tx_deps(rpc_client: &RPCClient, tx_hash: [u8; 32]) -> Result<Ve
     for cell_fut in get_cell_futs {
         let cell = cell_fut
             .await?
+            .and_then(|cell_status| cell_status.cell)
             .ok_or_else(|| anyhow!("can't find dep cell"))?;
         cells.push(cell);
     }

--- a/crates/block-producer/src/debugger.rs
+++ b/crates/block-producer/src/debugger.rs
@@ -65,7 +65,11 @@ pub async fn build_mock_transaction(
             return Ok(vec![]);
         }
         // parse dep group
-        let cell = match rpc_client.get_cell(dep.out_point()).await? {
+        let cell = match rpc_client
+            .get_cell(dep.out_point())
+            .await?
+            .and_then(|cell_status| cell_status.cell)
+        {
             Some(cell) => Some(cell),
             None => rpc_client.get_cell_from_mempool(dep.out_point()).await?,
         }
@@ -91,7 +95,11 @@ pub async fn build_mock_transaction(
 
     let mut inputs: Vec<ReprMockInput> = Vec::with_capacity(tx.raw().inputs().len());
     for input in tx.raw().inputs() {
-        let input_cell = match rpc_client.get_cell(input.previous_output()).await? {
+        let input_cell = match rpc_client
+            .get_cell(input.previous_output())
+            .await?
+            .and_then(|cell_status| cell_status.cell)
+        {
             Some(cell) => Some(cell),
             None => {
                 rpc_client
@@ -138,7 +146,11 @@ pub async fn build_mock_transaction(
 
     let mut cell_deps: Vec<ReprMockCellDep> = Vec::with_capacity(resolved_cell_deps.len());
     for cell_dep in resolved_cell_deps {
-        let dep_cell = match rpc_client.get_cell(cell_dep.out_point()).await? {
+        let dep_cell = match rpc_client
+            .get_cell(cell_dep.out_point())
+            .await?
+            .and_then(|cell_status| cell_status.cell)
+        {
             Some(cell) => Some(cell),
             None => {
                 rpc_client

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -718,6 +718,7 @@ fn check_rollup_config_cell(
                 .into(),
         ),
     )?
+    .and_then(|cell_with_status| cell_with_status.cell)
     .ok_or_else(|| anyhow!("can't find rollup config cell"))?;
     let cell_data = RollupConfig::from_slice(&rollup_config_cell.data.to_vec())?;
     let eoa_set = rollup_config

--- a/crates/challenge/src/offchain.rs
+++ b/crates/challenge/src/offchain.rs
@@ -548,7 +548,9 @@ async fn resolve_cell_deps(
     for dep in flatten_deps {
         let dep_cell = {
             let query = rpc_client.get_cell(dep.out_point()).await?;
-            query.ok_or_else(|| anyhow!("can't find dep cell"))?
+            query
+                .and_then(|q| q.cell)
+                .ok_or_else(|| anyhow!("can't find dep cell"))?
         };
         resolved_deps.push(into_input_cell_info(dep_cell));
     }
@@ -565,7 +567,9 @@ async fn resolve_dep_group(rpc_client: &RPCClient, dep: &CellDep) -> Result<Vec<
     // parse dep group
     let cell = {
         let query = rpc_client.get_cell(dep.out_point()).await?;
-        query.ok_or_else(|| anyhow!("can't find dep group cell"))?
+        query
+            .and_then(|q| q.cell)
+            .ok_or_else(|| anyhow!("can't find dep group cell"))?
     };
 
     let out_points =

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -16,6 +16,7 @@ gw-traits = { path = "../traits" }
 gw-rpc-client = { path = "../rpc-client" }
 gw-poa = { path = "../poa" }
 gw-config = { path = "../config" }
+gw-utils = { path = "../utils" }
 smol = "1.2.5"
 anyhow = "1.0"
 log = "0.4"

--- a/crates/mem-pool/src/default_provider.rs
+++ b/crates/mem-pool/src/default_provider.rs
@@ -5,8 +5,10 @@ use gw_poa::PoA;
 use gw_rpc_client::rpc_client::RPCClient;
 use gw_store::Store;
 use gw_types::{
-    offchain::{CollectedCustodianCells, DepositInfo, InputCellInfo, RollupContext},
-    packed::{CellInput, WithdrawalRequest},
+    offchain::{
+        CellWithStatus, CollectedCustodianCells, DepositInfo, InputCellInfo, RollupContext,
+    },
+    packed::{CellInput, OutPoint, WithdrawalRequest},
     prelude::*,
 };
 use smol::{lock::Mutex, Task};
@@ -61,6 +63,11 @@ impl MemPoolProvider for DefaultMemPoolProvider {
     fn collect_deposit_cells(&self) -> Task<Result<Vec<DepositInfo>>> {
         let rpc_client = self.rpc_client.clone();
         smol::spawn(async move { rpc_client.query_deposit_cells(MAX_MEM_BLOCK_DEPOSITS).await })
+    }
+
+    fn get_cell(&self, out_point: OutPoint) -> Task<Result<Option<CellWithStatus>>> {
+        let rpc_client = self.rpc_client.clone();
+        smol::spawn(async move { rpc_client.get_cell(out_point).await })
     }
 
     fn query_available_custodians(

--- a/crates/mem-pool/src/traits.rs
+++ b/crates/mem-pool/src/traits.rs
@@ -2,8 +2,10 @@ use std::time::Duration;
 
 use anyhow::Result;
 use gw_types::{
-    offchain::{CollectedCustodianCells, DepositInfo, ErrorTxReceipt, RollupContext},
-    packed::WithdrawalRequest,
+    offchain::{
+        CellWithStatus, CollectedCustodianCells, DepositInfo, ErrorTxReceipt, RollupContext,
+    },
+    packed::{OutPoint, WithdrawalRequest},
 };
 use smol::Task;
 
@@ -16,6 +18,7 @@ pub trait MemPoolProvider {
         last_finalized_block_number: u64,
         rollup_context: RollupContext,
     ) -> Task<Result<CollectedCustodianCells>>;
+    fn get_cell(&self, out_point: OutPoint) -> Task<Result<Option<CellWithStatus>>>;
 }
 
 pub trait MemPoolErrorTxHandler {

--- a/crates/tests/src/testing_tool/mem_pool_provider.rs
+++ b/crates/tests/src/testing_tool/mem_pool_provider.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use anyhow::Result;
 use gw_mem_pool::traits::MemPoolProvider;
 use gw_types::{
-    offchain::{CollectedCustodianCells, DepositInfo, RollupContext},
-    packed::WithdrawalRequest,
+    offchain::{CellWithStatus, CollectedCustodianCells, DepositInfo, RollupContext},
+    packed::{OutPoint, WithdrawalRequest},
 };
 use smol::Task;
 
@@ -32,5 +32,8 @@ impl MemPoolProvider for DummyMemPoolProvider {
     ) -> Task<Result<CollectedCustodianCells>> {
         let collected_custodians = self.collected_custodians.clone();
         smol::spawn(async move { Ok(collected_custodians) })
+    }
+    fn get_cell(&self, _out_point: OutPoint) -> Task<Result<Option<CellWithStatus>>> {
+        smol::spawn(async { Ok(None) })
     }
 }

--- a/crates/tests/src/tests/chain.rs
+++ b/crates/tests/src/tests/chain.rs
@@ -95,7 +95,7 @@ fn test_produce_blocks() {
 
     // block #2
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(user_script_a.clone())
         .build();
     produce_a_block(&mut chain, deposit, rollup_cell.clone(), 2);
@@ -146,7 +146,7 @@ fn test_produce_blocks() {
         let balance_b = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&script_hash_b))
             .unwrap();
-        assert_eq!(balance_a, 490 * CKB as u128);
+        assert_eq!(balance_a, 690 * CKB as u128);
         assert_eq!(balance_b, 500 * CKB as u128);
     }
 
@@ -175,7 +175,7 @@ fn test_layer1_fork() {
             })
             .build();
         let deposit = DepositRequest::new_builder()
-            .capacity((190u64 * CKB).pack())
+            .capacity((290u64 * CKB).pack())
             .script(charlie_script)
             .build();
         let chain = setup_chain(rollup_type_script);
@@ -206,7 +206,7 @@ fn test_layer1_fork() {
         })
         .build();
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(alice_script)
         .build();
     let block_result = {
@@ -370,7 +370,7 @@ fn test_layer1_revert() {
         })
         .build();
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(alice_script.clone())
         .build();
     let block_result = {
@@ -498,7 +498,7 @@ fn test_layer1_revert() {
         let alice_balance = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&alice_script_hash))
             .unwrap();
-        assert_eq!(alice_balance, 200 * CKB as u128);
+        assert_eq!(alice_balance, 400 * CKB as u128);
 
         let bob_id_opt = tree
             .get_account_id_by_script_hash(&bob_script.hash().into())
@@ -547,7 +547,7 @@ fn test_layer1_revert() {
         let alice_balance = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&alice_script_hash))
             .unwrap();
-        assert_eq!(alice_balance, 200 * CKB as u128);
+        assert_eq!(alice_balance, 400 * CKB as u128);
 
         let bob_script_hash: H256 = bob_script.hash().into();
         let bob_id = tree
@@ -586,7 +586,7 @@ fn test_sync_blocks() {
         .build();
     let sudt_script_hash: H256 = [42u8; 32].into();
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(user_script_a.clone())
         .sudt_script_hash(sudt_script_hash.pack())
         .build();
@@ -594,7 +594,7 @@ fn test_sync_blocks() {
 
     // block #2
     let deposit = DepositRequest::new_builder()
-        .capacity((200u64 * CKB).pack())
+        .capacity((400u64 * CKB).pack())
         .script(user_script_a.clone())
         .build();
     let sync_2 = produce_a_block(&mut chain1, deposit, rollup_cell.clone(), 2);
@@ -662,7 +662,7 @@ fn test_sync_blocks() {
         let balance_b = tree
             .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_short_address(&script_hash_b))
             .unwrap();
-        assert_eq!(balance_a, 400 * CKB as u128);
+        assert_eq!(balance_a, 800 * CKB as u128);
         assert_eq!(balance_b, 500 * CKB as u128);
     }
 

--- a/crates/tools/src/deposit_ckb.rs
+++ b/crates/tools/src/deposit_ckb.rs
@@ -79,10 +79,10 @@ pub fn deposit_ckb(
     );
     log::info!("layer2 script hash: {}", l2_lock_hash_str);
 
-    // cancel_timeout default to 2 days
+    // cancel_timeout default to 20 minutes
     let deposit_lock_args = DepositLockArgs::new_builder()
         .owner_lock_hash(owner_lock_hash)
-        .cancel_timeout(GwPack::pack(&0xc00000000002a300u64))
+        .cancel_timeout(GwPack::pack(&0xc0000000000004b0u64))
         .layer2_lock(l2_lock)
         .build();
 

--- a/crates/types/src/offchain/rpc.rs
+++ b/crates/types/src/offchain/rpc.rs
@@ -12,6 +12,25 @@ pub struct CellInfo {
     pub data: Bytes,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CellStatus {
+    Live,
+    Dead,
+    Unknown,
+}
+
+impl Default for CellStatus {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CellWithStatus {
+    pub cell: Option<CellInfo>,
+    pub status: CellStatus,
+}
+
 #[derive(Debug, Clone)]
 pub struct InputCellInfo {
     pub input: CellInput,

--- a/crates/types/src/std_traits.rs
+++ b/crates/types/src/std_traits.rs
@@ -112,6 +112,7 @@ cfg_if::cfg_if! {
         }
         impl_std_hash!(L2Transaction);
         impl_std_hash!(WithdrawalRequest);
+        impl_std_hash!(DepositRequest);
         impl_std_hash!(CellDep);
         impl_std_eq!(CellDep);
         impl_std_hash!(OutPoint);

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod fee;
 pub mod genesis_info;
+pub mod since;
 pub mod transaction_skeleton;
 pub mod wallet;

--- a/crates/utils/src/since.rs
+++ b/crates/utils/src/since.rs
@@ -1,0 +1,151 @@
+/// Transaction input's since field
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Since(u64);
+
+impl Since {
+    const LOCK_TYPE_FLAG: u64 = 1 << 63;
+    const METRIC_TYPE_FLAG_MASK: u64 = 0x6000_0000_0000_0000;
+    const FLAGS_MASK: u64 = 0xff00_0000_0000_0000;
+    const VALUE_MASK: u64 = 0x00ff_ffff_ffff_ffff;
+    const REMAIN_FLAGS_BITS: u64 = 0x1f00_0000_0000_0000;
+    const LOCK_BY_BLOCK_NUMBER_MASK: u64 = 0x0000_0000_0000_0000;
+    const LOCK_BY_EPOCH_MASK: u64 = 0x2000_0000_0000_0000;
+    const LOCK_BY_TIMESTAMP_MASK: u64 = 0x4000_0000_0000_0000;
+
+    pub fn new(v: u64) -> Self {
+        Since(v)
+    }
+
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    pub fn is_absolute(self) -> bool {
+        self.0 & Self::LOCK_TYPE_FLAG == 0
+    }
+
+    #[inline]
+    pub fn is_relative(self) -> bool {
+        !self.is_absolute()
+    }
+
+    pub fn flags_is_valid(self) -> bool {
+        (self.0 & Self::REMAIN_FLAGS_BITS == 0)
+            && ((self.0 & Self::METRIC_TYPE_FLAG_MASK) != Self::METRIC_TYPE_FLAG_MASK)
+    }
+
+    pub fn flags(self) -> u64 {
+        self.0 & Self::FLAGS_MASK
+    }
+
+    pub fn extract_lock_value(self) -> Option<LockValue> {
+        let value = self.0 & Self::VALUE_MASK;
+        match self.0 & Self::METRIC_TYPE_FLAG_MASK {
+            //0b0000_0000
+            Self::LOCK_BY_BLOCK_NUMBER_MASK => Some(LockValue::BlockNumber(value)),
+            //0b0010_0000
+            Self::LOCK_BY_EPOCH_MASK => Some(LockValue::EpochNumberWithFraction(
+                EpochNumberWithFraction::from_full_value(value),
+            )),
+            //0b0100_0000
+            Self::LOCK_BY_TIMESTAMP_MASK => Some(LockValue::Timestamp(value * 1000)),
+            _ => None,
+        }
+    }
+}
+
+pub enum LockValue {
+    BlockNumber(u64),
+    EpochNumberWithFraction(EpochNumberWithFraction),
+    Timestamp(u64),
+}
+
+impl LockValue {
+    pub fn block_number(&self) -> Option<u64> {
+        if let Self::BlockNumber(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    pub fn epoch(&self) -> Option<EpochNumberWithFraction> {
+        if let Self::EpochNumberWithFraction(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    pub fn timestamp(&self) -> Option<u64> {
+        if let Self::Timestamp(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct EpochNumberWithFraction(u64);
+
+impl EpochNumberWithFraction {
+    pub const NUMBER_OFFSET: usize = 0;
+    pub const NUMBER_BITS: usize = 24;
+    pub const NUMBER_MAXIMUM_VALUE: u64 = (1u64 << Self::NUMBER_BITS);
+    pub const NUMBER_MASK: u64 = (Self::NUMBER_MAXIMUM_VALUE - 1);
+    pub const INDEX_OFFSET: usize = Self::NUMBER_BITS;
+    pub const INDEX_BITS: usize = 16;
+    pub const INDEX_MAXIMUM_VALUE: u64 = (1u64 << Self::INDEX_BITS);
+    pub const INDEX_MASK: u64 = (Self::INDEX_MAXIMUM_VALUE - 1);
+    pub const LENGTH_OFFSET: usize = Self::NUMBER_BITS + Self::INDEX_BITS;
+    pub const LENGTH_BITS: usize = 16;
+    pub const LENGTH_MAXIMUM_VALUE: u64 = (1u64 << Self::LENGTH_BITS);
+    pub const LENGTH_MASK: u64 = (Self::LENGTH_MAXIMUM_VALUE - 1);
+
+    pub fn new(number: u64, index: u64, length: u64) -> EpochNumberWithFraction {
+        debug_assert!(number < Self::NUMBER_MAXIMUM_VALUE);
+        debug_assert!(index < Self::INDEX_MAXIMUM_VALUE);
+        debug_assert!(length < Self::LENGTH_MAXIMUM_VALUE);
+        debug_assert!(length > 0);
+        Self::new_unchecked(number, index, length)
+    }
+
+    pub const fn new_unchecked(number: u64, index: u64, length: u64) -> Self {
+        EpochNumberWithFraction(
+            (length << Self::LENGTH_OFFSET)
+                | (index << Self::INDEX_OFFSET)
+                | (number << Self::NUMBER_OFFSET),
+        )
+    }
+
+    pub fn number(self) -> u64 {
+        (self.0 >> Self::NUMBER_OFFSET) & Self::NUMBER_MASK
+    }
+
+    pub fn index(self) -> u64 {
+        (self.0 >> Self::INDEX_OFFSET) & Self::INDEX_MASK
+    }
+
+    pub fn length(self) -> u64 {
+        (self.0 >> Self::LENGTH_OFFSET) & Self::LENGTH_MASK
+    }
+
+    pub fn full_value(self) -> u64 {
+        self.0
+    }
+
+    // One caveat here, is that if the user specifies a zero epoch length either
+    // delibrately, or by accident, calling to_rational() after that might
+    // result in a division by zero panic. To prevent that, this method would
+    // automatically rewrite the value to epoch index 0 with epoch length to
+    // prevent panics
+    pub fn from_full_value(value: u64) -> Self {
+        let epoch = Self(value);
+        if epoch.length() == 0 {
+            Self::new(epoch.number(), 0, 1)
+        } else {
+            epoch
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the potential inconsistent state during mem-pool reset.

## Issue

Some users report they found txs revert after get the tx receipt.

## Context:

The mem-pool reset it's state when receive new l2block, then calculate new state of the next block:

1. execute l2 withdrawals
2. execute l2 deposits
3. execute l2 txs

Unlike withdrawals & txs, the deposits is collected from layer1 CKB's cells, and the count of collected deposits is uncertain everytime.

This 'uncertain' causes the problem, every time we reset the mem-pool the deposits cells may changed, and new created accounts are changed, for example:

The first time mem-pool reset creates 3 accounts:

1. Deposit A(id: 100)
2. Deposit B(id: 101)
3. Contract Account(id: 102)

But when the mem-pool resets again, the accounts are changed:

1. Deposit A(id: 100)
2. Deposit B(id: 101)
3. Deposit C(id: 102)
3. Contract Account(id: 103)

In example, we collected another new deposit cell, the new deposit changes the id of contract account.

## Solution:

This PR introduce a pending_deposits fields in the mem-pool. The new collected deposits cells are stored in the `pending_deposits` field.

Thus, everytime we reset mem-pool, we use the same pending_deposits to construct next block, so we can get consistent state.

There are two refresh strategy of `pending_deposits`:

- safety refresh: when there are no new accounts created in the mem-pool, we are safe to re-collect the deposits cells from CKB. Because this would not change id of accounts.
- forced refresh: when a deposit is found unavailable in the CKB chain or it's already processed by the l2 block, we are forced to refresh the deposits. (Apply a l2 block with deposits causes forced refresh, but this still a safety operation since the deposits is consist between l2 block and mem-pool state).