### PR TITLE
fix(mem-pool): readonly node create mempool failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "gw-block-producer"
-version = "0.8.0"
+version = "1.0.0-rc1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -494,6 +494,8 @@ impl MemPool {
         let new_tip = match new_tip {
             Some(block_hash) => block_hash,
             None => {
+                log::debug!("reset new tip to last valid tip block");
+
                 let db = self.store.begin_transaction();
                 db.get_last_valid_tip_block_hash()?
             }
@@ -596,7 +598,8 @@ impl MemPool {
         // reset mem block state
         {
             let snapshot = self.store.get_snapshot();
-            assert_eq!(snapshot.get_tip_block_hash()?, new_tip, "set new snapshot");
+            let snap_last_valid_tip = snapshot.get_last_valid_tip_block_hash()?;
+            assert_eq!(snap_last_valid_tip, new_tip, "set new snapshot");
             let mem_store = MemStore::new(snapshot);
             self.mem_pool_state.store(Arc::new(mem_store));
         }


### PR DESCRIPTION
Compare last valid tip block hash with tip block hash, but they may be
different. Should always use last valid tip block hash.