### PR TITLE
fix(gw-tools): Use the first Godwoken account (id = 2) as block_producer

### DIFF
--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -68,7 +68,7 @@ pub async fn generate_node_config(args: GenerateNodeConfigArgs<'_>) -> Result<Co
         .into();
 
     // build configuration
-    let account_id = 0;
+    let account_id = 2; // Use the first Godwoken account (id = 2) as block_producer by default
     let node_wallet_info = get_wallet_info(privkey_path);
     let code_hash: [u8; 32] = {
         let mut hash = [0u8; 32];

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -68,7 +68,8 @@ pub async fn generate_node_config(args: GenerateNodeConfigArgs<'_>) -> Result<Co
         .into();
 
     // build configuration
-    let account_id = 2; // Use the first Godwoken account (id = 2) as block_producer by default
+    // In Godwoken v1, block producer should be an ETH EOA.
+    let account_id = 2; // Use the first Godwoken EOA (account_id = 2) as block_producer by default
     let node_wallet_info = get_wallet_info(privkey_path);
     let code_hash: [u8; 32] = {
         let mut hash = [0u8; 32];


### PR DESCRIPTION
In Godwoken v1, block producer should be an ETH EOA.
By default, Use the first Godwoken EOA (account_id = 2) as block_producer.

- https://github.com/nervosnetwork/godwoken-polyjuice/pull/130
   `block.coinbase` needs the real block_producer's account ID

## Refs
- https://github.com/nervosnetwork/godwoken/issues/616
- https://github.com/RetricSu/godwoken-kicker/pull/188
