### PR TITLE
fix: make sure tip block and epoch are consistent

### DIFF
--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -232,30 +232,24 @@ impl ChainTask {
 
                 // update global hardfork info
                 let hardfork_switch = self.rpc_client.get_hardfork_switch().await?;
-                let rpc32_epoch_number = hardfork_switch.rfc_0032();
+                let rfc0032_epoch_number = hardfork_switch.rfc_0032();
                 let global_hardfork_switch = GLOBAL_HARDFORK_SWITCH.load();
                 if !is_hardfork_switch_eq(&*global_hardfork_switch, &hardfork_switch) {
                     GLOBAL_HARDFORK_SWITCH.store(Arc::new(hardfork_switch));
                 }
 
-                // update global current epoch number
-                let current_epoch_number = {
+                // when switching the epoch, update the tip epoch number and VM version
+                let tip_epoch = {
                     let tip_epoch: u64 = block.header().raw().epoch().unpack();
-                    EpochNumberWithFraction::from_full_value(tip_epoch).number()
+                    EpochNumberWithFraction::from_full_value(tip_epoch)
                 };
-                let global_epoch_number = GLOBAL_CURRENT_EPOCH_NUMBER.load(Ordering::SeqCst);
-                if global_epoch_number != current_epoch_number {
-                    GLOBAL_CURRENT_EPOCH_NUMBER.store(current_epoch_number, Ordering::SeqCst);
-                }
-
-                // update global vm version
-                let vm_version: u32 = if current_epoch_number >= rpc32_epoch_number {
-                    1
-                } else {
-                    0
-                };
-                let global_vm_version = GLOBAL_VM_VERSION.load(Ordering::SeqCst);
-                if global_vm_version != vm_version {
+                if tip_epoch.index() == 0 || tip_epoch.index() == tip_epoch.length() - 1 {
+                    let vm_version: u32 = if tip_epoch.number() >= rfc0032_epoch_number {
+                        1
+                    } else {
+                        0
+                    };
+                    GLOBAL_CURRENT_EPOCH_NUMBER.store(tip_epoch.number(), Ordering::SeqCst);
                     GLOBAL_VM_VERSION.store(vm_version, Ordering::SeqCst);
                 }
                 last_event_time = Instant::now();

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -48,7 +48,7 @@ use gw_types::{
     packed::{Byte32, CellDep, NumberHash, RollupConfig, Script},
     prelude::*,
 };
-use gw_utils::{genesis_info::CKBGenesisInfo, wallet::Wallet};
+use gw_utils::{genesis_info::CKBGenesisInfo, since::EpochNumberWithFraction, wallet::Wallet};
 use gw_web3_indexer::{ErrorReceiptIndexer, Web3Indexer};
 use semver::Version;
 use sqlx::{
@@ -239,7 +239,10 @@ impl ChainTask {
                 }
 
                 // update global current epoch number
-                let current_epoch_number = self.rpc_client.get_current_epoch_number().await?;
+                let current_epoch_number = {
+                    let tip_epoch: u64 = block.header().raw().epoch().unpack();
+                    EpochNumberWithFraction::from_full_value(tip_epoch).number()
+                };
                 let global_epoch_number = GLOBAL_CURRENT_EPOCH_NUMBER.load(Ordering::SeqCst);
                 if global_epoch_number != current_epoch_number {
                     GLOBAL_CURRENT_EPOCH_NUMBER.store(current_epoch_number, Ordering::SeqCst);


### PR DESCRIPTION
I think [`GLOBAL_CURRENT_EPOCH_NUMBER`](https://github.com/nervosnetwork/godwoken/blob/6e476055b31674741a314d4b18fb754eb72e7ce0/crates/ckb-hardfork/src/lib.rs#L11) and [`GLOBAL_VM_VERSION`](https://github.com/nervosnetwork/godwoken/blob/6e476055b31674741a314d4b18fb754eb72e7ce0/crates/ckb-hardfork/src/lib.rs#L7) should match [tip block](https://github.com/nervosnetwork/godwoken/blob/768d7bdc3f0e0c20dc3a67b05fdc2cb603cccd04/crates/block-producer/src/runner.rs#L109). And we can extract the tip's corresponding epoch info from the block header.