### PR TITLE
feat: simplify and improve rpc TCP listener

### DIFF
--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.15", default-features = false, features = ["rt-multi-thre
 bytes-v10 = { version = "1.0", package = "bytes" }
 async-trait = "0.1"
 lru = "0.7"
-socket2 = "0.4"
+socket2 = { version = "0.4", features = ["all"] }
 pprof = { version = "0.6", features = ["flamegraph", "cpp", "protobuf"]}
 once_cell = "1.8"
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.4.2" }


### PR DESCRIPTION
* Use tokio bind function to simplify code and set `SO_REUSEADDR`. This
  also causes the socket to use a bigger listen backlog of 1024 (mio
  default) instead of 128. And this supports IPv6.

* Set TCP keepalive interval and count too, because the default (75
  seconds, 9) is not ideal either.

* Set `TCP_NODELAY`. Disabling Nagle's algorithm is usually the better
  default.
