### PR TITLE
doc: update rocksDB tuning

### DIFF
--- a/docs/rocksdb_tuning.md
+++ b/docs/rocksdb_tuning.md
@@ -16,14 +16,13 @@ keep_log_file_num=32
 
 [CFOptions "default"]
 level_compaction_dynamic_level_bytes=true
-write_buffer_size=8388608
+write_buffer_size=67108864
 min_write_buffer_number_to_merge=1
 max_write_buffer_number=2
 max_write_buffer_size_to_maintain=-1
 
 [TableOptions/BlockBasedTable "default"]
 pin_l0_filter_and_index_blocks_in_cache=true
-block_size=16384
 ```
 
 use db.toml in the godwoken config:


### PR DESCRIPTION
1. Remove the block size, use default value(4K). Tuning this value do not affect the performance of our program.
2. Increase `write_buffer_size` to 64M, in stress testing we see the error:

```
Transaction could not check for conflicts for operation at SequenceNumber 11871223343 as the MemTable only contains changes newer than SequenceNumber 11871336085.  Increasing the value of the max_write_buffer_size_to_maintain option could reduce the frequency of this error.
```

The `max_write_buffer_size_to_maintain ` is setting to -1, so RocksDB will tuning max write buffer to `write_buffer_size * max_write_buffer_number`.

We increase the write_buffer_size to avoid the error.