### PR TITLE
fix: gw-tools deploy-scripts miss omni_lock

### DIFF
--- a/crates/tools/src/deploy_scripts.rs
+++ b/crates/tools/src/deploy_scripts.rs
@@ -129,6 +129,7 @@ pub fn deploy_scripts(
         &scripts_result.programs.withdrawal_lock,
         &scripts_result.programs.challenge_lock,
         &scripts_result.programs.stake_lock,
+        &scripts_result.programs.omni_lock,
         &scripts_result.programs.state_validator,
         &scripts_result.programs.l2_sudt_validator,
         &scripts_result.programs.eth_account_lock,
@@ -184,6 +185,13 @@ pub fn deploy_scripts(
         privkey_path,
         &mut rpc_client,
         &scripts_result.programs.stake_lock,
+        &target_lock,
+        &target_address,
+    )?;
+    let omni_lock = deploy_program(
+        privkey_path,
+        &mut rpc_client,
+        &scripts_result.programs.omni_lock,
         &target_lock,
         &target_address,
     )?;
@@ -243,6 +251,7 @@ pub fn deploy_scripts(
         withdrawal_lock,
         challenge_lock,
         stake_lock,
+        omni_lock,
         state_validator,
         l2_sudt_validator,
         meta_contract_validator,

--- a/crates/tools/src/prepare_scripts.rs
+++ b/crates/tools/src/prepare_scripts.rs
@@ -309,6 +309,7 @@ fn generate_script_deploy_config(
         withdrawal_lock: get_path("withdrawal_lock"),
         challenge_lock: get_path("challenge_lock"),
         stake_lock: get_path("stake_lock"),
+        omni_lock: get_path("omni_lock"),
         state_validator: get_path("state_validator"),
         l2_sudt_validator: get_path("l2_sudt_validator"),
         eth_account_lock: get_path("eth_account_lock"),

--- a/crates/tools/src/types.rs
+++ b/crates/tools/src/types.rs
@@ -57,6 +57,7 @@ pub struct ScriptsDeploymentResult {
     pub withdrawal_lock: DeployItem,
     pub challenge_lock: DeployItem,
     pub stake_lock: DeployItem,
+    pub omni_lock: DeployItem,
     pub state_validator: DeployItem,
     pub meta_contract_validator: DeployItem,
     pub l2_sudt_validator: DeployItem,
@@ -92,6 +93,8 @@ pub struct Programs {
     pub challenge_lock: PathBuf,
     // path: godwoken-scripts/build/release/stake-lock
     pub stake_lock: PathBuf,
+    // path: godwoken-scripts/build/release/omni_lock
+    pub omni_lock: PathBuf,
     // path: godwoken-scripts/build/release/state-validator
     pub state_validator: PathBuf,
     // path: godwoken-scripts/c/build/sudt-validator


### PR DESCRIPTION
The Omni lock script should be deployed and generated deployment information in the `gw-tools deploy-scripts`. [Pull Request #555](https://github.com/nervosnetwork/godwoken/pull/555/files#diff-8c87c879c2757bfaab97aebdbca26afc5678a487025e2cf0e64cbd1072ac80b3L234-L247) removes PoA lock but does not adds Omni deployment steps.