### PR TITLE
fix: fix potential UB in Unpack impls in types

### DIFF
--- a/crates/types/src/conversion/blockchain.rs
+++ b/crates/types/src/conversion/blockchain.rs
@@ -12,7 +12,7 @@ impl Pack<packed::Byte32> for [u8; 32] {
 impl<'r> Unpack<[u8; 32]> for packed::Byte32Reader<'r> {
     #[inline]
     fn unpack(&self) -> [u8; 32] {
-        self.as_slice().try_into().unwrap()
+        self.as_slice().try_into().expect("unpack Byte32Reader")
     }
 }
 impl_conversion_for_entity_unpack!([u8; 32], Byte32);
@@ -27,7 +27,9 @@ impl Pack<packed::ProposalShortId> for [u8; 10] {
 impl<'r> Unpack<[u8; 10]> for packed::ProposalShortIdReader<'r> {
     #[inline]
     fn unpack(&self) -> [u8; 10] {
-        self.as_slice().try_into().unwrap()
+        self.as_slice()
+            .try_into()
+            .expect("unpack ProposalShortIdReader")
     }
 }
 impl_conversion_for_entity_unpack!([u8; 10], ProposalShortId);

--- a/crates/types/src/conversion/blockchain.rs
+++ b/crates/types/src/conversion/blockchain.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::vec::Vec;
 use crate::{bytes::Bytes, packed, prelude::*};
 
@@ -8,9 +10,9 @@ impl Pack<packed::Byte32> for [u8; 32] {
 }
 
 impl<'r> Unpack<[u8; 32]> for packed::Byte32Reader<'r> {
+    #[inline]
     fn unpack(&self) -> [u8; 32] {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 32];
-        unsafe { *ptr }
+        self.as_slice().try_into().unwrap()
     }
 }
 impl_conversion_for_entity_unpack!([u8; 32], Byte32);
@@ -23,9 +25,9 @@ impl Pack<packed::ProposalShortId> for [u8; 10] {
 }
 
 impl<'r> Unpack<[u8; 10]> for packed::ProposalShortIdReader<'r> {
+    #[inline]
     fn unpack(&self) -> [u8; 10] {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 10];
-        unsafe { *ptr }
+        self.as_slice().try_into().unwrap()
     }
 }
 impl_conversion_for_entity_unpack!([u8; 10], ProposalShortId);

--- a/crates/types/src/conversion/ckb_h256.rs
+++ b/crates/types/src/conversion/ckb_h256.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::{packed, prelude::*};
 use ckb_fixed_hash::H256;
 
@@ -8,9 +10,9 @@ impl Pack<packed::Byte32> for H256 {
 }
 
 impl<'r> Unpack<H256> for packed::Byte32Reader<'r> {
+    #[inline]
     fn unpack(&self) -> H256 {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 32];
-        let r = unsafe { *ptr };
+        let r: [u8; 32] = self.as_slice().try_into().unwrap();
         r.into()
     }
 }

--- a/crates/types/src/conversion/ckb_h256.rs
+++ b/crates/types/src/conversion/ckb_h256.rs
@@ -12,7 +12,7 @@ impl Pack<packed::Byte32> for H256 {
 impl<'r> Unpack<H256> for packed::Byte32Reader<'r> {
     #[inline]
     fn unpack(&self) -> H256 {
-        let r: [u8; 32] = self.as_slice().try_into().unwrap();
+        let r: [u8; 32] = self.as_slice().try_into().expect("unpack Byte32Reader");
         r.into()
     }
 }

--- a/crates/types/src/conversion/godwoken.rs
+++ b/crates/types/src/conversion/godwoken.rs
@@ -28,7 +28,7 @@ impl Pack<packed::Byte20> for [u8; 20] {
 impl<'r> Unpack<[u8; 20]> for packed::Byte20Reader<'r> {
     #[inline]
     fn unpack(&self) -> [u8; 20] {
-        self.as_slice().try_into().unwrap()
+        self.as_slice().try_into().expect("unpack Byte20Reader")
     }
 }
 impl_conversion_for_entity_unpack!([u8; 20], Byte20);

--- a/crates/types/src/conversion/godwoken.rs
+++ b/crates/types/src/conversion/godwoken.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::{core::H256, packed, prelude::*, vec::Vec};
 
 impl Pack<packed::KVPair> for (H256, H256) {
@@ -24,9 +26,9 @@ impl Pack<packed::Byte20> for [u8; 20] {
 }
 
 impl<'r> Unpack<[u8; 20]> for packed::Byte20Reader<'r> {
+    #[inline]
     fn unpack(&self) -> [u8; 20] {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 20];
-        unsafe { *ptr }
+        self.as_slice().try_into().unwrap()
     }
 }
 impl_conversion_for_entity_unpack!([u8; 20], Byte20);

--- a/crates/types/src/conversion/primitive.rs
+++ b/crates/types/src/conversion/primitive.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::{borrow::ToOwned, str, string::String, vec::Vec};
 use crate::{bytes::Bytes, packed, prelude::*};
 
@@ -32,37 +34,34 @@ impl Pack<packed::Uint32> for usize {
 }
 
 impl<'r> Unpack<u16> for packed::Uint16Reader<'r> {
-    #[allow(clippy::cast_ptr_alignment)]
+    #[inline]
     fn unpack(&self) -> u16 {
-        let le = self.as_slice().as_ptr() as *const u16;
-        u16::from_le(unsafe { *le })
+        // Unwrap is ok because slice should always be of the correct length, so try_into should not fail.
+        u16::from_le_bytes(self.as_slice().try_into().unwrap())
     }
 }
 impl_conversion_for_entity_unpack!(u16, Uint16);
 
 impl<'r> Unpack<u32> for packed::Uint32Reader<'r> {
-    #[allow(clippy::cast_ptr_alignment)]
+    #[inline]
     fn unpack(&self) -> u32 {
-        let le = self.as_slice().as_ptr() as *const u32;
-        u32::from_le(unsafe { *le })
+        u32::from_le_bytes(self.as_slice().try_into().unwrap())
     }
 }
 impl_conversion_for_entity_unpack!(u32, Uint32);
 
 impl<'r> Unpack<u64> for packed::Uint64Reader<'r> {
-    #[allow(clippy::cast_ptr_alignment)]
+    #[inline]
     fn unpack(&self) -> u64 {
-        let le = self.as_slice().as_ptr() as *const u64;
-        u64::from_le(unsafe { *le })
+        u64::from_le_bytes(self.as_slice().try_into().unwrap())
     }
 }
 impl_conversion_for_entity_unpack!(u64, Uint64);
 
 impl<'r> Unpack<u128> for packed::Uint128Reader<'r> {
-    #[allow(clippy::cast_ptr_alignment)]
+    #[inline]
     fn unpack(&self) -> u128 {
-        let le = self.as_slice().as_ptr() as *const u128;
-        u128::from_le(unsafe { *le })
+        u128::from_le_bytes(self.as_slice().try_into().unwrap())
     }
 }
 impl_conversion_for_entity_unpack!(u128, Uint128);

--- a/crates/types/src/conversion/primitive.rs
+++ b/crates/types/src/conversion/primitive.rs
@@ -34,6 +34,7 @@ impl Pack<packed::Uint32> for usize {
 }
 
 impl<'r> Unpack<u16> for packed::Uint16Reader<'r> {
+    // Inline so that the panic branch can be optimized out.
     #[inline]
     fn unpack(&self) -> u16 {
         // Unwrap is ok because slice should always be of the correct length, so try_into should not fail.

--- a/crates/types/src/conversion/primitive.rs
+++ b/crates/types/src/conversion/primitive.rs
@@ -37,8 +37,7 @@ impl<'r> Unpack<u16> for packed::Uint16Reader<'r> {
     // Inline so that the panic branch can be optimized out.
     #[inline]
     fn unpack(&self) -> u16 {
-        // Unwrap is ok because slice should always be of the correct length, so try_into should not fail.
-        u16::from_le_bytes(self.as_slice().try_into().unwrap())
+        u16::from_le_bytes(self.as_slice().try_into().expect("unpack Uint16Reader"))
     }
 }
 impl_conversion_for_entity_unpack!(u16, Uint16);
@@ -46,7 +45,7 @@ impl_conversion_for_entity_unpack!(u16, Uint16);
 impl<'r> Unpack<u32> for packed::Uint32Reader<'r> {
     #[inline]
     fn unpack(&self) -> u32 {
-        u32::from_le_bytes(self.as_slice().try_into().unwrap())
+        u32::from_le_bytes(self.as_slice().try_into().expect("unpack Uint32Reader"))
     }
 }
 impl_conversion_for_entity_unpack!(u32, Uint32);
@@ -54,7 +53,7 @@ impl_conversion_for_entity_unpack!(u32, Uint32);
 impl<'r> Unpack<u64> for packed::Uint64Reader<'r> {
     #[inline]
     fn unpack(&self) -> u64 {
-        u64::from_le_bytes(self.as_slice().try_into().unwrap())
+        u64::from_le_bytes(self.as_slice().try_into().expect("unpack Uint64Reader"))
     }
 }
 impl_conversion_for_entity_unpack!(u64, Uint64);
@@ -62,7 +61,7 @@ impl_conversion_for_entity_unpack!(u64, Uint64);
 impl<'r> Unpack<u128> for packed::Uint128Reader<'r> {
     #[inline]
     fn unpack(&self) -> u128 {
-        u128::from_le_bytes(self.as_slice().try_into().unwrap())
+        u128::from_le_bytes(self.as_slice().try_into().expect("unpack Uint128Reader"))
     }
 }
 impl_conversion_for_entity_unpack!(u128, Uint128);

--- a/crates/types/src/conversion/smt_h256.rs
+++ b/crates/types/src/conversion/smt_h256.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::core::H256;
 use crate::{packed, prelude::*, vec::Vec};
 
@@ -8,9 +10,9 @@ impl Pack<packed::Byte32> for H256 {
 }
 
 impl<'r> Unpack<H256> for packed::Byte32Reader<'r> {
+    #[inline]
     fn unpack(&self) -> H256 {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 32];
-        let r = unsafe { *ptr };
+        let r: [u8; 32] = self.as_slice().try_into().unwrap();
         r.into()
     }
 }

--- a/crates/types/src/conversion/smt_h256.rs
+++ b/crates/types/src/conversion/smt_h256.rs
@@ -12,7 +12,7 @@ impl Pack<packed::Byte32> for H256 {
 impl<'r> Unpack<H256> for packed::Byte32Reader<'r> {
     #[inline]
     fn unpack(&self) -> H256 {
-        let r: [u8; 32] = self.as_slice().try_into().unwrap();
+        let r: [u8; 32] = self.as_slice().try_into().expect("unpack Byte32Reader");
         r.into()
     }
 }

--- a/crates/types/src/conversion/store.rs
+++ b/crates/types/src/conversion/store.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::{packed, prelude::*};
 use molecule::prelude::Byte;
 use sparse_merkle_tree::merge::MergeValue;
@@ -10,9 +12,9 @@ impl Pack<packed::TransactionKey> for [u8; 36] {
 }
 
 impl<'r> Unpack<[u8; 36]> for packed::TransactionKeyReader<'r> {
+    #[inline]
     fn unpack(&self) -> [u8; 36] {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 36];
-        unsafe { *ptr }
+        self.as_slice().try_into().unwrap()
     }
 }
 impl_conversion_for_entity_unpack!([u8; 36], TransactionKey);
@@ -24,9 +26,9 @@ impl Pack<packed::WithdrawalKey> for [u8; 36] {
 }
 
 impl<'r> Unpack<[u8; 36]> for packed::WithdrawalKeyReader<'r> {
+    #[inline]
     fn unpack(&self) -> [u8; 36] {
-        let ptr = self.as_slice().as_ptr() as *const [u8; 36];
-        unsafe { *ptr }
+        self.as_slice().try_into().unwrap()
     }
 }
 impl_conversion_for_entity_unpack!([u8; 36], WithdrawalKey);

--- a/crates/types/src/conversion/store.rs
+++ b/crates/types/src/conversion/store.rs
@@ -14,7 +14,9 @@ impl Pack<packed::TransactionKey> for [u8; 36] {
 impl<'r> Unpack<[u8; 36]> for packed::TransactionKeyReader<'r> {
     #[inline]
     fn unpack(&self) -> [u8; 36] {
-        self.as_slice().try_into().unwrap()
+        self.as_slice()
+            .try_into()
+            .expect("unpack TransactionKeyReader")
     }
 }
 impl_conversion_for_entity_unpack!([u8; 36], TransactionKey);
@@ -28,7 +30,9 @@ impl Pack<packed::WithdrawalKey> for [u8; 36] {
 impl<'r> Unpack<[u8; 36]> for packed::WithdrawalKeyReader<'r> {
     #[inline]
     fn unpack(&self) -> [u8; 36] {
-        self.as_slice().try_into().unwrap()
+        self.as_slice()
+            .try_into()
+            .expect("unpack WithdrawalKeyReader")
     }
 }
 impl_conversion_for_entity_unpack!([u8; 36], WithdrawalKey);


### PR DESCRIPTION
Eliminate potential unaligned or out-of-bound loads.

Adding `#[inline]` should allow the compiler to remove the bounds check when it can prove the length of the slice and just emit a simple load instruction most of the time. This is necessary because we use multiple crates and are not using LTO.