### PR TITLE
perf: optimize molecule usage

### DIFF
--- a/crates/mem-pool/src/sync/mq/gw_kafka.rs
+++ b/crates/mem-pool/src/sync/mq/gw_kafka.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::Result;
 use async_trait::async_trait;
 use gw_types::{
-    packed::{RefreshMemBlockMessage, RefreshMemBlockMessageUnion},
+    packed::{RefreshMemBlockMessage, RefreshMemBlockMessageReader, RefreshMemBlockMessageUnion},
     prelude::{Builder, Entity, Reader},
 };
 use rdkafka::{
@@ -134,8 +134,7 @@ impl Consume for Consumer {
                     );
 
                     if let Some(payload) = payload {
-                        let refresh_msg = RefreshMemBlockMessage::from_slice(payload)?;
-                        let reader = refresh_msg.as_reader();
+                        let reader = RefreshMemBlockMessageReader::from_slice(payload)?;
                         let refresh_msg = reader.to_enum();
                         match &refresh_msg {
                             gw_types::packed::RefreshMemBlockMessageUnionReader::NextL2Transaction(

--- a/crates/store/src/mem_pool_state.rs
+++ b/crates/store/src/mem_pool_state.rs
@@ -11,8 +11,8 @@ use gw_db::{
     schema::{Col, COLUMNS, COLUMN_ACCOUNT_SMT_BRANCH, COLUMN_ACCOUNT_SMT_LEAF, COLUMN_META},
 };
 use gw_types::{
-    packed::{self},
-    prelude::{Entity, FromSliceShouldBeOk, Pack, Reader, Unpack},
+    from_box_should_be_ok, packed,
+    prelude::{Entity, FromSliceShouldBeOk, Pack, Unpack},
 };
 
 use crate::{
@@ -102,11 +102,9 @@ impl MemStore {
 
     pub fn get_mem_block_account_count(&self) -> Result<Option<u32>, Error> {
         match self.get(COLUMN_META, META_MEM_SMT_COUNT_KEY) {
-            Some(slice) => {
-                let count =
-                    packed::Uint32Reader::from_slice_should_be_ok(slice.as_ref()).to_entity();
-                Ok(Some(count.unpack()))
-            }
+            Some(slice) => Ok(Some(
+                packed::Uint32Reader::from_slice_should_be_ok(&slice).unpack(),
+            )),
             None => Ok(None),
         }
     }
@@ -131,9 +129,7 @@ impl MemStore {
 
     pub fn get_mem_pool_block_info(&self) -> Result<Option<packed::BlockInfo>, Error> {
         match self.get(COLUMN_META, META_MEM_BLOCK_INFO) {
-            Some(slice) => Ok(Some(
-                packed::BlockInfoReader::from_slice_should_be_ok(slice.as_ref()).to_entity(),
-            )),
+            Some(slice) => Ok(Some(from_box_should_be_ok!(packed::BlockInfoReader, slice))),
             None => Ok(None),
         }
     }

--- a/crates/store/src/state/mem_state_db.rs
+++ b/crates/store/src/state/mem_state_db.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use gw_common::{error::Error as StateError, smt::SMT, state::State, H256};
 use gw_db::schema::{COLUMN_DATA, COLUMN_SCRIPT, COLUMN_SCRIPT_PREFIX};
 use gw_traits::CodeStore;
+use gw_types::from_box_should_be_ok;
 use gw_types::{
     bytes::Bytes,
     packed::{self, AccountMerkleState},
@@ -109,7 +110,7 @@ impl<'a> CodeStore for MemStateTree<'a> {
         self.db()
             .get(COLUMN_SCRIPT, script_hash.as_slice())
             .or_else(|| self.db().get(COLUMN_SCRIPT, script_hash.as_slice()))
-            .map(|slice| packed::ScriptReader::from_slice_should_be_ok(slice.as_ref()).to_entity())
+            .map(|slice| from_box_should_be_ok!(packed::ScriptReader, slice))
     }
 
     fn get_script_hash_by_short_script_hash(&self, script_hash_prefix: &[u8]) -> Option<H256> {

--- a/crates/store/src/state/state_db.rs
+++ b/crates/store/src/state/state_db.rs
@@ -11,6 +11,7 @@ use gw_db::schema::{COLUMN_DATA, COLUMN_SCRIPT, COLUMN_SCRIPT_PREFIX};
 use gw_traits::CodeStore;
 use gw_types::{
     bytes::Bytes,
+    from_box_should_be_ok,
     packed::{self, AccountMerkleState, Byte32},
     prelude::*,
 };
@@ -236,7 +237,7 @@ impl<'a> CodeStore for StateTree<'a> {
     fn get_script(&self, script_hash: &H256) -> Option<packed::Script> {
         self.db()
             .get(COLUMN_SCRIPT, script_hash.as_slice())
-            .map(|slice| packed::ScriptReader::from_slice_should_be_ok(slice.as_ref()).to_entity())
+            .map(|slice| from_box_should_be_ok!(packed::ScriptReader, slice))
     }
 
     fn get_script_hash_by_short_script_hash(&self, script_hash_prefix: &[u8]) -> Option<H256> {

--- a/crates/store/src/transaction/store_transaction.rs
+++ b/crates/store/src/transaction/store_transaction.rs
@@ -240,10 +240,9 @@ impl StoreTransaction {
     // TODO: prune db state
     pub fn get_reverted_block_hashes(&self) -> Result<HashSet<H256>, Error> {
         let iter = self.get_iter(COLUMN_REVERTED_BLOCK_SMT_LEAF, IteratorMode::End);
-        let to_byte32 = iter.map(|(key, _value)| {
-            packed::Byte32Reader::from_slice_should_be_ok(key.as_ref()).to_entity()
+        let to_h256 = iter.map(|(key, _value)| {
+            packed::Byte32Reader::from_slice_should_be_ok(key.as_ref()).unpack()
         });
-        let to_h256 = to_byte32.map(|byte32| byte32.unpack());
 
         Ok(to_h256.collect())
     }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -29,3 +29,11 @@ cfg_if::cfg_if! {
         use alloc::string;
     }
 }
+
+#[macro_export]
+macro_rules! from_box_should_be_ok {
+    ($r:ty, $b:ident) => {{
+        <$r>::from_slice_should_be_ok(&$b);
+        <$r as gw_types::prelude::Reader>::Entity::new_unchecked($b.into())
+    }};
+}


### PR DESCRIPTION
The principle here is to try to avoid `Entity::from_slice` or `Reader::to_entity` if possible, because they need to allocate and copy memory.

* Replace `Box<[u8]>` -> `as_ref` -> `Reader::from_slice_should_be_ok` -> `to_entity` with `from_box_should_be_ok!`, which is `from_slice_should_be_ok` + `into` -> `new_unchecked`.

* Replace `Entity::from_slice` -> `as_reader` with `Reader::from_slice`.

* Replace `to_entity` -> `unpack` with `unpack`.