### PR TITLE
fix: overwrite mem block timestamp if CKB median time is less than tip block

### DIFF
--- a/crates/block-producer/src/block_producer.rs
+++ b/crates/block-producer/src/block_producer.rs
@@ -312,6 +312,18 @@ impl BlockProducer {
             Some(time) => time,
             None => return Ok(()),
         };
+        let tip_block_timestamp = Duration::from_millis(
+            self.store
+                .get_last_valid_tip_block()?
+                .raw()
+                .timestamp()
+                .unpack(),
+        );
+        if median_time < tip_block_timestamp {
+            log::warn!("[block producer] median time is less than tip block timestamp, skip produce new block");
+            return Ok(());
+        }
+
         let poa_cell_input = InputCellInfo {
             input: CellInput::new_builder()
                 .previous_output(rollup_cell.out_point.clone())

--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, Sub};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -360,9 +360,12 @@ pub fn deploy_rollup_cell(args: DeployRollupCellArgs) -> Result<RollupDeployment
 
     // millisecond
     let timestamp = timestamp.unwrap_or_else(|| {
+        // New created CKB dev chain's may out of sync with real world time,
+        // So we using an earlier time to get around this issue.
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("timestamp")
+            .sub(core::time::Duration::from_secs(3600))
             .as_millis() as u64
     });
 


### PR DESCRIPTION
Godwoken relies on [CKB median time](https://github.com/nervosnetwork/ckb/tree/develop/rpc#method-get_block_median_time) to produce layer2 block. In some situation, the CKB median time will be less than tip layer2 block's timestamp, for example: CKB re-org.
So a contract developer may submit a transaction with a timestamp t1, and then execute a tx with a timestamp t2, and the t2 may be less than t1. This may cause logic error in contract.

This PR fix this by overwrite a later timestamp to mem-pool's block info if median time is less than the tip block's timestamp. This PR also adjust the default genesis block's timestamp, if user doesn't specific the timestamp of the genesis, we would use a earlier timestamp as the genesis, so it won't conflict with the CKB's median time in the development environment.