### PR TITLE
backport: Stat custodian cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ name = "gw-tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-jsonrpc-client",
  "bech32",
  "ckb-crypto 0.100.0",
  "ckb-fixed-hash 0.100.0",

--- a/crates/rpc-client/src/indexer_client.rs
+++ b/crates/rpc-client/src/indexer_client.rs
@@ -1,11 +1,12 @@
 #![allow(clippy::mutable_key_type)]
 
-use crate::indexer_types::{Cell, Order, Pagination, ScriptType, SearchKey};
+use crate::indexer_types::{Cell, Order, Pagination, ScriptType, SearchKey, SearchKeyFilter};
 use crate::utils::{to_result, DEFAULT_QUERY_LIMIT};
 use anyhow::{anyhow, Result};
 use async_jsonrpc_client::{HttpClient, Params as ClientParams, Transport};
 use ckb_types::prelude::Entity;
 use gw_jsonrpc_types::ckb_jsonrpc_types::Uint32;
+use gw_types::offchain::CustodianStat;
 use gw_types::{
     offchain::CellInfo,
     packed::{CellOutput, OutPoint, Script},
@@ -115,19 +116,30 @@ impl CKBIndexerClient {
         Ok(collected_cells)
     }
 
-    pub async fn query_custodian_ckb(&self, lock: Script) -> Result<u128> {
+    pub async fn query_custodian_ckb(
+        &self,
+        lock: Script,
+        min_capacity: Option<u64>,
+    ) -> Result<CustodianStat> {
+        let filter = min_capacity.map(|min_capacity| SearchKeyFilter {
+            output_capacity_range: Some([min_capacity.into(), u64::MAX.into()]),
+            script: None,
+            block_range: None,
+            output_data_len_range: None,
+        });
         let search_key = SearchKey {
             script: {
                 let lock = ckb_types::packed::Script::new_unchecked(lock.as_bytes());
                 lock.into()
             },
             script_type: ScriptType::Lock,
-            filter: None,
+            filter,
         };
         let order = Order::Desc;
         let limit = Uint32::from(DEFAULT_QUERY_LIMIT as u32);
 
         let mut total_capacity = 0u128;
+        let mut cells_count = 0;
         let mut cursor = None;
         loop {
             let cells: Pagination<Cell> = to_result(
@@ -149,11 +161,15 @@ impl CKBIndexerClient {
             }
             cursor = Some(cells.last_cursor);
 
+            cells_count += cells.objects.len();
             for cell in cells.objects.into_iter() {
                 let capacity: u64 = cell.output.capacity.into();
                 total_capacity += capacity as u128;
             }
         }
-        Ok(total_capacity)
+        Ok(CustodianStat {
+            cells_count,
+            total_capacity,
+        })
     }
 }

--- a/crates/rpc-client/src/utils.rs
+++ b/crates/rpc-client/src/utils.rs
@@ -3,7 +3,7 @@ use gw_common::H256;
 use serde::de::DeserializeOwned;
 use serde_json::from_value;
 
-pub(crate) const DEFAULT_QUERY_LIMIT: usize = 1000;
+pub(crate) const DEFAULT_QUERY_LIMIT: usize = 500;
 
 lazy_static::lazy_static! {
     /// CKB built-in type ID code hash

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -35,6 +35,7 @@ gw-generator = { path = "../generator" }
 gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-utils = { path = "../utils" }
 gw-rpc-client = { path = "../rpc-client" }
+async-jsonrpc-client = { version = "0.3.0", default-features = false, features = ["http-async-std"] }
 url = "2.2"
 faster-hex = "0.5.0"
 rand = "0.8"

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -726,6 +726,13 @@ fn run_cli() -> Result<()> {
                         .required(true)
                         .help("Custodian script type hash"),
                 )
+                .arg(
+                    Arg::with_name("min-capacity")
+                        .long("min-capacity")
+                        .takes_value(true)
+                        .default_value("0")
+                        .help("Query cells with min capacity(shannon)"),
+                )
         );
 
     let matches = app.clone().get_matches();
@@ -1204,17 +1211,20 @@ fn run_cli() -> Result<()> {
             let rollup_type_hash = cli_args::to_h256(m.value_of("rollup-type-hash").unwrap())?;
             let custodian_script_type_hash =
                 cli_args::to_h256(m.value_of("custodian-script-type-hash").unwrap())?;
+            let min_capacity: u64 = m.value_of("min-capacity").unwrap_or_default().parse()?;
             let rpc_client = CKBIndexerClient::new(HttpClient::new(indexer_rpc_url)?);
 
-            let total_capacity = stat::query_custodian_ckb(
+            let stat = stat::query_custodian_ckb(
                 &rpc_client,
                 &rollup_type_hash.into(),
                 &custodian_script_type_hash.into(),
+                Some(min_capacity),
             )?;
 
-            let ckb = total_capacity / ONE_CKB as u128;
-            let shannon = total_capacity - (ckb * ONE_CKB as u128);
-            log::debug!("Total capacity: {}", total_capacity);
+            let ckb = stat.total_capacity / ONE_CKB as u128;
+            let shannon = stat.total_capacity - (ckb * ONE_CKB as u128);
+            log::debug!("Cells count: {}", stat.cells_count);
+            log::debug!("Total capacity: {}", stat.total_capacity);
             println!("Total custodian: {}.{:0>8} CKB", ckb, shannon);
         }
         _ => {

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -12,6 +12,7 @@ mod hasher;
 mod polyjuice;
 mod prepare_scripts;
 mod setup;
+mod stat;
 mod transfer;
 pub(crate) mod types;
 mod update_cell;
@@ -19,11 +20,14 @@ mod utils;
 mod withdraw;
 
 use anyhow::Result;
+use async_jsonrpc_client::HttpClient;
+use ckb_sdk::constants::ONE_CKB;
 use clap::{value_t, App, Arg, SubCommand};
 use deploy_genesis::DeployRollupCellArgs;
 use dump_tx::ChallengeBlock;
 use generate_config::GenerateNodeConfigArgs;
 use gw_jsonrpc_types::godwoken::ChallengeTargetType;
+use gw_rpc_client::indexer_client::CKBIndexerClient;
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -703,6 +707,25 @@ fn run_cli() -> Result<()> {
                         .required(true)
                         .help("output file"),
                 ),
+        )
+        .subcommand(
+            SubCommand::with_name("stat-custodian-ckb")
+                .about("Output amount of layer2 custodian CKB")
+                .arg(arg_indexer_rpc.clone())
+                .arg(
+                    Arg::with_name("rollup-type-hash")
+                        .long("rollup-type-hash")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Rollup type hash"),
+                )
+                .arg(
+                    Arg::with_name("custodian-script-type-hash")
+                        .long("custodian-script-type-hash")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Custodian script type hash"),
+                )
         );
 
     let matches = app.clone().get_matches();
@@ -1175,6 +1198,24 @@ fn run_cli() -> Result<()> {
                 log::error!("Dump offchain cancel challenge tx: {}", err);
                 std::process::exit(-1);
             };
+        }
+        ("stat-custodian-ckb", Some(m)) => {
+            let indexer_rpc_url = m.value_of("indexer-rpc-url").unwrap();
+            let rollup_type_hash = cli_args::to_h256(m.value_of("rollup-type-hash").unwrap())?;
+            let custodian_script_type_hash =
+                cli_args::to_h256(m.value_of("custodian-script-type-hash").unwrap())?;
+            let rpc_client = CKBIndexerClient::new(HttpClient::new(indexer_rpc_url)?);
+
+            let total_capacity = stat::query_custodian_ckb(
+                &rpc_client,
+                &rollup_type_hash.into(),
+                &custodian_script_type_hash.into(),
+            )?;
+
+            let ckb = total_capacity / ONE_CKB as u128;
+            let shannon = total_capacity - (ckb * ONE_CKB as u128);
+            log::debug!("Total capacity: {}", total_capacity);
+            println!("Total custodian: {}.{:0>8} CKB", ckb, shannon);
         }
         _ => {
             app.print_help().expect("print help");

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::mutable_key_type)]
+
 mod account;
 mod address;
 mod create_creator_account;
@@ -22,6 +24,7 @@ mod withdraw;
 use anyhow::Result;
 use async_jsonrpc_client::HttpClient;
 use ckb_sdk::constants::ONE_CKB;
+use ckb_types::prelude::Unpack;
 use clap::{value_t, App, Arg, SubCommand};
 use deploy_genesis::DeployRollupCellArgs;
 use dump_tx::ChallengeBlock;
@@ -29,6 +32,7 @@ use generate_config::GenerateNodeConfigArgs;
 use gw_jsonrpc_types::godwoken::ChallengeTargetType;
 use gw_rpc_client::indexer_client::CKBIndexerClient;
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -1214,7 +1218,34 @@ fn run_cli() -> Result<()> {
             let min_capacity: u64 = m.value_of("min-capacity").unwrap_or_default().parse()?;
             let rpc_client = CKBIndexerClient::new(HttpClient::new(indexer_rpc_url)?);
 
-            let stat = stat::query_custodian_ckb(
+            let alias: HashMap<ckb_types::bytes::Bytes, String> = [
+                (
+                    "USDC",
+                    "5c4ac961a2428137f27271cf2af205e5c55156d26d9ac285ed3170e8c4cc1501",
+                ),
+                (
+                    "TAI",
+                    "08430183dda1cbd81912c4762a3006a59e2291d5bd43b48bb7fa7544cace9e4a",
+                ),
+                (
+                    "ETH",
+                    "9657b32fcdc463e13ec9205914fd91c443822a949937ae94add9869e7f2e1de8",
+                ),
+                (
+                    "dCKB",
+                    "e5451c05231e1df43e4b199b5d12dbed820dfbea2769943bb593f874526eeb55",
+                ),
+            ]
+            .iter()
+            .map(|(symbol, script_args)| {
+                (
+                    hex::decode(&script_args).unwrap().into(),
+                    symbol.to_string(),
+                )
+            })
+            .collect();
+
+            let stat = stat::stat_custodian_cells(
                 &rpc_client,
                 &rollup_type_hash.into(),
                 &custodian_script_type_hash.into(),
@@ -1223,9 +1254,24 @@ fn run_cli() -> Result<()> {
 
             let ckb = stat.total_capacity / ONE_CKB as u128;
             let shannon = stat.total_capacity - (ckb * ONE_CKB as u128);
-            log::debug!("Cells count: {}", stat.cells_count);
-            log::debug!("Total capacity: {}", stat.total_capacity);
+            println!("Cells count: {}", stat.cells_count);
             println!("Total custodian: {}.{:0>8} CKB", ckb, shannon);
+            if !stat.sudt_total_amount.is_empty() {
+                println!("========================================");
+            }
+            for (sudt_script, sudt_amount) in stat.sudt_total_amount {
+                let sudt_args: ckb_types::bytes::Bytes = sudt_script.args().unpack();
+                let alias_name = alias
+                    .get(&sudt_args)
+                    .cloned()
+                    .unwrap_or_else(|| "Unknown".to_string());
+                println!(
+                    "Simple UDT ({} {}) amount: {}",
+                    alias_name,
+                    sudt_script.args(),
+                    sudt_amount
+                );
+            }
         }
         _ => {
             app.print_help().expect("print help");

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -1224,6 +1224,10 @@ fn run_cli() -> Result<()> {
                     "5c4ac961a2428137f27271cf2af205e5c55156d26d9ac285ed3170e8c4cc1501",
                 ),
                 (
+                    "USDT",
+                    "1b89ae72b96c4f02fa7667ab46febcedf9b495737752176303ddd215d66a615a",
+                ),
+                (
                     "TAI",
                     "08430183dda1cbd81912c4762a3006a59e2291d5bd43b48bb7fa7544cace9e4a",
                 ),
@@ -1256,20 +1260,22 @@ fn run_cli() -> Result<()> {
             let shannon = stat.total_capacity - (ckb * ONE_CKB as u128);
             println!("Cells count: {}", stat.cells_count);
             println!("Total custodian: {}.{:0>8} CKB", ckb, shannon);
-            if !stat.sudt_total_amount.is_empty() {
+            println!("CKB cells count: {}", stat.ckb_cells_count);
+            if !stat.sudt_stat.is_empty() {
                 println!("========================================");
             }
-            for (sudt_script, sudt_amount) in stat.sudt_total_amount {
+            for (sudt_script, sudt_stat) in stat.sudt_stat {
                 let sudt_args: ckb_types::bytes::Bytes = sudt_script.args().unpack();
                 let alias_name = alias
                     .get(&sudt_args)
                     .cloned()
                     .unwrap_or_else(|| "Unknown".to_string());
                 println!(
-                    "Simple UDT ({} {}) amount: {}",
+                    "Simple UDT ({} {}) amount: {} cells count: {}",
                     alias_name,
                     sudt_script.args(),
-                    sudt_amount
+                    sudt_stat.amount,
+                    sudt_stat.cells_count,
                 );
             }
         }

--- a/crates/tools/src/stat/mod.rs
+++ b/crates/tools/src/stat/mod.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use ckb_types::prelude::{Builder, Entity};
+use gw_common::H256;
+use gw_rpc_client::indexer_client::CKBIndexerClient;
+use gw_types::{core::ScriptHashType, packed::Script, prelude::Pack};
+
+/// Query custodian ckb from ckb-indexer
+pub fn query_custodian_ckb(
+    rpc_client: &CKBIndexerClient,
+    rollup_type_hash: &H256,
+    custodian_script_type_hash: &H256,
+) -> Result<u128> {
+    let script = Script::new_builder()
+        .code_hash(custodian_script_type_hash.pack())
+        .hash_type(ScriptHashType::Type.into())
+        .args(rollup_type_hash.as_slice().to_vec().pack())
+        .build();
+    smol::block_on(rpc_client.query_custodian_ckb(script))
+}

--- a/crates/tools/src/stat/mod.rs
+++ b/crates/tools/src/stat/mod.rs
@@ -5,7 +5,7 @@ use gw_rpc_client::indexer_client::CKBIndexerClient;
 use gw_types::{core::ScriptHashType, offchain::CustodianStat, packed::Script, prelude::Pack};
 
 /// Query custodian ckb from ckb-indexer
-pub fn query_custodian_ckb(
+pub fn stat_custodian_cells(
     rpc_client: &CKBIndexerClient,
     rollup_type_hash: &H256,
     custodian_script_type_hash: &H256,
@@ -16,5 +16,5 @@ pub fn query_custodian_ckb(
         .hash_type(ScriptHashType::Type.into())
         .args(rollup_type_hash.as_slice().to_vec().pack())
         .build();
-    smol::block_on(rpc_client.query_custodian_ckb(script, min_capacity))
+    smol::block_on(rpc_client.stat_custodian_cells(script, min_capacity))
 }

--- a/crates/tools/src/stat/mod.rs
+++ b/crates/tools/src/stat/mod.rs
@@ -10,11 +10,16 @@ pub fn stat_custodian_cells(
     rollup_type_hash: &H256,
     custodian_script_type_hash: &H256,
     min_capacity: Option<u64>,
+    last_finalized_block_number: u64,
 ) -> Result<CustodianStat> {
     let script = Script::new_builder()
         .code_hash(custodian_script_type_hash.pack())
         .hash_type(ScriptHashType::Type.into())
         .args(rollup_type_hash.as_slice().to_vec().pack())
         .build();
-    smol::block_on(rpc_client.stat_custodian_cells(script, min_capacity))
+    smol::block_on(rpc_client.stat_custodian_cells(
+        script,
+        min_capacity,
+        last_finalized_block_number,
+    ))
 }

--- a/crates/tools/src/stat/mod.rs
+++ b/crates/tools/src/stat/mod.rs
@@ -2,18 +2,19 @@ use anyhow::Result;
 use ckb_types::prelude::{Builder, Entity};
 use gw_common::H256;
 use gw_rpc_client::indexer_client::CKBIndexerClient;
-use gw_types::{core::ScriptHashType, packed::Script, prelude::Pack};
+use gw_types::{core::ScriptHashType, offchain::CustodianStat, packed::Script, prelude::Pack};
 
 /// Query custodian ckb from ckb-indexer
 pub fn query_custodian_ckb(
     rpc_client: &CKBIndexerClient,
     rollup_type_hash: &H256,
     custodian_script_type_hash: &H256,
-) -> Result<u128> {
+    min_capacity: Option<u64>,
+) -> Result<CustodianStat> {
     let script = Script::new_builder()
         .code_hash(custodian_script_type_hash.pack())
         .hash_type(ScriptHashType::Type.into())
         .args(rollup_type_hash.as_slice().to_vec().pack())
         .build();
-    smol::block_on(rpc_client.query_custodian_ckb(script))
+    smol::block_on(rpc_client.query_custodian_ckb(script, min_capacity))
 }

--- a/crates/types/src/offchain/rpc.rs
+++ b/crates/types/src/offchain/rpc.rs
@@ -85,9 +85,16 @@ pub struct DepositInfo {
     pub cell: CellInfo,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct SUDTStat {
+    pub amount: u128,
+    pub cells_count: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct CustodianStat {
     pub total_capacity: u128,
     pub cells_count: usize,
-    pub sudt_total_amount: HashMap<ckb_types::packed::Script, u128>,
+    pub ckb_cells_count: usize,
+    pub sudt_stat: HashMap<ckb_types::packed::Script, SUDTStat>,
 }

--- a/crates/types/src/offchain/rpc.rs
+++ b/crates/types/src/offchain/rpc.rs
@@ -89,4 +89,5 @@ pub struct DepositInfo {
 pub struct CustodianStat {
     pub total_capacity: u128,
     pub cells_count: usize,
+    pub sudt_total_amount: HashMap<ckb_types::packed::Script, u128>,
 }

--- a/crates/types/src/offchain/rpc.rs
+++ b/crates/types/src/offchain/rpc.rs
@@ -84,3 +84,9 @@ pub struct DepositInfo {
     pub request: DepositRequest,
     pub cell: CellInfo,
 }
+
+#[derive(Debug, Clone)]
+pub struct CustodianStat {
+    pub total_capacity: u128,
+    pub cells_count: usize,
+}

--- a/crates/types/src/offchain/rpc.rs
+++ b/crates/types/src/offchain/rpc.rs
@@ -87,13 +87,15 @@ pub struct DepositInfo {
 
 #[derive(Debug, Clone, Default)]
 pub struct SUDTStat {
-    pub amount: u128,
+    pub total_amount: u128,
+    pub finalized_amount: u128,
     pub cells_count: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct CustodianStat {
     pub total_capacity: u128,
+    pub finalized_capacity: u128,
     pub cells_count: usize,
     pub ckb_cells_count: usize,
     pub sudt_stat: HashMap<ckb_types::packed::Script, SUDTStat>,


### PR DESCRIPTION
Example, query mainnet custodian CKB:

gw-tools stat-custodian-ckb --rollup-type-hash 0x40d73f0d3c561fcaae330eabc030d8d96a9d0af36d0c5114883658a350cb9e3b --custodian-script-type-hash 0x45c112df97daece27c4afa02b24b15f64403bdfd45ab2e0e88c9fb2a24796b1d --ckb-indexer-rpc https://mainnet.ckbapp.dev/indexer