### PR TITLE
Enable `aot-vm` feature by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "gw-block-producer"
-version = "0.8.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-block-producer"
-version = "0.8.0"
+version = "0.10.1"
 authors = ["Nervos Network"]
 edition = "2018"
 
@@ -66,6 +66,6 @@ opentelemetry = { version = "0.16", features = ["rt-tokio"] }
 tikv-jemallocator = { version = "0.4.0", features = ["unprefixed_malloc_on_supported_platforms"] }
 
 [features]
-default = []
+default = ["aot-vm"]
 profiling = ["tikv-jemallocator/profiling"]
 aot-vm = ["gw-generator/aot"]


### PR DESCRIPTION
## crates/block-producer/Cargo.toml
```TOML
[features]
default = ["aot-vm"]
profiling = ["tikv-jemallocator/profiling"]
aot-vm = ["gw-generator/aot"]
```

Related PR:
- Polyjuice: https://github.com/nervosnetwork/godwoken-polyjuice/pull/123