### PR TITLE
CI: lock the `kicker_ref` of integration-test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,3 +37,4 @@ jobs:
       # github.head_ref: The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.
       # github.ref: The branch or tag ref that triggered the workflow run. For branches this is the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>.
       godwoken_ref: ${{ github.head_ref || github.ref }}
+      kicker_ref: 9ee4c8272974562d21124f7f10e9028aed78812d


### PR DESCRIPTION
-> https://github.com/RetricSu/godwoken-kicker/commits/9ee4c8272974562d21124f7f10e9028aed78812d