### PR TITLE
[HOT FIX] sync mem pool

### DIFF
--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -296,11 +296,8 @@ impl MemPool {
             ));
         }
 
-        // Skip verification on readonly node in case of inconsistent nonce value.
-        if self.node_mode == NodeMode::FullNode {
-            // verification
-            self.verify_tx(state, &tx)?;
-        }
+        // verification
+        self.verify_tx(state, &tx)?;
 
         // instantly run tx in background & update local state
         let t = Instant::now();

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -296,8 +296,11 @@ impl MemPool {
             ));
         }
 
-        // verification
-        self.verify_tx(state, &tx)?;
+        // Skip verification on readonly node in case of inconsistent nonce value.
+        if self.node_mode == NodeMode::FullNode {
+            // verification
+            self.verify_tx(state, &tx)?;
+        }
 
         // instantly run tx in background & update local state
         let t = Instant::now();
@@ -1422,9 +1425,7 @@ impl MemPool {
             // txs from the past block should be ignored
             return Ok(());
         }
-        let db = self.store.begin_transaction();
-        self.finalize_tx(&db, tx).await?;
-        db.commit()?;
+        self.push_transaction(tx).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
- mutates mem state by using push_tx instead and skip verification on readonly
- lower consumer latency 
 