### PR TITLE
chore(ci): integration test through chat bot

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,87 @@
+name: Dispatch integration test from PR
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  from-comment:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/itest')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query author repository permissions
+        uses: octokit/request-action@v2.x
+        id: user_permission
+        with:
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # restrict /itest to users with admin or write permission
+      # see https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-repository-permissions-for-a-user
+      - name: Dispatch if user does have correct permission
+        if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
+        id: dispatch
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+          script: |
+            const dispatch = {
+              comment_body: `${{ github.event.comment.body }}`,
+              repo: context.repo,
+              issue: context.issue,
+            };
+            const jsonDispatch = JSON.stringify(dispatch)
+              .replace(/\\b/g, "\\\\b")
+              .replace(/\\f/g, "\\\\f")
+              .replace(/\\n/g, "\\\\n")
+              .replace(/\\r/g, "\\\\r")
+              .replace(/\\t/g, "\\\\t");
+
+            const resp = await github.rest.actions.createWorkflowDispatch({
+              owner: "nervosnetwork",
+              repo: "godwoken-tests",
+              workflow_id: "integration-test-chat-bot-v1.yml",
+              ref: "develop",
+              inputs: {
+                dispatch: jsonDispatch,
+              }
+            });
+
+            core.info(`${JSON.stringify(resp, null, 2)}`);
+
+  from-pr:
+    if: github.event.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch from pull request
+        uses: actions/github-script@v6
+        id: dispatch
+        with:
+          github-token: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+          script: |
+            const dispatch = {
+              comment_body: "",
+              repo: context.repo,
+              issue: context.issue,
+            };
+            const jsonDispatch = JSON.stringify(dispatch)
+              .replace(/\\b/g, "\\\\b")
+              .replace(/\\f/g, "\\\\f")
+              .replace(/\\n/g, "\\\\n")
+              .replace(/\\r/g, "\\\\r")
+              .replace(/\\t/g, "\\\\t");
+
+            const resp = await github.rest.actions.createWorkflowDispatch({
+              owner: "nervosnetwork",
+              repo: "godwoken-tests",
+              workflow_id: "integration-test-chat-bot-v1.yml",
+              ref: "develop",
+              inputs: {
+                dispatch: jsonDispatch,
+              }
+            });
+
+            core.info(`${JSON.stringify(resp, null, 2)}`);

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,12 +30,3 @@ jobs:
         run: RUST_BACKTRACE=1 cargo test --all-targets
       - name: Test TOML serialization
         run: cargo run --bin godwoken -- generate-example-config -o test.toml
-
-  integration-test:
-    uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@6e20527d3a5bc7a843c947366a64da4c97520795
-    with:
-      # github.head_ref: The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.
-      # github.ref: The branch or tag ref that triggered the workflow run. For branches this is the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>.
-      godwoken_ref: ${{ github.head_ref || github.ref }}
-      kicker_ref: 9ee4c8272974562d21124f7f10e9028aed78812d
-      tests_ref: 6e20527d3a5bc7a843c947366a64da4c97520795


### PR DESCRIPTION
Use chat bot to run integration test

[preview url](https://github.com/zeroqn/chatops/pull/2#issuecomment-1082591041)

require godwoken-tests pr: [95](https://github.com/nervosnetwork/godwoken-tests/pull/95)

NOTE: must configure ```secrets.WORKFLOW_DISPATCH_TOKEN``` in repository settings.