### PR TITLE
feat(db): add db version and migrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "ckb-rocksdb",
  "gw-config",
  "libc",
+ "log",
  "serde",
  "tempfile",
  "thiserror",

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -10,7 +10,7 @@ use gw_challenge::offchain::OffChainMockContext;
 use gw_ckb_hardfork::{GLOBAL_CURRENT_EPOCH_NUMBER, GLOBAL_HARDFORK_SWITCH, GLOBAL_VM_VERSION};
 use gw_common::{blake2b::new_blake2b, H256};
 use gw_config::{BlockProducerConfig, Config, NodeMode};
-use gw_db::{schema::COLUMNS, RocksDB};
+use gw_db::migrate::open_or_create_db;
 use gw_generator::{
     account_lock_manage::{
         secp256k1::{Secp256k1Eth, Secp256k1Tron},
@@ -281,7 +281,7 @@ impl BaseInitComponents {
             log::warn!("config.store.path is blank, using temporary store");
             Store::open_tmp().with_context(|| "init store")?
         } else {
-            Store::new(RocksDB::open(&config.store, COLUMNS))
+            Store::new(open_or_create_db(&config.store)?)
         };
         let elapsed_ms = timer.elapsed().as_millis();
         log::debug!("Open rocksdb costs: {}ms.", elapsed_ms);

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -12,4 +12,8 @@ gw-config = { path = "../config" }
 libc = "0.2"
 thiserror = "1.0"
 tempfile = "3.0"
+log = "0.4.14"
 serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -2,6 +2,8 @@ pub mod db;
 pub mod error;
 pub mod iter;
 pub mod memory_stats;
+pub mod migrate;
+pub mod read_only_db;
 pub mod schema;
 pub mod snapshot;
 pub mod transaction;

--- a/crates/db/src/migrate.rs
+++ b/crates/db/src/migrate.rs
@@ -1,0 +1,223 @@
+// This mod is used to init a db version when the db version is absent at the first time.
+// And check present db version is still compatible. Godwoken must run on a valid db.
+// If godwoken with an advanced verion runs on an old db, this is the time we can run migrations.
+use crate::{
+    error::Error,
+    read_only_db::{self, ReadOnlyDB},
+    schema::{COLUMN_META, META_TIP_BLOCK_HASH_KEY},
+    Result,
+};
+use std::{cmp::Ordering, collections::BTreeMap};
+
+use gw_config::StoreConfig;
+
+use crate::{
+    schema::{COLUMNS, MIGRATION_VERSION_KEY},
+    RocksDB,
+};
+
+pub fn open_or_create_db(config: &StoreConfig) -> Result<RocksDB> {
+    let read_only_db =
+        read_only_db::ReadOnlyDB::open_cf(&config.path, vec![COLUMN_META.to_string()])?;
+    let factory = init_migration_factory();
+    if let Some(db) = read_only_db {
+        match check_readonly_db_version(&db, factory.last_db_version())? {
+            Ordering::Greater => {
+                eprintln!(
+                    "The database is created by a higher version executable binary, \n\
+                     so that the current executable binary couldn't open this database.\n\
+                     Please download the latest executable binary."
+                );
+                Err(Error {
+                    message: "The database is created by a higher version executable binary"
+                        .to_string(),
+                })
+            }
+            Ordering::Equal => Ok(RocksDB::open(config, COLUMNS)),
+            Ordering::Less => {
+                log::info!("process fast migrations ...");
+                // TODO: Currently, there is only one migration: Add db version.
+                // So we can add db version by running default migration here.
+                // We should stop the process if we have more migrations and use **migration** command to run migration instead.
+                let factory = init_migration_factory();
+                let db = RocksDB::open(config, COLUMNS);
+                let _ = factory.migrate(db)?;
+
+                Ok(RocksDB::open(config, COLUMNS))
+            }
+        }
+    } else {
+        let db = RocksDB::open(config, COLUMNS);
+        init_db_version(&db, factory.last_db_version())?;
+        Ok(db)
+    }
+}
+
+//TODO: Replace with migration db version when we have our first migration impl.
+pub(crate) fn init_db_version(db: &RocksDB, db_ver: Option<&str>) -> Result<()> {
+    if let Some(db_ver) = db_ver {
+        log::info!("Init db version: {}", db_ver);
+        db.put_default(MIGRATION_VERSION_KEY, db_ver)?
+    }
+    Ok(())
+}
+
+fn check_readonly_db_version(db: &ReadOnlyDB, db_ver: Option<&str>) -> Result<Ordering> {
+    let version = match db.get_pinned_default(MIGRATION_VERSION_KEY)? {
+        Some(version_bytes) => {
+            String::from_utf8(version_bytes.to_vec()).expect("version bytes to utf8")
+        }
+        None => {
+            let ordering = if is_non_empty_rdb(db) {
+                Ordering::Less
+            } else {
+                Ordering::Equal
+            };
+            return Ok(ordering);
+        }
+    };
+    log::debug!("current database version [{}]", version);
+    Ok(version.as_str().cmp(db_ver.expect("Db version is absent!")))
+}
+
+fn is_non_empty_rdb(db: &ReadOnlyDB) -> bool {
+    if let Ok(v) = db.get_pinned(COLUMN_META, META_TIP_BLOCK_HASH_KEY) {
+        if v.is_some() {
+            return true;
+        }
+    }
+    false
+}
+
+trait Migration {
+    fn migrate(&self, db: RocksDB) -> Result<RocksDB>;
+    // Version can be genereated with: date '+%Y%m%d%H%M%S'
+    fn version(&self) -> &str;
+    fn expensive(&self) -> bool;
+}
+
+struct DefaultMigration;
+impl Migration for DefaultMigration {
+    fn migrate(&self, db: RocksDB) -> Result<RocksDB> {
+        Ok(db)
+    }
+    #[allow(clippy::needless_return)]
+    fn version(&self) -> &str {
+        return "20211229181750";
+    }
+    fn expensive(&self) -> bool {
+        false
+    }
+}
+
+struct MigrationFactory {
+    migration_map: BTreeMap<String, Box<dyn Migration>>,
+}
+
+fn init_migration_factory() -> MigrationFactory {
+    let mut factory = MigrationFactory::create();
+    let migration = DefaultMigration;
+    factory.insert(Box::new(migration));
+    factory
+}
+
+impl MigrationFactory {
+    fn create() -> Self {
+        let migration_map = BTreeMap::new();
+        Self { migration_map }
+    }
+
+    fn insert(&mut self, migration: Box<dyn Migration>) {
+        self.migration_map
+            .insert(migration.version().to_string(), migration);
+    }
+
+    fn migrate(&self, db: RocksDB) -> Result<RocksDB> {
+        let db_version = db
+            .get_pinned_default(MIGRATION_VERSION_KEY)?
+            .map(|v| String::from_utf8(v.to_vec()).expect("version bytes to utf8"))
+            .unwrap_or_else(|| "".to_string());
+        let mut db = db;
+        let v = db_version.as_str();
+        let mut last_version = None;
+        for (mv, migration) in &self.migration_map {
+            let mv = mv.as_str();
+            if mv > v {
+                db = migration.migrate(db)?;
+                last_version = Some(mv);
+            }
+        }
+        if let Some(v) = last_version {
+            db.put_default(MIGRATION_VERSION_KEY, v)?;
+            log::info!("Current db version is: {}", v);
+        }
+        Ok(db)
+    }
+
+    fn last_db_version(&self) -> Option<&str> {
+        self.migration_map.values().last().map(|m| m.version())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Result;
+    use std::collections::HashMap;
+
+    use gw_config::StoreConfig;
+
+    use crate::{
+        schema::{COLUMNS, MIGRATION_VERSION_KEY},
+        RocksDB,
+    };
+
+    use super::{init_migration_factory, open_or_create_db, MigrationFactory};
+    #[test]
+    fn test_migration() -> Result<()> {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let config = StoreConfig {
+            path: dir.path().to_owned(),
+            options: HashMap::new(),
+            options_file: None,
+            cache_size: None,
+        };
+        let old_db = RocksDB::open(&config, COLUMNS);
+        let factory = init_migration_factory();
+        assert!(factory.last_db_version().is_some());
+
+        let db = factory.migrate(old_db);
+
+        assert!(db.is_ok());
+        let db = db.unwrap();
+        let v = db
+            .get_pinned_default(MIGRATION_VERSION_KEY)?
+            .map(|v| String::from_utf8(v.to_vec()));
+
+        assert_eq!(v, Some(Ok(factory.last_db_version().unwrap().to_string())));
+        Ok(())
+    }
+
+    #[test]
+    fn test_migration_with_fresh_new() -> Result<()> {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let config = StoreConfig {
+            path: dir.path().to_owned(),
+            options: HashMap::new(),
+            options_file: None,
+            cache_size: None,
+        };
+        let db = open_or_create_db(&config)?;
+        let v = db.get_pinned_default(MIGRATION_VERSION_KEY)?;
+        assert!(v.is_some());
+        let factory = init_migration_factory();
+
+        let v = db
+            .get_pinned_default(MIGRATION_VERSION_KEY)?
+            .map(|v| String::from_utf8(v.to_vec()));
+
+        assert_eq!(v, Some(Ok(factory.last_db_version().unwrap().to_string())));
+        Ok(())
+    }
+}

--- a/crates/db/src/migrate.rs
+++ b/crates/db/src/migrate.rs
@@ -39,7 +39,6 @@ pub fn open_or_create_db(config: &StoreConfig) -> Result<RocksDB> {
                 // TODO: Currently, there is only one migration: Add db version.
                 // So we can add db version by running default migration here.
                 // We should stop the process if we have more migrations and use **migration** command to run migration instead.
-                let factory = init_migration_factory();
                 let db = RocksDB::open(config, COLUMNS);
                 let _ = factory.migrate(db)?;
 

--- a/crates/db/src/read_only_db.rs
+++ b/crates/db/src/read_only_db.rs
@@ -1,0 +1,73 @@
+//! ReadOnlyDB wrapper base on rocksdb read_only_open mode
+use crate::schema::Col;
+use crate::{internal_error, Result};
+use rocksdb::ops::{GetColumnFamilys, GetPinned, GetPinnedCF, OpenCF};
+use rocksdb::{DBPinnableSlice, Options, ReadOnlyDB as RawReadOnlyDB};
+use std::path::Path;
+use std::sync::Arc;
+
+/// ReadOnlyDB wrapper
+pub struct ReadOnlyDB {
+    pub(crate) inner: Arc<RawReadOnlyDB>,
+}
+
+impl ReadOnlyDB {
+    /// The behavior is similar to DB::Open,
+    /// except that it opens DB in read-only mode.
+    /// One big difference is that when opening the DB as read-only,
+    /// you don't need to specify all Column Families
+    /// -- you can only open a subset of Column Families.
+    pub fn open_cf<P, I, N>(path: P, cf_names: I) -> Result<Option<Self>>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = N>,
+        N: AsRef<str>,
+    {
+        let opts = Options::default();
+        RawReadOnlyDB::open_cf(&opts, path, cf_names).map_or_else(
+            |err| {
+                let err_str = err.as_ref();
+                // notice: err msg difference
+                if err_str.starts_with("IO error: No such file or directory")
+                {
+                    Ok(None)
+                } else if err_str.starts_with("Corruption:") {
+                    log::info!(
+                        "DB corrupted: {}.\n\
+                        Note: Currently there is a limitation that un-flushed column families will be lost after repair.\
+                        This would happen even if the DB is in healthy state.\n\
+                        See https://github.com/facebook/rocksdb/wiki/RocksDB-Repairer for detail",
+                        err_str
+                    );
+                    Err(internal_error("DB corrupted"))
+                } else {
+                    Err(internal_error(format!(
+                        "failed to open the database: {}",
+                        err
+                    )))
+                }
+            },
+            |db| {
+                Ok(Some(ReadOnlyDB {
+                    inner: Arc::new(db),
+                }))
+            },
+        )
+    }
+
+    /// Return the value associated with a key using RocksDB's PinnableSlice from the default column
+    /// so as to avoid unnecessary memory copy.
+    pub fn get_pinned_default(&self, key: &[u8]) -> Result<Option<DBPinnableSlice>> {
+        self.inner.get_pinned(&key).map_err(internal_error)
+    }
+
+    /// Return the value associated with a key using RocksDB's PinnableSlice from the given column
+    /// so as to avoid unnecessary memory copy.
+    pub fn get_pinned(&self, col: Col, key: &[u8]) -> Result<Option<DBPinnableSlice>> {
+        let cf = self
+            .inner
+            .cf_handle(&col.to_string())
+            .ok_or_else(|| internal_error(format!("column {} not found", col)))?;
+        self.inner.get_pinned_cf(cf, &key).map_err(internal_error)
+    }
+}


### PR DESCRIPTION
This pr includes:
- Check db version when we open rocksdb for the first time.
- Add a migrate trait that is used to migrate from an old version to the current one.
- It needs to init a db version as the first version.