### PR TITLE
Fix pruning state

### DIFF
--- a/crates/replay-chain/src/main.rs
+++ b/crates/replay-chain/src/main.rs
@@ -1,4 +1,5 @@
 mod replay;
+mod setup;
 
 use replay::*;
 
@@ -6,6 +7,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::{App, Arg, SubCommand};
 use gw_config::Config;
 use gw_db::schema::COLUMNS;
+use setup::{setup, SetupArgs};
 use std::{fs, path::Path};
 
 const ARG_CONFIG: &str = "config";
@@ -51,6 +53,37 @@ fn run_cli() -> Result<()> {
                         .required(true),
                 )
                 .display_order(0),
+        )
+        .subcommand(
+            SubCommand::with_name("detach")
+                .about("Detach chain")
+                .arg(
+                    Arg::with_name(ARG_CONFIG)
+                        .short("c")
+                        .takes_value(true)
+                        .required(true)
+                        .default_value("./config.toml")
+                        .help("The config file path"),
+                )
+                .arg(
+                    Arg::with_name("from-db-store")
+                        .long("from-db-store")
+                        .takes_value(true)
+                        .required(true),
+                )
+                .arg(
+                    Arg::with_name("from-db-columns")
+                        .long("from-db-columns")
+                        .takes_value(true)
+                        .required(false),
+                )
+                .arg(
+                    Arg::with_name("to-db-store")
+                        .long("to-db-store")
+                        .takes_value(true)
+                        .required(true),
+                )
+                .display_order(0),
         );
 
     // handle subcommands
@@ -66,13 +99,33 @@ fn run_cli() -> Result<()> {
                 .transpose()?
                 .unwrap_or(COLUMNS);
             let to_db_store = m.value_of("to-db-store").unwrap().into();
-            let args = ReplayArgs {
+            let args = SetupArgs {
                 config,
                 from_db_store,
                 to_db_store,
                 from_db_columns,
             };
-            replay(args).expect("replay");
+            let context = setup(args).expect("setup");
+            replay_chain(context).expect("replay");
+        }
+        ("detach", Some(m)) => {
+            let config_path = m.value_of(ARG_CONFIG).unwrap();
+            let config = read_config(&config_path)?;
+            let from_db_store = m.value_of("from-db-store").unwrap().into();
+            let from_db_columns = m
+                .value_of("from-db-columns")
+                .map(|s| s.parse())
+                .transpose()?
+                .unwrap_or(COLUMNS);
+            let to_db_store = m.value_of("to-db-store").unwrap().into();
+            let args = SetupArgs {
+                config,
+                from_db_store,
+                to_db_store,
+                from_db_columns,
+            };
+            let context = setup(args).expect("setup");
+            detach_chain(context).expect("detach");
         }
         _ => {
             return Err(anyhow!("unknown command"));

--- a/crates/replay-chain/src/replay.rs
+++ b/crates/replay-chain/src/replay.rs
@@ -1,154 +1,21 @@
-use std::{convert::TryInto, path::PathBuf, sync::Arc, time::Instant};
+use std::{convert::TryInto, time::Instant};
 
-use anyhow::{anyhow, Context, Result};
-use async_jsonrpc_client::HttpClient;
-use ckb_types::{bytes::Bytes, prelude::Entity};
-use gw_chain::chain::Chain;
+use crate::setup::Context as ChainContext;
+use anyhow::{anyhow, Result};
 use gw_common::H256;
-use gw_config::{Config, StoreConfig};
-use gw_db::{schema::COLUMNS, RocksDB};
-use gw_generator::{
-    account_lock_manage::{
-        secp256k1::{Secp256k1Eth, Secp256k1Tron},
-        AccountLockManage,
-    },
-    backend_manage::BackendManage,
-    genesis::init_genesis,
-    Generator,
-};
-use gw_rpc_client::rpc_client::RPCClient;
-use gw_store::Store;
+use gw_store::state::state_db::StateContext;
 use gw_types::{
     core::ChallengeTargetType,
-    offchain::RollupContext,
-    packed::{Byte32, RollupConfig},
+    packed::Byte32,
     prelude::{Pack, Unpack},
 };
 
-pub struct ReplayArgs {
-    pub from_db_store: PathBuf,
-    pub from_db_columns: u32,
-    pub to_db_store: PathBuf,
-    pub config: Config,
-}
-
-pub fn replay(args: ReplayArgs) -> Result<()> {
-    let ReplayArgs {
-        from_db_store,
-        to_db_store,
-        config,
-        from_db_columns,
-    } = args;
-
-    let store_config = StoreConfig {
-        path: to_db_store,
-        options: config.store.options.clone(),
-        options_file: config.store.options_file.clone(),
-        cache_size: config.store.cache_size,
-    };
-    let local_store = Store::new(RocksDB::open(&store_config, COLUMNS));
-    let rollup_type_script = {
-        let script: gw_types::packed::Script = config.chain.rollup_type_script.clone().into();
-        script
-    };
-    let rollup_config: RollupConfig = config.genesis.rollup_config.clone().into();
-    let rollup_context = RollupContext {
-        rollup_config: rollup_config.clone(),
-        rollup_script_hash: {
-            let rollup_script_hash: [u8; 32] = config.genesis.rollup_type_hash.clone().into();
-            rollup_script_hash.into()
-        },
-    };
-    let secp_data: Bytes = {
-        let rpc_client = {
-            let indexer_client = HttpClient::new(config.rpc_client.indexer_url.to_owned())?;
-            let ckb_client = HttpClient::new(config.rpc_client.ckb_url.to_owned())?;
-            let rollup_type_script =
-                ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
-            RPCClient::new(
-                rollup_type_script,
-                rollup_context.clone(),
-                ckb_client,
-                indexer_client,
-            )
-        };
-        let out_point = config.genesis.secp_data_dep.out_point.clone();
-        smol::block_on(rpc_client.get_transaction(out_point.tx_hash.0.into()))?
-            .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?
-            .raw()
-            .outputs_data()
-            .get(out_point.index.value() as usize)
-            .expect("get secp output data")
-            .raw_data()
-    };
-
-    init_genesis(
-        &local_store,
-        &config.genesis,
-        config.chain.genesis_committed_info.clone().into(),
-        secp_data,
-    )
-    .with_context(|| "init genesis")?;
-    let generator = {
-        let backend_manage = BackendManage::from_config(config.backends.clone())
-            .with_context(|| "config backends")?;
-        let mut account_lock_manage = AccountLockManage::default();
-        let eth_lock_script_type_hash = rollup_config
-            .allowed_eoa_type_hashes()
-            .get(0)
-            .ok_or_else(|| anyhow!("Eth: No allowed EoA type hashes in the rollup config"))?;
-        account_lock_manage.register_lock_algorithm(
-            eth_lock_script_type_hash.unpack(),
-            Box::new(Secp256k1Eth::default()),
-        );
-        let tron_lock_script_type_hash = rollup_config.allowed_eoa_type_hashes().get(1);
-        if let Some(code_hash) = tron_lock_script_type_hash {
-            account_lock_manage
-                .register_lock_algorithm(code_hash.unpack(), Box::new(Secp256k1Tron::default()))
-        }
-        Arc::new(Generator::new(
-            backend_manage,
-            account_lock_manage,
-            rollup_context,
-            Some(config.rpc.clone()),
-        ))
-    };
-
-    let mut chain = Chain::create(
-        &rollup_config,
-        &rollup_type_script,
-        &config.chain,
-        local_store.clone(),
-        generator,
-        None,
-    )?;
-
-    let from_store = {
-        let store_config = StoreConfig {
-            path: from_db_store,
-            options: config.store.options.clone(),
-            options_file: config.store.options_file.clone(),
-            cache_size: config.store.cache_size,
-        };
-        Store::new(RocksDB::open(&store_config, from_db_columns))
-    };
-
-    println!(
-        "Skip blocks: {:?}",
-        config
-            .chain
-            .skipped_invalid_block_list
-            .iter()
-            .map(|hash| hash.to_string())
-            .collect::<Vec<_>>()
-    );
-
-    replay_chain(&mut chain, from_store, local_store)?;
-
-    Ok(())
-}
-
-pub fn replay_chain(chain: &mut Chain, from_store: Store, local_store: Store) -> Result<()> {
+pub fn replay_chain(ctx: ChainContext) -> Result<()> {
+    let ChainContext {
+        mut chain,
+        from_store,
+        local_store,
+    } = ctx;
     let tip = local_store.get_tip_block()?;
     let number = {
         let block_hash = from_store.get_block_hash_by_number(tip.raw().number().unpack())?;
@@ -227,8 +94,42 @@ pub fn replay_chain(chain: &mut Chain, from_store: Store, local_store: Store) ->
             db_commit_ms,
             load_block_ms
         );
+        local_store.check_state()?;
 
         replay_number += 1;
+    }
+    Ok(())
+}
+
+pub fn detach_chain(ctx: ChainContext) -> Result<()> {
+    let ChainContext {
+        chain: _,
+        from_store: _,
+        local_store,
+    } = ctx;
+    let tip = local_store.get_tip_block()?;
+    let mut number = tip.raw().number().unpack();
+    let hash: Byte32 = tip.hash().pack();
+    println!("Detach from block: #{} {}", number, hash);
+
+    // query next block
+    while number > 0 {
+        let db = local_store.begin_transaction();
+        let detach_block = {
+            let block_hash = db.get_block_hash_by_number(number)?.unwrap();
+            db.get_block(&block_hash)?.unwrap()
+        };
+        let hash: Byte32 = detach_block.hash().pack();
+        number = detach_block.raw().number().unpack();
+        println!("Detach block: #{} {}", number, hash);
+        db.detach_block(&detach_block)?;
+        {
+            let mut state = db.state_tree(StateContext::DetachBlock(number))?;
+            state.detach_block_state()?;
+        }
+        db.commit()?;
+        local_store.check_state()?;
+        number -= 1;
     }
     Ok(())
 }

--- a/crates/replay-chain/src/setup.rs
+++ b/crates/replay-chain/src/setup.rs
@@ -1,0 +1,151 @@
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::{anyhow, Context as AnyHowContext, Result};
+use async_jsonrpc_client::HttpClient;
+use ckb_types::{bytes::Bytes, prelude::Entity};
+use gw_chain::chain::Chain;
+use gw_config::{Config, StoreConfig};
+use gw_db::{schema::COLUMNS, RocksDB};
+use gw_generator::{
+    account_lock_manage::{
+        secp256k1::{Secp256k1Eth, Secp256k1Tron},
+        AccountLockManage,
+    },
+    backend_manage::BackendManage,
+    genesis::init_genesis,
+    Generator,
+};
+use gw_rpc_client::rpc_client::RPCClient;
+use gw_store::Store;
+use gw_types::{offchain::RollupContext, packed::RollupConfig, prelude::Unpack};
+
+pub struct SetupArgs {
+    pub from_db_store: PathBuf,
+    pub from_db_columns: u32,
+    pub to_db_store: PathBuf,
+    pub config: Config,
+}
+
+pub struct Context {
+    pub chain: Chain,
+    pub from_store: Store,
+    pub local_store: Store,
+}
+
+pub fn setup(args: SetupArgs) -> Result<Context> {
+    let SetupArgs {
+        from_db_store,
+        to_db_store,
+        config,
+        from_db_columns,
+    } = args;
+
+    let store_config = StoreConfig {
+        path: to_db_store,
+        options: config.store.options.clone(),
+        options_file: config.store.options_file.clone(),
+        cache_size: config.store.cache_size,
+    };
+    let local_store = Store::new(RocksDB::open(&store_config, COLUMNS));
+    let rollup_type_script = {
+        let script: gw_types::packed::Script = config.chain.rollup_type_script.clone().into();
+        script
+    };
+    let rollup_config: RollupConfig = config.genesis.rollup_config.clone().into();
+    let rollup_context = RollupContext {
+        rollup_config: rollup_config.clone(),
+        rollup_script_hash: {
+            let rollup_script_hash: [u8; 32] = config.genesis.rollup_type_hash.clone().into();
+            rollup_script_hash.into()
+        },
+    };
+    let secp_data: Bytes = {
+        let rpc_client = {
+            let indexer_client = HttpClient::new(config.rpc_client.indexer_url.to_owned())?;
+            let ckb_client = HttpClient::new(config.rpc_client.ckb_url.to_owned())?;
+            let rollup_type_script =
+                ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
+            RPCClient::new(
+                rollup_type_script,
+                rollup_context.clone(),
+                ckb_client,
+                indexer_client,
+            )
+        };
+        let out_point = config.genesis.secp_data_dep.out_point.clone();
+        smol::block_on(rpc_client.get_transaction(out_point.tx_hash.0.into()))?
+            .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?
+            .raw()
+            .outputs_data()
+            .get(out_point.index.value() as usize)
+            .expect("get secp output data")
+            .raw_data()
+    };
+
+    init_genesis(
+        &local_store,
+        &config.genesis,
+        config.chain.genesis_committed_info.clone().into(),
+        secp_data,
+    )
+    .with_context(|| "init genesis")?;
+    let generator = {
+        let backend_manage = BackendManage::from_config(config.backends.clone())
+            .with_context(|| "config backends")?;
+        let mut account_lock_manage = AccountLockManage::default();
+        let eth_lock_script_type_hash = rollup_config
+            .allowed_eoa_type_hashes()
+            .get(0)
+            .ok_or_else(|| anyhow!("Eth: No allowed EoA type hashes in the rollup config"))?;
+        account_lock_manage.register_lock_algorithm(
+            eth_lock_script_type_hash.unpack(),
+            Box::new(Secp256k1Eth::default()),
+        );
+        let tron_lock_script_type_hash = rollup_config.allowed_eoa_type_hashes().get(1);
+        if let Some(code_hash) = tron_lock_script_type_hash {
+            account_lock_manage
+                .register_lock_algorithm(code_hash.unpack(), Box::new(Secp256k1Tron::default()))
+        }
+        Arc::new(Generator::new(
+            backend_manage,
+            account_lock_manage,
+            rollup_context,
+            Some(config.rpc.clone()),
+        ))
+    };
+
+    let chain = Chain::create(
+        &rollup_config,
+        &rollup_type_script,
+        &config.chain,
+        local_store.clone(),
+        generator,
+        None,
+    )?;
+
+    let from_store = {
+        let store_config = StoreConfig {
+            path: from_db_store,
+            options: config.store.options.clone(),
+            options_file: config.store.options_file.clone(),
+            cache_size: config.store.cache_size,
+        };
+        Store::new(RocksDB::open(&store_config, from_db_columns))
+    };
+
+    println!(
+        "Skip blocks: {:?}",
+        config
+            .chain
+            .skipped_invalid_block_list
+            .iter()
+            .map(|hash| hash.to_string())
+            .collect::<Vec<_>>()
+    );
+
+    Ok(Context {
+        chain,
+        from_store,
+        local_store,
+    })
+}

--- a/crates/store/src/state/state_db.rs
+++ b/crates/store/src/state/state_db.rs
@@ -140,6 +140,14 @@ impl<'a> State for StateTree<'a> {
                 .unwrap_or_default(),
             _ => self.tree.get(key)?,
         };
+        {
+            let k: Byte32 = key.pack();
+            let v: Byte32 = v.pack();
+            println!(
+                "[state-trace] get_raw ctx:{:?} k:{} v:{}",
+                self.context, k, v
+            );
+        }
         Ok(v)
     }
 
@@ -159,15 +167,36 @@ impl<'a> State for StateTree<'a> {
                 panic!("wrong ctx: {:?}", ctx);
             }
         }
+        {
+            let k: Byte32 = key.pack();
+            let v: Byte32 = value.pack();
+            println!(
+                "[state-trace] update_raw ctx:{:?} k:{} v:{}",
+                self.context, k, v
+            );
+        }
         Ok(())
     }
 
     fn get_account_count(&self) -> Result<u32, StateError> {
+        {
+            println!(
+                "[state-trace] get_account_count ctx:{:?} count:{}",
+                self.context, self.account_count
+            );
+        }
         Ok(self.account_count)
     }
 
     fn set_account_count(&mut self, count: u32) -> Result<(), StateError> {
+        let origin_count = self.account_count;
         self.account_count = count;
+        {
+            println!(
+                "[state-trace] set_account_count ctx:{:?} origin: {} count:{}",
+                self.context, origin_count, self.account_count
+            );
+        }
         Ok(())
     }
 

--- a/crates/store/src/state/state_db.rs
+++ b/crates/store/src/state/state_db.rs
@@ -195,16 +195,15 @@ impl<'a> State for StateTree<'a> {
     }
 
     fn set_account_count(&mut self, count: u32) -> Result<(), StateError> {
-        let origin_count = self.account_count;
-        self.account_count = count;
         if log_enabled!(log::Level::Trace) {
             log::trace!(
                 "[state-trace] set_account_count ctx:{:?} origin: {} count:{}",
                 self.context,
-                origin_count,
-                self.account_count
+                self.account_count,
+                count
             );
         }
+        self.account_count = count;
         Ok(())
     }
 

--- a/crates/store/src/state/state_db.rs
+++ b/crates/store/src/state/state_db.rs
@@ -10,6 +10,7 @@ use gw_types::{
     packed::{self, AccountMerkleState, Byte32},
     prelude::*,
 };
+use log::log_enabled;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum StateContext {
     ReadOnly,
@@ -140,12 +141,14 @@ impl<'a> State for StateTree<'a> {
                 .unwrap_or_default(),
             _ => self.tree.get(key)?,
         };
-        {
+        if log_enabled!(log::Level::Trace) {
             let k: Byte32 = key.pack();
             let v: Byte32 = v.pack();
-            println!(
+            log::trace!(
                 "[state-trace] get_raw ctx:{:?} k:{} v:{}",
-                self.context, k, v
+                self.context,
+                k,
+                v
             );
         }
         Ok(v)
@@ -167,22 +170,25 @@ impl<'a> State for StateTree<'a> {
                 panic!("wrong ctx: {:?}", ctx);
             }
         }
-        {
+        if log_enabled!(log::Level::Trace) {
             let k: Byte32 = key.pack();
             let v: Byte32 = value.pack();
-            println!(
+            log::trace!(
                 "[state-trace] update_raw ctx:{:?} k:{} v:{}",
-                self.context, k, v
+                self.context,
+                k,
+                v
             );
         }
         Ok(())
     }
 
     fn get_account_count(&self) -> Result<u32, StateError> {
-        {
-            println!(
+        if log_enabled!(log::Level::Trace) {
+            log::trace!(
                 "[state-trace] get_account_count ctx:{:?} count:{}",
-                self.context, self.account_count
+                self.context,
+                self.account_count
             );
         }
         Ok(self.account_count)
@@ -191,10 +197,12 @@ impl<'a> State for StateTree<'a> {
     fn set_account_count(&mut self, count: u32) -> Result<(), StateError> {
         let origin_count = self.account_count;
         self.account_count = count;
-        {
-            println!(
+        if log_enabled!(log::Level::Trace) {
+            log::trace!(
                 "[state-trace] set_account_count ctx:{:?} origin: {} count:{}",
-                self.context, origin_count, self.account_count
+                self.context,
+                origin_count,
+                self.account_count
             );
         }
         Ok(())

--- a/crates/store/src/transaction/state.rs
+++ b/crates/store/src/transaction/state.rs
@@ -16,9 +16,6 @@ use crate::{
     traits::KVStore,
 };
 
-/// TODO use a variable instead of hardcode
-const NUMBER_OF_CONFIRMATION: u64 = 3600;
-
 impl StoreTransaction {
     pub fn account_smt_store(&self) -> Result<SMTStore<'_, Self>, Error> {
         let smt_store = SMTStore::new(COLUMN_ACCOUNT_SMT_LEAF, COLUMN_ACCOUNT_SMT_BRANCH, self);
@@ -79,17 +76,13 @@ impl StoreTransaction {
         )
     }
 
+    /// TODO implement this
     /// Prune finalized block state record
     /// The arg new_number is current block number
-    pub(crate) fn prune_finalized_block_state_record(&self, new_number: u64) -> Result<(), Error> {
-        if new_number <= NUMBER_OF_CONFIRMATION {
-            return Ok(());
-        }
-        let finalized_block_number = new_number - NUMBER_OF_CONFIRMATION - 1;
-        if finalized_block_number == 0 {
-            return Ok(());
-        }
-        self.remove_block_state_record(finalized_block_number)
+    pub(crate) fn prune_finalized_block_state_record(&self, _new_number: u64) -> Result<(), Error> {
+        // this function is a placeholder for now
+        // we should prune unused block state record and save them into a state snapshot
+        Ok(())
     }
 
     pub(crate) fn remove_block_state_record(&self, block_number: u64) -> Result<(), Error> {

--- a/crates/store/src/transaction/state.rs
+++ b/crates/store/src/transaction/state.rs
@@ -43,7 +43,7 @@ impl StoreTransaction {
                 self.get_block(&block_hash)?
                     .ok_or_else(|| "can't find block".to_string())?
             }
-            _ => self.get_tip_block()?,
+            _ => self.get_last_valid_tip_block()?,
         };
         let merkle_state = block.raw().post_account();
         let account_count = merkle_state.count().unpack();


### PR DESCRIPTION
Current pruning implementation is wrong!

When detaching a block, we try to find a old key-value and apply it, but if the old key-value is inserted before 3600 blocks, it will be pruned, so we can't find it.

The correct implementation is to store pruned key-values in a mirror state and try to read old state from the mirror if it donot exist in the last 3600 blocks.

In this PR we simply remove the wrong implementation of the pruning.

* Remove pruning
* Add a new command `detach` to replay-chain cli, to help us debugging these issues.
* Fix state_tree method, use `last_valid_tip_block` to instead `tip_block`. 