### PR TITLE
Support AotCompilingMachine in generator

### DIFF
--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -60,3 +60,4 @@ tikv-jemallocator = { version = "0.4.0", features = ["unprefixed_malloc_on_suppo
 [features]
 default = []
 profiling = ["tikv-jemallocator/profiling"]
+aot-vm = ["gw-generator/aot"]

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 default = ["detect-asm"]
 detect-asm = ["ckb-vm/detect-asm"]
 enable-always-success-lock = []
+aot = ["detect-asm"]
 
 [dependencies]
 gw-types = { path = "../types" }

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -1,6 +1,4 @@
 use anyhow::Result;
-#[cfg(has_asm)]
-#[cfg(feature = "aot")]
 use ckb_vm::machine::aot::AotCode;
 use gw_common::H256;
 use gw_config::{BackendConfig, BackendType};

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -10,7 +10,7 @@ use crate::{
     erc20_creator_allowlist::SUDTProxyAccountAllowlist,
     error::{BlockError, TransactionValidateError, WithdrawalError},
     vm_cost_model::instruction_cycles,
-    Machine, VMVersion,
+    VMVersion,
 };
 use crate::{
     backend_manage::Backend,
@@ -45,9 +45,6 @@ use gw_types::{
 };
 
 use ckb_vm::{DefaultMachineBuilder, SupportMachine};
-
-#[cfg(has_asm)]
-use ckb_vm::machine::asm::AsmMachine;
 
 #[cfg(not(has_asm))]
 use ckb_vm::TraceMachine;
@@ -125,42 +122,86 @@ impl Generator {
         &self.account_lock_manage
     }
 
-    fn build_machine<'a, S: State + CodeStore, C: ChainStore>(
+    fn machine_run<'a, S: State + CodeStore, C: ChainStore>(
         &'a self,
-        run_result: &'a mut RunResult,
         chain: &'a C,
         state: &'a S,
         block_info: &'a BlockInfo,
         raw_tx: &'a RawL2Transaction,
         max_cycles: u64,
-    ) -> Machine<'a> {
-        let global_vm_version = smol::block_on(async { *GLOBAL_VM_VERSION.lock().await });
-        let vm_version = match global_vm_version {
-            0 => VMVersion::V0,
-            1 => VMVersion::V1,
-            ver => panic!("Unsupport VMVersion: {}", ver),
-        };
-        let core_machine = vm_version.init_core_machine(max_cycles);
-        let machine_builder = DefaultMachineBuilder::new(core_machine)
-            .syscall(Box::new(L2Syscalls {
-                chain,
-                state,
-                block_info,
-                raw_tx,
-                rollup_context: &self.rollup_context,
-                account_lock_manage: &self.account_lock_manage,
-                result: run_result,
-                code_store: state,
-            }))
-            .instruction_cycle_func(Box::new(instruction_cycles));
-        let default_machine = machine_builder.build();
+        code_bytes: Bytes,
+    ) -> Result<RunResult, TransactionError> {
+        let mut run_result = RunResult::default();
+        let used_cycles;
+        let exit_code;
 
-        #[cfg(has_asm)]
-        let machine = AsmMachine::new(default_machine, None);
-        #[cfg(not(has_asm))]
-        let machine = TraceMachine::new(default_machine);
+        {
+            let t = Instant::now();
+            let global_vm_version = smol::block_on(async { *GLOBAL_VM_VERSION.lock().await });
+            let vm_version = match global_vm_version {
+                0 => VMVersion::V0,
+                1 => VMVersion::V1,
+                ver => panic!("Unsupport VMVersion: {}", ver),
+            };
+            let core_machine = vm_version.init_core_machine(max_cycles);
+            let machine_builder = DefaultMachineBuilder::new(core_machine)
+                .syscall(Box::new(L2Syscalls {
+                    chain,
+                    state,
+                    block_info,
+                    raw_tx,
+                    rollup_context: &self.rollup_context,
+                    account_lock_manage: &self.account_lock_manage,
+                    result: &mut run_result,
+                    code_store: state,
+                }))
+                .instruction_cycle_func(Box::new(instruction_cycles));
+            let default_machine = machine_builder.build();
 
-        machine
+            #[cfg(has_asm)]
+            #[cfg(feature = "aot")]
+            let aot_code = {
+                let mut aot_machine = ckb_vm::machine::aot::AotCompilingMachine::load(
+                    &code_bytes,
+                    Some(Box::new(instruction_cycles)),
+                    vm_version.vm_isa(),
+                    vm_version.vm_version(),
+                )?;
+                aot_machine.compile()?
+            };
+            // TODO: cache the compiled aot_code
+            log::debug!(
+                "[execute tx] AotCompilingMachine::load time: {}ms",
+                t.elapsed().as_millis()
+            );
+
+            #[cfg(has_asm)]
+            #[cfg(feature = "aot")]
+            let mut machine =
+                ckb_vm::machine::asm::AsmMachine::new(default_machine, Some(&aot_code));
+
+            #[cfg(has_asm)]
+            #[cfg(not(feature = "aot"))]
+            let mut machine = ckb_vm::machine::asm::AsmMachine::new(default_machine, None);
+
+            #[cfg(not(has_asm))]
+            let machine = TraceMachine::new(default_machine);
+
+            machine.load_program(&code_bytes, &[])?;
+            exit_code = machine.run()?;
+            used_cycles = machine.machine.cycles();
+
+            log::debug!(
+                "[execute tx] VM machine_run time: {}ms, exit code: {} used_cycles: {}",
+                t.elapsed().as_millis(),
+                exit_code,
+                used_cycles
+            );
+        }
+        run_result.used_cycles = used_cycles;
+        run_result.exit_code = exit_code;
+
+        Ok(run_result)
     }
 
     /// Verify withdrawal request
@@ -684,40 +725,21 @@ impl Generator {
         let sender_id: u32 = raw_tx.from_id().unpack();
         let nonce_before_execution = state.get_nonce(sender_id)?;
 
-        let mut run_result = RunResult::default();
-        let used_cycles;
-        let exit_code;
-        {
-            let mut machine = self.build_machine(
-                &mut run_result,
-                chain,
-                state,
-                block_info,
-                raw_tx,
-                max_cycles,
-            );
-            let account_id = raw_tx.to_id().unpack();
-            let script_hash = state.get_script_hash(account_id)?;
-            let backend = self
-                .load_backend(state, &script_hash)
-                .ok_or(TransactionError::BackendNotFound { script_hash })?;
-            machine.load_program(&backend.generator, &[])?;
-            let t = Instant::now();
-            exit_code = machine.run()?;
-            used_cycles = machine.machine.cycles();
-            log::debug!(
-                "[execute tx] VM run time: {}ms, exit code: {} used_cycles: {} backend: {:?}",
-                t.elapsed().as_millis(),
-                exit_code,
-                used_cycles,
-                backend.backend_type
-            );
-        }
-        // record used cycles
-        run_result.used_cycles = used_cycles;
-        run_result.exit_code = exit_code;
+        let account_id = raw_tx.to_id().unpack();
+        let script_hash = state.get_script_hash(account_id)?;
+        let backend = self
+            .load_backend(state, &script_hash)
+            .ok_or(TransactionError::BackendNotFound { script_hash })?;
+        let run_result: RunResult = self.machine_run(
+            chain,
+            state,
+            block_info,
+            raw_tx,
+            max_cycles,
+            backend.generator,
+        )?;
 
-        if 0 == exit_code {
+        if 0 == run_result.exit_code {
             // check nonce is increased by backends
             let nonce_after_execution = {
                 let nonce_raw_key = build_account_field_key(sender_id, GW_ACCOUNT_NONCE_TYPE);

--- a/crates/generator/src/types.rs
+++ b/crates/generator/src/types.rs
@@ -6,7 +6,7 @@ use gw_types::packed::{ChallengeTarget, ChallengeWitness};
 use std::fmt::{self, Display};
 
 #[cfg(has_asm)]
-use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
+use ckb_vm::machine::asm::AsmCoreMachine;
 
 #[cfg(not(has_asm))]
 use ckb_vm::{DefaultCoreMachine, SparseMemory, TraceMachine, WXorXMemory};
@@ -74,8 +74,8 @@ impl VMVersion {
     }
 }
 
-#[cfg(has_asm)]
-pub(crate) type Machine<'a> = AsmMachine<'a>;
+// #[cfg(has_asm)]
+// pub(crate) type Machine<'a> = AsmMachine<'a>;
 #[cfg(not(has_asm))]
 pub(crate) type Machine<'a> = TraceMachine<'a, CoreMachine>;
 

--- a/crates/generator/src/types.rs
+++ b/crates/generator/src/types.rs
@@ -6,7 +6,7 @@ use gw_types::packed::{ChallengeTarget, ChallengeWitness};
 use std::fmt::{self, Display};
 
 #[cfg(has_asm)]
-use ckb_vm::machine::asm::AsmCoreMachine;
+use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 
 #[cfg(not(has_asm))]
 use ckb_vm::{DefaultCoreMachine, SparseMemory, TraceMachine, WXorXMemory};
@@ -74,8 +74,9 @@ impl VMVersion {
     }
 }
 
-// #[cfg(has_asm)]
-// pub(crate) type Machine<'a> = AsmMachine<'a>;
+#[allow(dead_code)]
+#[cfg(has_asm)]
+pub(crate) type Machine<'a> = AsmMachine<'a>;
 #[cfg(not(has_asm))]
 pub(crate) type Machine<'a> = TraceMachine<'a, CoreMachine>;
 


### PR DESCRIPTION
- Use Ahead-of-time compilation mode(AOT mode) of CKB-VM in generator crate
   Build godwoken with this command to enable AOT mode
   `cargo build --release --features aot-vm`

```TOML
# crates/block-producer/Cargo.toml
[features]
aot-vm = ["gw-generator/aot"]

# crates/generator/Cargo.toml
[features]
default = ["detect-asm"]
detect-asm = ["ckb-vm/detect-asm"]
enable-always-success-lock = []
aot = ["detect-asm"]
```
- Cache the AOT codes of generators in `BackendManage`


## Benchmark

```
# https://github.com/nervosnetwork/ckb-vm/releases/tag/0.20.0-rc5
> cargo bench --features detect-asm

asm_benchmark   time:   [4.1360 ms 4.1392 ms 4.1426 ms]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

---

aot_benchmark     time:   [1.3947 ms 1.3957 ms 1.3967 ms]                                 
Found 16 outliers among 100 measurements (16.00%)
  7 (7.00%) high mild
  9 (9.00%) high severe
```