### PR TITLE
v1 fix: overwrite mem block timestamp if CKB median time is less than tip block

### DIFF
--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -1,6 +1,8 @@
+use std::collections::HashSet;
 use std::iter::FromIterator;
+use std::ops::Sub;
+use std::path::Path;
 use std::str::FromStr;
-use std::{collections::HashSet, path::Path};
 
 use anyhow::{anyhow, Result};
 use ckb_types::bytes::{BufMut, BytesMut};
@@ -376,9 +378,12 @@ pub fn deploy_rollup_cell(args: DeployRollupCellArgs) -> Result<RollupDeployment
 
     // millisecond
     let timestamp = timestamp.unwrap_or_else(|| {
+        // New created CKB dev chain's may out of sync with real world time,
+        // So we using an earlier time to get around this issue.
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("timestamp")
+            .sub(core::time::Duration::from_secs(3600))
             .as_millis() as u64
     });
 


### PR DESCRIPTION
- https://github.com/nervosnetwork/godwoken/pull/625