### PR TITLE
fix: only check whitelist in mem-pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,6 +1934,7 @@ dependencies = [
  "gw-challenge",
  "gw-common",
  "gw-config",
+ "gw-dynamic-config",
  "gw-generator",
  "gw-poa",
  "gw-rpc-client",

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -153,12 +153,7 @@ impl BenchExecutionEnvironment {
             manage
         };
 
-        let generator = Generator::new(
-            backend_manage,
-            account_lock_manage,
-            rollup_context,
-            Default::default(),
-        );
+        let generator = Generator::new(backend_manage, account_lock_manage, rollup_context);
 
         Self::init_genesis(&store, &genesis_config, accounts);
         let mem_pool_state = MemPoolState::new(Arc::new(MemStore::new(store.get_snapshot())));
@@ -236,7 +231,14 @@ impl BenchExecutionEnvironment {
 
             let run_result = self
                 .generator
-                .execute_transaction(&self.chain, &state, &block_info, &raw_tx, L2TX_MAX_CYCLES)
+                .execute_transaction(
+                    &self.chain,
+                    &state,
+                    &block_info,
+                    &raw_tx,
+                    L2TX_MAX_CYCLES,
+                    None,
+                )
                 .unwrap();
 
             state.apply_run_result(&run_result).unwrap();

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -85,15 +85,16 @@ fn run_contract_get_result<S: State + CodeStore>(
         rollup_config: rollup_config.clone(),
         rollup_script_hash: [42u8; 32].into(),
     };
-    let generator = Generator::new(
-        backend_manage,
-        account_lock_manage,
-        rollup_ctx,
-        Default::default(),
-    );
+    let generator = Generator::new(backend_manage, account_lock_manage, rollup_ctx);
     let chain_view = DummyChainStore;
-    let run_result =
-        generator.execute_transaction(&chain_view, tree, block_info, &raw_tx, L2TX_MAX_CYCLES)?;
+    let run_result = generator.execute_transaction(
+        &chain_view,
+        tree,
+        block_info,
+        &raw_tx,
+        L2TX_MAX_CYCLES,
+        None,
+    )?;
     tree.apply_run_result(&run_result).expect("update state");
     Ok(run_result)
 }

--- a/crates/block-producer/src/replay_block.rs
+++ b/crates/block-producer/src/replay_block.rs
@@ -115,6 +115,7 @@ impl ReplayBlock {
                 &block_info,
                 &raw_tx,
                 L2TX_MAX_CYCLES,
+                None,
             )?;
 
             state.apply_run_result(&run_result)?;

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -389,7 +389,6 @@ impl BaseInitComponents {
                 backend_manage,
                 account_lock_manage,
                 rollup_context.clone(),
-                dynamic_config_manager.clone(),
             ))
         };
 
@@ -553,6 +552,7 @@ pub async fn run(config: Config, skip_config_check: bool) -> Result<()> {
                         error_tx_receipt_notifier: notify_controller.clone(),
                         config: config.mem_pool.clone(),
                         node_mode: config.node_mode,
+                        dynamic_config_manager: base.dynamic_config_manager.clone(),
                     };
                     Arc::new(Mutex::new(
                         MemPool::create(args)

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -17,8 +17,9 @@ gw-rpc-client = { path = "../rpc-client" }
 gw-poa = { path = "../poa" }
 gw-config = { path = "../config" }
 gw-utils = { path = "../utils" }
-rdkafka = { version = "0.25", default-features = false }
 gw-rpc-ws-server = { path = "../rpc-ws-server" }
+gw-dynamic-config = { path = "../dynamic-config" }
+rdkafka = { version = "0.25", default-features = false }
 tokio = "1.15"
 anyhow = "1.0"
 log = "0.4"

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -18,8 +18,9 @@ use gw_common::{
     H256,
 };
 use gw_config::{MemPoolConfig, NodeMode};
+use gw_dynamic_config::manager::DynamicConfigManager;
 use gw_generator::{
-    constants::L2TX_MAX_CYCLES, error::TransactionError, traits::StateExt, Generator,
+    constants::L2TX_MAX_CYCLES, error::TransactionError, traits::StateExt, ArcSwap, Generator,
 };
 use gw_rpc_ws_server::notify_controller::NotifyController;
 use gw_store::{
@@ -104,6 +105,7 @@ pub struct MemPool {
     mem_pool_publish_service: Option<MemPoolPublishService>,
     node_mode: NodeMode,
     mem_pool_state: Arc<MemPoolState>,
+    dynamic_config_manager: Arc<ArcSwap<DynamicConfigManager>>,
 }
 
 pub struct MemPoolCreateArgs {
@@ -115,6 +117,7 @@ pub struct MemPoolCreateArgs {
     pub error_tx_receipt_notifier: Option<NotifyController>,
     pub config: MemPoolConfig,
     pub node_mode: NodeMode,
+    pub dynamic_config_manager: Arc<ArcSwap<DynamicConfigManager>>,
 }
 
 impl Drop for MemPool {
@@ -138,6 +141,7 @@ impl MemPool {
             error_tx_receipt_notifier,
             config,
             node_mode,
+            dynamic_config_manager,
         } = args;
 
         let pending = Default::default();
@@ -194,6 +198,7 @@ impl MemPool {
             mem_pool_publish_service: fan_out_mem_block_handler,
             node_mode,
             mem_pool_state,
+            dynamic_config_manager,
         };
 
         // update mem block info
@@ -1305,6 +1310,7 @@ impl MemPool {
             block_info,
             &raw_tx,
             L2TX_MAX_CYCLES,
+            Some(self.dynamic_config_manager.clone()),
         )?;
 
         if run_result.exit_code != 0 {

--- a/crates/replay-chain/src/setup.rs
+++ b/crates/replay-chain/src/setup.rs
@@ -113,7 +113,6 @@ pub async fn setup(args: SetupArgs) -> Result<Context> {
             backend_manage,
             account_lock_manage,
             rollup_context,
-            Default::default(),
         ))
     };
 

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -245,7 +245,6 @@ pub fn chain_generator(chain: &Chain, rollup_type_script: Script) -> Arc<Generat
         backend_manage,
         account_lock_manage,
         rollup_context,
-        Default::default(),
     ))
 }
 
@@ -287,7 +286,6 @@ pub async fn setup_chain_with_account_lock_manage(
         backend_manage,
         account_lock_manage,
         rollup_context,
-        Default::default(),
     ));
     let provider = opt_mem_pool_provider.unwrap_or_default();
     let args = MemPoolCreateArgs {
@@ -299,6 +297,7 @@ pub async fn setup_chain_with_account_lock_manage(
         error_tx_receipt_notifier: None,
         config: mem_pool_config,
         node_mode: gw_config::NodeMode::FullNode,
+        dynamic_config_manager: Default::default(),
     };
     let mem_pool = MemPool::create(args).await.unwrap();
     Chain::create(


### PR DESCRIPTION
Node should skip whitelist when syncing blocks. Otherwise the node should inconsistent with block producer if the whitelist mis-configured.

This PR fixes the issue by moving whitelist into mem-pool & RPC.