### PR TITLE
feat: rpc server enable tcp keep-alive

### DIFF
--- a/crates/rpc-server/src/server.rs
+++ b/crates/rpc-server/src/server.rs
@@ -46,8 +46,10 @@ pub async fn start_jsonrpc_server(
     log::info!("JSONRPC server listening on {}", url);
 
     // Start a hyper server.
-    let server =
-        Server::builder(AddrIncoming::from_listener(listener)?).serve(make_service_fn(move |_| {
+    let server = Server::builder(AddrIncoming::from_listener(listener)?)
+        //Make sure the connection from web3 client could be keep-alive for 2 hours.
+        .tcp_keepalive(Some(Duration::from_secs(7200)))
+        .serve(make_service_fn(move |_| {
             let rpc_server = Arc::clone(&rpc_server);
             async { Ok::<_, Error>(service_fn(move |req| serve(Arc::clone(&rpc_server), req))) }
         }));


### PR DESCRIPTION
HTTP clients(godwoken-web3) get ECONNRESET errors constantly and periodically.
This means the remote endpoint has closed the TCP connection, but the client still sends requests on this connection.
As web3 enables keep-alive, the TCP connections should be more reliable by setting the default timeout to 2h(which is also a default value for the duration of a keep-alive TCP connection).
This pr may resolve the ECONNRESET error.