### PR TITLE
chore: tune MAX_DEPOSITS and MAX_WITHDRAWALS in mem-pool

### DIFF
--- a/crates/mem-pool/src/constants.rs
+++ b/crates/mem-pool/src/constants.rs
@@ -1,7 +1,7 @@
 /// MAX deposits in the mem block
-pub const MAX_MEM_BLOCK_DEPOSITS: usize = 50;
+pub const MAX_MEM_BLOCK_DEPOSITS: usize = 20;
 /// MAX withdrawals in the mem block
-pub const MAX_MEM_BLOCK_WITHDRAWALS: usize = 50;
+pub const MAX_MEM_BLOCK_WITHDRAWALS: usize = 20;
 /// MAX withdrawals in the mem block
 pub const MAX_MEM_BLOCK_TXS: usize = 1000;
 /// MAX tx size 50 KB


### PR DESCRIPTION
to fix the size limit of secp256k1 lock temporarily

/// MAX deposits in the mem block
pub const MAX_MEM_BLOCK_DEPOSITS: usize = 20;
/// MAX withdrawals in the mem block
pub const MAX_MEM_BLOCK_WITHDRAWALS: usize = 20;