### PR TITLE
feat: fast withdrawal to v1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Install Rust components
       run: rustup component add rustfmt && rustup component add clippy
     - uses: actions/cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-        ref: ${{ github.event.pull_request.head.sha }}
     - name: Install Rust components
       run: rustup component add rustfmt && rustup component add clippy
     - uses: actions/cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,6 +2065,7 @@ dependencies = [
  "gw-store",
  "gw-traits",
  "gw-types",
+ "gw-utils",
  "gw-version",
  "hyper",
  "jsonrpc-v2",

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -799,6 +799,7 @@ pub async fn run(config: Config, skip_config_check: bool) -> Result<()> {
         last_submitted_tx_hash: block_producer
             .as_ref()
             .map(|bp| bp.last_submitted_tx_hash()),
+        withdrawal_to_v1_config: config.withdrawal_to_v1_config.clone(),
     };
 
     let rpc_registry = Registry::create(args).await;

--- a/crates/block-producer/src/withdrawal.rs
+++ b/crates/block-producer/src/withdrawal.rs
@@ -232,7 +232,7 @@ pub fn unlock_to_owner(
     let l1_sudt_script_hash = rollup_context.rollup_config.l1_sudt_script_type_hash();
     for withdrawal_cell in withdrawal_cells {
         // Double check
-        if let Err(err) = gw_rpc_client::withdrawal::verify_unlockable_to_owner(
+        if let Err(err) = gw_rpc_client::withdrawal::unlockable_to_owner(
             &withdrawal_cell,
             last_finalized_block_number,
             &l1_sudt_script_hash,
@@ -454,7 +454,7 @@ mod test {
         };
         let last_finalized_block_number =
             block.raw().number().unpack() + rollup_context.rollup_config.finality_blocks().unpack();
-        gw_rpc_client::withdrawal::verify_unlockable_to_owner(
+        gw_rpc_client::withdrawal::unlockable_to_owner(
             &info,
             last_finalized_block_number,
             &sudt_script.code_hash(),

--- a/crates/block-producer/src/withdrawal.rs
+++ b/crates/block-producer/src/withdrawal.rs
@@ -217,7 +217,7 @@ pub fn unlock_to_owner(
     let mut unlocked_to_owner_outputs = vec![];
 
     let unlock_via_finalize_witness = {
-        let unlock_args = UnlockWithdrawalViaFinalize::new_builder().build();
+        let unlock_args = UnlockWithdrawalViaFinalize::default();
         let unlock_witness = UnlockWithdrawalWitness::new_builder()
             .set(UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaFinalize(
                 unlock_args,
@@ -228,7 +228,7 @@ pub fn unlock_to_owner(
             .build()
     };
     let unlock_to_v1_witness = {
-        let unlock_args = UnlockWithdrawalToV1::new_builder().build();
+        let unlock_args = UnlockWithdrawalToV1::default();
         let unlock_witness = UnlockWithdrawalWitness::new_builder()
             .set(UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(
                 unlock_args,
@@ -691,7 +691,7 @@ mod test {
         assert_eq!(expected_input.cell.data, input.cell.data);
 
         let expected_witness = {
-            let unlock_args = UnlockWithdrawalViaFinalize::new_builder().build();
+            let unlock_args = UnlockWithdrawalViaFinalize::default();
             let unlock_witness = UnlockWithdrawalWitness::new_builder()
                 .set(UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaFinalize(
                     unlock_args,
@@ -737,7 +737,7 @@ mod test {
         assert_eq!(expected_input.cell.data, input.cell.data);
 
         let expected_witness = {
-            let unlock_args = UnlockWithdrawalToV1::new_builder().build();
+            let unlock_args = UnlockWithdrawalToV1::default();
             let unlock_witness = UnlockWithdrawalWitness::new_builder()
                 .set(UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(
                     unlock_args,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -44,6 +44,8 @@ pub struct Config {
     pub reload_config_github_url: Option<GithubConfigUrl>,
     #[serde(default)]
     pub dynamic_config: DynamicConfig,
+    #[serde(default)]
+    pub withdrawal_to_v1_config: Option<WithdrawalToV1Config>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -419,6 +421,13 @@ pub struct GithubConfigUrl {
 pub struct DynamicConfig {
     pub fee_config: FeeConfig,
     pub rpc_config: RPCConfig,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WithdrawalToV1Config {
+    pub v1_rollup_type_hash: H256,
+    pub v1_deposit_lock_code_hash: H256,
+    pub v1_deposit_minimal_cancel_timeout_msecs: u64,
 }
 
 #[cfg(test)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -427,6 +427,7 @@ pub struct DynamicConfig {
 pub struct WithdrawalToV1Config {
     pub v1_rollup_type_hash: H256,
     pub v1_deposit_lock_code_hash: H256,
+    pub v1_eth_lock_code_hash: H256, // Used in gw-tools withdraw-to-v1 command
     pub v1_deposit_minimal_cancel_timeout_msecs: u64,
 }
 

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -72,6 +72,8 @@ pub enum WithdrawalError {
     NonPositiveSUDTAmount,
     #[error("Expected owner lock hash {0}")]
     OwnerLock(Byte32),
+    #[error("Expected v1 deposit lock hash {0}")]
+    V1DepositLock(Byte32),
 }
 
 impl From<WithdrawalError> for Error {

--- a/crates/rpc-client/src/rpc_client.rs
+++ b/crates/rpc-client/src/rpc_client.rs
@@ -1428,7 +1428,7 @@ impl RPCClient {
                     continue;
                 }
 
-                if let Err(err) = crate::withdrawal::verify_unlockable_to_owner(
+                if let Err(err) = crate::withdrawal::unlockable_to_owner(
                     &info,
                     last_finalized_block_number,
                     &rollup_context.rollup_config.l1_sudt_script_type_hash(),

--- a/crates/rpc-client/src/withdrawal.rs
+++ b/crates/rpc-client/src/withdrawal.rs
@@ -13,6 +13,15 @@ pub enum UnlockMethod {
     WithdrawalToV1 { deposit_lock: Script },
 }
 
+impl UnlockMethod {
+    pub fn into_owner_lock(self) -> Script {
+        match self {
+            UnlockMethod::Finalized { owner_lock } => owner_lock,
+            UnlockMethod::WithdrawalToV1 { deposit_lock } => deposit_lock,
+        }
+    }
+}
+
 pub fn unlockable_to_owner(
     info: &CellInfo,
     last_finalized_block_number: u64,

--- a/crates/rpc-client/src/withdrawal.rs
+++ b/crates/rpc-client/src/withdrawal.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use anyhow::{bail, Result};
 use ckb_types::prelude::{Entity, Reader};
 use gw_types::bytes::Bytes;
@@ -85,9 +87,8 @@ impl WithdrawalLock {
                 Err(_) => bail!("invalid withdrawal lock args"),
             };
 
-        let mut owner_lock_len_buf = [0u8; 4];
-        owner_lock_len_buf.copy_from_slice(&args.slice(lock_args_end..owner_lock_start));
-        let owner_lock_len = u32::from_be_bytes(owner_lock_len_buf) as usize;
+        let owner_lock_len =
+            u32::from_be_bytes(args[lock_args_end..owner_lock_start].try_into()?) as usize;
         let owner_lock_end = owner_lock_start + owner_lock_len;
         if owner_lock_end != args_len && owner_lock_end + 1 != args_len {
             bail!("invalid owner lock len");

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -21,6 +21,7 @@ gw-version = { path = "../version" }
 gw-rpc-client = { path = "../rpc-client" }
 gw-rpc-ws-server = { path = "../rpc-ws-server" }
 gw-dynamic-config = { path = "../dynamic-config"}
+gw-utils = { path = "../utils" }
 faster-hex = "0.4"
 ckb-crypto = "0.100.0"
 ckb-fixed-hash = "0.100.0"

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -1765,7 +1765,7 @@ mod tests {
             args.extend_from_slice(&err_deposit_args.as_bytes());
             args
         };
-        let err_deposit_lock = { deposit_lock.clone() }
+        let err_deposit_lock = deposit_lock
             .as_builder()
             .args(err_args_bytes.pack())
             .build();

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -1582,6 +1582,7 @@ mod tests {
         let config = WithdrawalToV1Config {
             v1_rollup_type_hash: H256([1u8; 32]),
             v1_deposit_lock_code_hash: H256([2u8; 32]),
+            v1_eth_lock_code_hash: H256([9u8; 32]),
             v1_deposit_minimal_cancel_timeout_msecs: SEVEN_DAYS.as_millis() as u64,
         };
         let verifier = WithdrawalToV1RequestVerifier::new(Some(config.clone()));
@@ -1628,7 +1629,7 @@ mod tests {
         assert!(err.to_string().contains("withdrawal to v1 is disabled"));
 
         // ## No deposit lock
-        let no_deposit_lock = req_extra.clone().as_builder().owner_lock(None.pack());
+        let no_deposit_lock = req_extra.as_builder().owner_lock(None.pack());
         let err = verifier.verify(&no_deposit_lock.build()).unwrap_err();
         assert!(err.to_string().contains("v1 deposit lock not found"));
 
@@ -1755,7 +1756,7 @@ mod tests {
         assert!(err_str.contains("invalid v1 deposit cancel timeout"));
 
         // ## V1 ceposit cancel timeout use block number
-        let err_deposit_args = { deposit_args.clone() }
+        let err_deposit_args = deposit_args
             .as_builder()
             .cancel_timeout((FLAG_SINCE_RELATIVE | FLAG_SINCE_BLOCK_NUMBER | 1).pack())
             .build();

--- a/crates/tests/src/tests/restore_mem_block.rs
+++ b/crates/tests/src/tests/restore_mem_block.rs
@@ -236,6 +236,7 @@ async fn test_restore_mem_block() {
             server_config: Default::default(),
             dynamic_config_manager,
             last_submitted_tx_hash: None,
+            withdrawal_to_v1_config: None,
         };
 
         Registry::create(args).await

--- a/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
+++ b/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
@@ -512,7 +512,7 @@ async fn test_build_unlock_to_owner_tx() {
     let unlockable_random_withdrawals: Vec<_> = random_withdrawal_cells
         .into_iter()
         .filter(|cell| {
-            gw_rpc_client::withdrawal::verify_unlockable_to_owner(
+            gw_rpc_client::withdrawal::unlockable_to_owner(
                 cell,
                 last_finalized_block_number,
                 &rollup_context.rollup_config.l1_sudt_script_type_hash(),

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -251,6 +251,7 @@ pub async fn generate_node_config(args: GenerateNodeConfigArgs<'_>) -> Result<Co
         trace: None,
         reload_config_github_url: None,
         dynamic_config: Default::default(),
+        withdrawal_to_v1_config: Default::default(),
     };
 
     Ok(config)

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -1122,7 +1122,9 @@ async fn run_cli() -> Result<()> {
                 eth_address,
                 config_path,
                 scripts_deployment_path,
-            ) {
+            )
+            .await
+            {
                 log::error!("Withdrawal error: {}", err);
                 std::process::exit(-1);
             };

--- a/crates/tools/src/utils/transaction.rs
+++ b/crates/tools/src/utils/transaction.rs
@@ -88,22 +88,19 @@ pub fn wait_for_tx(
     let start_time = Instant::now();
     while start_time.elapsed() < retry_timeout {
         std::thread::sleep(Duration::from_secs(5));
-        match rpc_client
-            .get_transaction(tx_hash.clone())
-            .map_err(|err| anyhow!(err))?
-        {
-            Some(tx_with_status) if tx_with_status.tx_status.status == Status::Pending => {
+        match rpc_client.get_transaction(tx_hash.clone()) {
+            Ok(Some(tx_with_status)) if tx_with_status.tx_status.status == Status::Pending => {
                 log::info!("tx pending");
             }
-            Some(tx_with_status) if tx_with_status.tx_status.status == Status::Proposed => {
+            Ok(Some(tx_with_status)) if tx_with_status.tx_status.status == Status::Proposed => {
                 log::info!("tx proposed");
             }
-            Some(tx_with_status) if tx_with_status.tx_status.status == Status::Committed => {
+            Ok(Some(tx_with_status)) if tx_with_status.tx_status.status == Status::Committed => {
                 log::info!("tx commited");
                 return Ok(tx_with_status.transaction);
             }
-            err => {
-                log::error!("unexpected tx status: {:?}", err)
+            res => {
+                log::error!("unexpected response of get_transaction: {:?}", res)
             }
         }
     }

--- a/crates/tools/src/withdraw_to_v1.rs
+++ b/crates/tools/src/withdraw_to_v1.rs
@@ -29,6 +29,8 @@ const FLAG_SINCE_RELATIVE: u64 =
 const FLAG_SINCE_TIMESTAMP: u64 =
     0b100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
 
+const ETH_REGISTRY_ACCOUNT_ID: u32 = 2;
+
 #[allow(clippy::too_many_arguments)]
 pub fn withdraw(
     godwoken_rpc_url: &str,
@@ -102,6 +104,7 @@ pub fn withdraw(
             .owner_lock_hash(owner_lock_hash.pack())
             .cancel_timeout(cancel_timeout.pack())
             .layer2_lock(v1_l2_lock)
+            .registry_id(ETH_REGISTRY_ACCOUNT_ID.pack())
             .build();
 
         let mut args = v1_config.v1_rollup_type_hash.0.to_vec();

--- a/crates/tools/src/withdraw_to_v1.rs
+++ b/crates/tools/src/withdraw_to_v1.rs
@@ -5,13 +5,15 @@ use crate::godwoken_rpc::GodwokenRpcClient;
 use crate::hasher::{CkbHasher, EthHasher};
 use crate::types::ScriptsDeploymentResult;
 use crate::utils::transaction::read_config;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use ckb_fixed_hash::H256;
 use ckb_jsonrpc_types::JsonBytes;
-use ckb_sdk::{Address, HumanCapacity};
+use ckb_sdk::{AddressPayload, HumanCapacity, SECP256K1};
 use ckb_types::{prelude::Builder as CKBBuilder, prelude::Entity as CKBEntity};
 use gw_types::core::ScriptHashType;
-use gw_types::packed::{CellOutput, WithdrawalLockArgs, WithdrawalRequestExtra};
+use gw_types::packed::{
+    CellOutput, Script, V1DepositLockArgs, WithdrawalLockArgs, WithdrawalRequestExtra,
+};
 use gw_types::{
     bytes::Bytes as GwBytes,
     packed::{Byte32, RawWithdrawalRequest, WithdrawalRequest},
@@ -22,18 +24,28 @@ use std::time::{Duration, Instant};
 use std::u128;
 use std::{fs, path::Path};
 
+const FLAG_SINCE_RELATIVE: u64 =
+    0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+const FLAG_SINCE_TIMESTAMP: u64 =
+    0b100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+
 #[allow(clippy::too_many_arguments)]
-pub async fn withdraw(
+pub fn withdraw(
     godwoken_rpc_url: &str,
     privkey_path: &Path,
     capacity: &str,
     amount: &str,
     fee: &str,
     sudt_script_hash: &str,
-    owner_ckb_address: &str,
+    eth_address: &str,
     config_path: &Path,
     scripts_deployment_path: &Path,
 ) -> Result<()> {
+    let config = read_config(&config_path)?;
+    if config.withdrawal_to_v1_config.is_none() {
+        bail!("withdrawal to v1 is disabled");
+    }
+
     let sudt_script_hash = H256::from_str(sudt_script_hash.trim().trim_start_matches("0x"))?;
     let capacity = parse_capacity(capacity)?;
     let amount: u128 = amount.parse().expect("sUDT amount format error");
@@ -46,7 +58,7 @@ pub async fn withdraw(
     let mut godwoken_rpc_client = GodwokenRpcClient::new(godwoken_rpc_url);
 
     let sell_capacity = u64::MAX;
-    let config = read_config(&config_path)?;
+    let payment_lock_hash = H256::from([0u8; 32]);
     let rollup_type_hash = &config.genesis.rollup_type_hash;
 
     let is_sudt = sudt_script_hash != H256([0u8; 32]);
@@ -60,31 +72,61 @@ pub async fn withdraw(
         return Err(msg);
     }
 
-    let payment_lock_hash = H256::from([0u8; 32]);
-
-    // owner_ckb_address -> owner_lock_hash
-    let owner_lock_script = {
-        let address = Address::from_str(owner_ckb_address).map_err(|err| anyhow!(err))?;
-        let payload = address.payload();
-        ckb_types::packed::Script::from(payload)
-    };
-    let owner_lock_hash: H256 = CkbHasher::new()
-        .update(owner_lock_script.as_slice())
-        .finalize();
-
     let privkey = read_privkey(privkey_path)?;
+    let v1_config = config.withdrawal_to_v1_config.expect("v1 config");
+
+    // v1 l2 lock
+    let v1_l2_lock = {
+        let eth_address = hex::decode(&eth_address.trim_start_matches("0x").as_bytes())?;
+        let args = {
+            let mut args = v1_config.v1_rollup_type_hash.0.to_vec();
+            args.extend_from_slice(&eth_address);
+            args
+        };
+
+        Script::new_builder()
+            .code_hash(v1_config.v1_eth_lock_code_hash.pack())
+            .hash_type(ScriptHashType::Type.into())
+            .args(args.pack())
+            .build()
+    };
+    let v1_deposit_lock = {
+        let owner_lock_hash = privkey_to_lock_hash(&privkey)?;
+        let cancel_timeout = {
+            let timestamp =
+                Duration::from_millis(v1_config.v1_deposit_minimal_cancel_timeout_msecs).as_secs()
+                    + 1;
+            FLAG_SINCE_RELATIVE | FLAG_SINCE_TIMESTAMP | timestamp
+        };
+        let lock_args = V1DepositLockArgs::new_builder()
+            .owner_lock_hash(owner_lock_hash.pack())
+            .cancel_timeout(cancel_timeout.pack())
+            .layer2_lock(v1_l2_lock)
+            .build();
+
+        let mut args = v1_config.v1_rollup_type_hash.0.to_vec();
+        args.extend_from_slice(lock_args.as_slice());
+
+        Script::new_builder()
+            .code_hash(v1_config.v1_deposit_lock_code_hash.pack())
+            .hash_type(ScriptHashType::Type.into())
+            .args(args.pack())
+            .build()
+    };
+
+    let v1_deposit_lock_hash: H256 = CkbHasher::new()
+        .update(v1_deposit_lock.as_slice())
+        .finalize();
 
     let from_address = privkey_to_short_address(&privkey, rollup_type_hash, &scripts_deployment)?;
 
     // get from_id
-    let from_id = short_address_to_account_id(&mut godwoken_rpc_client, &from_address).await?;
+    let from_id = short_address_to_account_id(&mut godwoken_rpc_client, &from_address)?;
     let from_id = from_id.expect("from id not found!");
-    let nonce =
-        tokio::runtime::Handle::current().block_on(godwoken_rpc_client.get_nonce(from_id))?;
+    let nonce = godwoken_rpc_client.get_nonce(from_id)?;
 
     // get account_script_hash
-    let account_script_hash =
-        tokio::runtime::Handle::current().block_on(godwoken_rpc_client.get_script_hash(from_id))?;
+    let account_script_hash = godwoken_rpc_client.get_script_hash(from_id)?;
 
     let raw_request = create_raw_withdrawal_request(
         &nonce,
@@ -95,7 +137,7 @@ pub async fn withdraw(
         &account_script_hash,
         &sell_capacity,
         &0u128,
-        &owner_lock_hash,
+        &v1_deposit_lock_hash,
         &payment_lock_hash,
     )?;
 
@@ -106,21 +148,19 @@ pub async fn withdraw(
         .raw(raw_request)
         .signature(signature.pack())
         .build();
-    let owner_lock = gw_types::packed::Script::new_unchecked(owner_lock_script.as_bytes());
     let withdrawal_request_extra = WithdrawalRequestExtra::new_builder()
         .request(withdrawal_request)
-        .owner_lock(Some(owner_lock).pack())
+        .owner_lock(Some(v1_deposit_lock).pack())
+        .withdraw_to_v1(1u8.into())
         .build();
 
     log::info!("withdrawal_request_extra: {}", withdrawal_request_extra);
 
-    let init_balance = tokio::runtime::Handle::current().block_on(
-        godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1),
-    )?;
+    let init_balance =
+        godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1)?;
 
     let bytes = JsonBytes::from_bytes(withdrawal_request_extra.as_bytes());
-    let withdrawal_hash = tokio::runtime::Handle::current()
-        .block_on(godwoken_rpc_client.submit_withdrawal_request(bytes))?;
+    let withdrawal_hash = godwoken_rpc_client.submit_withdrawal_request(bytes)?;
     log::info!("withdrawal_hash: {}", withdrawal_hash.pack());
 
     wait_for_balance_change(&mut godwoken_rpc_client, from_address, init_balance, 180u64)?;
@@ -198,9 +238,8 @@ fn wait_for_balance_change(
     while start_time.elapsed() < retry_timeout {
         std::thread::sleep(Duration::from_secs(2));
 
-        let balance = tokio::runtime::Handle::current().block_on(
-            godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1),
-        )?;
+        let balance =
+            godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1)?;
         log::info!(
             "current balance: {}, waiting for {} secs.",
             balance,
@@ -271,4 +310,16 @@ fn minimal_withdrawal_capacity(is_sudt: bool) -> Result<u64> {
 
     let capacity = output.occupied_capacity(data_capacity)?;
     Ok(capacity)
+}
+
+fn privkey_to_lock_hash(privkey: &H256) -> Result<H256> {
+    use ckb_types::packed::Script;
+    use ckb_types::prelude::Unpack;
+
+    let privkey = secp256k1::SecretKey::from_slice(privkey.as_bytes())?;
+    let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &privkey);
+    let address_payload = AddressPayload::from_pubkey(&pubkey);
+
+    let lock_hash: H256 = Script::from(&address_payload).calc_script_hash().unpack();
+    Ok(lock_hash)
 }

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -163,6 +163,13 @@ table DepositLockArgs {
     layer2_lock: Script,
     cancel_timeout: Uint64,
 }
+
+table V1DepositLockArgs {
+    // layer1 lock hash
+    owner_lock_hash: Byte32,
+    layer2_lock: Script,
+    cancel_timeout: Uint64,
+}
 // --- end of deposit lock ---
 
 // --- custodian lock ---

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -201,6 +201,7 @@ union UnlockWithdrawalWitness {
     UnlockWithdrawalViaFinalize,
     UnlockWithdrawalViaRevert,
     UnlockWithdrawalViaTrade,
+    UnlockWithdrawalToV1,
 }
 table UnlockWithdrawalViaFinalize {
 }
@@ -209,6 +210,8 @@ struct UnlockWithdrawalViaRevert {
 }
 table UnlockWithdrawalViaTrade {
     owner_lock: Script,
+}
+table UnlockWithdrawalToV1 {
 }
 // --- end of withdrawal lock ---
 

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -169,6 +169,7 @@ table V1DepositLockArgs {
     owner_lock_hash: Byte32,
     layer2_lock: Script,
     cancel_timeout: Uint64,
+    registry_id: Uint32,
 }
 // --- end of deposit lock ---
 

--- a/crates/types/schemas/store.mol
+++ b/crates/types/schemas/store.mol
@@ -50,6 +50,13 @@ table WithdrawalReceipt {
 table WithdrawalRequestExtra {
     request: WithdrawalRequest,
     owner_lock: ScriptOpt,
+    withdraw_to_v1: byte,
+}
+
+// For exists mempool withdrawal request in db
+table DeprecatedWithdrawRequestExtra {
+    request: WithdrawalRequest,
+    owner_lock: ScriptOpt,
 }
 
 struct SMTBranchKey {

--- a/crates/types/src/conversion/godwoken.rs
+++ b/crates/types/src/conversion/godwoken.rs
@@ -24,4 +24,3 @@ impl_conversion_for_packed_iterator_pack!(DepositRequest, DepositRequestVec);
 impl_conversion_for_packed_iterator_pack!(WithdrawalRequest, WithdrawalRequestVec);
 impl_conversion_for_packed_iterator_pack!(L2Transaction, L2TransactionVec);
 impl_conversion_for_packed_iterator_pack!(RawL2Block, RawL2BlockVec);
-impl_conversion_for_packed_iterator_pack!(DepositInfo, DepositInfoVec);

--- a/crates/types/src/conversion/mem_block.rs
+++ b/crates/types/src/conversion/mem_block.rs
@@ -95,6 +95,7 @@ impl<'r> Unpack<CollectedCustodianCells> for packed::CollectedCustodianCellsRead
 }
 
 impl_conversion_for_packed_iterator_pack!(AccountMerkleState, AccountMerkleStateVec);
+impl_conversion_for_packed_iterator_pack!(DepositInfo, DepositInfoVec);
 impl_conversion_for_vector!(DepositInfo, DepositInfoVec, DepositInfoVecReader);
 impl_conversion_for_vector!(CellInfo, CellInfoVec, CellInfoVecReader);
 impl_conversion_for_vector!(SudtCustodian, SudtCustodianVec, SudtCustodianVecReader);

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -7109,6 +7109,298 @@ impl molecule::prelude::Builder for DepositLockArgsBuilder {
     }
 }
 #[derive(Clone)]
+pub struct V1DepositLockArgs(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for V1DepositLockArgs {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for V1DepositLockArgs {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for V1DepositLockArgs {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "owner_lock_hash", self.owner_lock_hash())?;
+        write!(f, ", {}: {}", "layer2_lock", self.layer2_lock())?;
+        write!(f, ", {}: {}", "cancel_timeout", self.cancel_timeout())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for V1DepositLockArgs {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            109, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 53, 0, 0, 0, 16, 0, 0,
+            0, 48, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        V1DepositLockArgs::new_unchecked(v.into())
+    }
+}
+impl V1DepositLockArgs {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn owner_lock_hash(&self) -> Byte32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Byte32::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn layer2_lock(&self) -> Script {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Script::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn cancel_timeout(&self) -> Uint64 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            Uint64::new_unchecked(self.0.slice(start..end))
+        } else {
+            Uint64::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> V1DepositLockArgsReader<'r> {
+        V1DepositLockArgsReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for V1DepositLockArgs {
+    type Builder = V1DepositLockArgsBuilder;
+    const NAME: &'static str = "V1DepositLockArgs";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        V1DepositLockArgs(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        V1DepositLockArgsReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        V1DepositLockArgsReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .owner_lock_hash(self.owner_lock_hash())
+            .layer2_lock(self.layer2_lock())
+            .cancel_timeout(self.cancel_timeout())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct V1DepositLockArgsReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for V1DepositLockArgsReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for V1DepositLockArgsReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for V1DepositLockArgsReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "owner_lock_hash", self.owner_lock_hash())?;
+        write!(f, ", {}: {}", "layer2_lock", self.layer2_lock())?;
+        write!(f, ", {}: {}", "cancel_timeout", self.cancel_timeout())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> V1DepositLockArgsReader<'r> {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn owner_lock_hash(&self) -> Byte32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Byte32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn layer2_lock(&self) -> ScriptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        ScriptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn cancel_timeout(&self) -> Uint64Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            Uint64Reader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            Uint64Reader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for V1DepositLockArgsReader<'r> {
+    type Entity = V1DepositLockArgs;
+    const NAME: &'static str = "V1DepositLockArgsReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        V1DepositLockArgsReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Byte32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        ScriptReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Uint64Reader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct V1DepositLockArgsBuilder {
+    pub(crate) owner_lock_hash: Byte32,
+    pub(crate) layer2_lock: Script,
+    pub(crate) cancel_timeout: Uint64,
+}
+impl V1DepositLockArgsBuilder {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn owner_lock_hash(mut self, v: Byte32) -> Self {
+        self.owner_lock_hash = v;
+        self
+    }
+    pub fn layer2_lock(mut self, v: Script) -> Self {
+        self.layer2_lock = v;
+        self
+    }
+    pub fn cancel_timeout(mut self, v: Uint64) -> Self {
+        self.cancel_timeout = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for V1DepositLockArgsBuilder {
+    type Entity = V1DepositLockArgs;
+    const NAME: &'static str = "V1DepositLockArgsBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.owner_lock_hash.as_slice().len()
+            + self.layer2_lock.as_slice().len()
+            + self.cancel_timeout.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.owner_lock_hash.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.layer2_lock.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.cancel_timeout.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.owner_lock_hash.as_slice())?;
+        writer.write_all(self.layer2_lock.as_slice())?;
+        writer.write_all(self.cancel_timeout.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        V1DepositLockArgs::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct CustodianLockArgs(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for CustodianLockArgs {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -7894,7 +7894,7 @@ impl ::core::default::Default for UnlockWithdrawalWitness {
     }
 }
 impl UnlockWithdrawalWitness {
-    pub const ITEMS_COUNT: usize = 3;
+    pub const ITEMS_COUNT: usize = 4;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -7904,6 +7904,7 @@ impl UnlockWithdrawalWitness {
             0 => UnlockWithdrawalViaFinalize::new_unchecked(inner).into(),
             1 => UnlockWithdrawalViaRevert::new_unchecked(inner).into(),
             2 => UnlockWithdrawalViaTrade::new_unchecked(inner).into(),
+            3 => UnlockWithdrawalToV1::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -7960,7 +7961,7 @@ impl<'r> ::core::fmt::Display for UnlockWithdrawalWitnessReader<'r> {
     }
 }
 impl<'r> UnlockWithdrawalWitnessReader<'r> {
-    pub const ITEMS_COUNT: usize = 3;
+    pub const ITEMS_COUNT: usize = 4;
     pub fn item_id(&self) -> molecule::Number {
         molecule::unpack_number(self.as_slice())
     }
@@ -7970,6 +7971,7 @@ impl<'r> UnlockWithdrawalWitnessReader<'r> {
             0 => UnlockWithdrawalViaFinalizeReader::new_unchecked(inner).into(),
             1 => UnlockWithdrawalViaRevertReader::new_unchecked(inner).into(),
             2 => UnlockWithdrawalViaTradeReader::new_unchecked(inner).into(),
+            3 => UnlockWithdrawalToV1Reader::new_unchecked(inner).into(),
             _ => panic!("{}: invalid data", Self::NAME),
         }
     }
@@ -7998,6 +8000,7 @@ impl<'r> molecule::prelude::Reader<'r> for UnlockWithdrawalWitnessReader<'r> {
             0 => UnlockWithdrawalViaFinalizeReader::verify(inner_slice, compatible),
             1 => UnlockWithdrawalViaRevertReader::verify(inner_slice, compatible),
             2 => UnlockWithdrawalViaTradeReader::verify(inner_slice, compatible),
+            3 => UnlockWithdrawalToV1Reader::verify(inner_slice, compatible),
             _ => ve!(Self, UnknownItem, Self::ITEMS_COUNT, item_id),
         }?;
         Ok(())
@@ -8006,7 +8009,7 @@ impl<'r> molecule::prelude::Reader<'r> for UnlockWithdrawalWitnessReader<'r> {
 #[derive(Debug, Default)]
 pub struct UnlockWithdrawalWitnessBuilder(pub(crate) UnlockWithdrawalWitnessUnion);
 impl UnlockWithdrawalWitnessBuilder {
-    pub const ITEMS_COUNT: usize = 3;
+    pub const ITEMS_COUNT: usize = 4;
     pub fn set<I>(mut self, v: I) -> Self
     where
         I: ::core::convert::Into<UnlockWithdrawalWitnessUnion>,
@@ -8037,12 +8040,14 @@ pub enum UnlockWithdrawalWitnessUnion {
     UnlockWithdrawalViaFinalize(UnlockWithdrawalViaFinalize),
     UnlockWithdrawalViaRevert(UnlockWithdrawalViaRevert),
     UnlockWithdrawalViaTrade(UnlockWithdrawalViaTrade),
+    UnlockWithdrawalToV1(UnlockWithdrawalToV1),
 }
 #[derive(Debug, Clone, Copy)]
 pub enum UnlockWithdrawalWitnessUnionReader<'r> {
     UnlockWithdrawalViaFinalize(UnlockWithdrawalViaFinalizeReader<'r>),
     UnlockWithdrawalViaRevert(UnlockWithdrawalViaRevertReader<'r>),
     UnlockWithdrawalViaTrade(UnlockWithdrawalViaTradeReader<'r>),
+    UnlockWithdrawalToV1(UnlockWithdrawalToV1Reader<'r>),
 }
 impl ::core::default::Default for UnlockWithdrawalWitnessUnion {
     fn default() -> Self {
@@ -8081,6 +8086,15 @@ impl ::core::fmt::Display for UnlockWithdrawalWitnessUnion {
                     item
                 )
             }
+            UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(ref item) => {
+                write!(
+                    f,
+                    "{}::{}({})",
+                    Self::NAME,
+                    UnlockWithdrawalToV1::NAME,
+                    item
+                )
+            }
         }
     }
 }
@@ -8114,6 +8128,15 @@ impl<'r> ::core::fmt::Display for UnlockWithdrawalWitnessUnionReader<'r> {
                     item
                 )
             }
+            UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalToV1(ref item) => {
+                write!(
+                    f,
+                    "{}::{}({})",
+                    Self::NAME,
+                    UnlockWithdrawalToV1::NAME,
+                    item
+                )
+            }
         }
     }
 }
@@ -8129,6 +8152,7 @@ impl UnlockWithdrawalWitnessUnion {
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaTrade(ref item) => {
                 write!(f, "{}", item)
             }
+            UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(ref item) => write!(f, "{}", item),
         }
     }
 }
@@ -8142,6 +8166,9 @@ impl<'r> UnlockWithdrawalWitnessUnionReader<'r> {
                 write!(f, "{}", item)
             }
             UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaTrade(ref item) => {
+                write!(f, "{}", item)
+            }
+            UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalToV1(ref item) => {
                 write!(f, "{}", item)
             }
         }
@@ -8160,6 +8187,11 @@ impl ::core::convert::From<UnlockWithdrawalViaRevert> for UnlockWithdrawalWitnes
 impl ::core::convert::From<UnlockWithdrawalViaTrade> for UnlockWithdrawalWitnessUnion {
     fn from(item: UnlockWithdrawalViaTrade) -> Self {
         UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaTrade(item)
+    }
+}
+impl ::core::convert::From<UnlockWithdrawalToV1> for UnlockWithdrawalWitnessUnion {
+    fn from(item: UnlockWithdrawalToV1) -> Self {
+        UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(item)
     }
 }
 impl<'r> ::core::convert::From<UnlockWithdrawalViaFinalizeReader<'r>>
@@ -8183,6 +8215,13 @@ impl<'r> ::core::convert::From<UnlockWithdrawalViaTradeReader<'r>>
         UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaTrade(item)
     }
 }
+impl<'r> ::core::convert::From<UnlockWithdrawalToV1Reader<'r>>
+    for UnlockWithdrawalWitnessUnionReader<'r>
+{
+    fn from(item: UnlockWithdrawalToV1Reader<'r>) -> Self {
+        UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalToV1(item)
+    }
+}
 impl UnlockWithdrawalWitnessUnion {
     pub const NAME: &'static str = "UnlockWithdrawalWitnessUnion";
     pub fn as_bytes(&self) -> molecule::bytes::Bytes {
@@ -8190,6 +8229,7 @@ impl UnlockWithdrawalWitnessUnion {
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaFinalize(item) => item.as_bytes(),
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaRevert(item) => item.as_bytes(),
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaTrade(item) => item.as_bytes(),
+            UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(item) => item.as_bytes(),
         }
     }
     pub fn as_slice(&self) -> &[u8] {
@@ -8197,6 +8237,7 @@ impl UnlockWithdrawalWitnessUnion {
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaFinalize(item) => item.as_slice(),
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaRevert(item) => item.as_slice(),
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaTrade(item) => item.as_slice(),
+            UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
@@ -8204,6 +8245,7 @@ impl UnlockWithdrawalWitnessUnion {
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaFinalize(_) => 0,
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaRevert(_) => 1,
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaTrade(_) => 2,
+            UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(_) => 3,
         }
     }
     pub fn item_name(&self) -> &str {
@@ -8215,6 +8257,7 @@ impl UnlockWithdrawalWitnessUnion {
                 "UnlockWithdrawalViaRevert"
             }
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaTrade(_) => "UnlockWithdrawalViaTrade",
+            UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(_) => "UnlockWithdrawalToV1",
         }
     }
     pub fn as_reader<'r>(&'r self) -> UnlockWithdrawalWitnessUnionReader<'r> {
@@ -8226,6 +8269,7 @@ impl UnlockWithdrawalWitnessUnion {
                 item.as_reader().into()
             }
             UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaTrade(item) => item.as_reader().into(),
+            UnlockWithdrawalWitnessUnion::UnlockWithdrawalToV1(item) => item.as_reader().into(),
         }
     }
 }
@@ -8238,6 +8282,7 @@ impl<'r> UnlockWithdrawalWitnessUnionReader<'r> {
             }
             UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaRevert(item) => item.as_slice(),
             UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaTrade(item) => item.as_slice(),
+            UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalToV1(item) => item.as_slice(),
         }
     }
     pub fn item_id(&self) -> molecule::Number {
@@ -8245,6 +8290,7 @@ impl<'r> UnlockWithdrawalWitnessUnionReader<'r> {
             UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaFinalize(_) => 0,
             UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaRevert(_) => 1,
             UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaTrade(_) => 2,
+            UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalToV1(_) => 3,
         }
     }
     pub fn item_name(&self) -> &str {
@@ -8258,6 +8304,7 @@ impl<'r> UnlockWithdrawalWitnessUnionReader<'r> {
             UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalViaTrade(_) => {
                 "UnlockWithdrawalViaTrade"
             }
+            UnlockWithdrawalWitnessUnionReader::UnlockWithdrawalToV1(_) => "UnlockWithdrawalToV1",
         }
     }
 }
@@ -8837,6 +8884,182 @@ impl molecule::prelude::Builder for UnlockWithdrawalViaTradeBuilder {
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
         UnlockWithdrawalViaTrade::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct UnlockWithdrawalToV1(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for UnlockWithdrawalToV1 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for UnlockWithdrawalToV1 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for UnlockWithdrawalToV1 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for UnlockWithdrawalToV1 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        UnlockWithdrawalToV1::new_unchecked(v.into())
+    }
+}
+impl UnlockWithdrawalToV1 {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn as_reader<'r>(&'r self) -> UnlockWithdrawalToV1Reader<'r> {
+        UnlockWithdrawalToV1Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for UnlockWithdrawalToV1 {
+    type Builder = UnlockWithdrawalToV1Builder;
+    const NAME: &'static str = "UnlockWithdrawalToV1";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        UnlockWithdrawalToV1(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        UnlockWithdrawalToV1Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        UnlockWithdrawalToV1Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+    }
+}
+#[derive(Clone, Copy)]
+pub struct UnlockWithdrawalToV1Reader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for UnlockWithdrawalToV1Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for UnlockWithdrawalToV1Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for UnlockWithdrawalToV1Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ".. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> UnlockWithdrawalToV1Reader<'r> {
+    pub const FIELD_COUNT: usize = 0;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for UnlockWithdrawalToV1Reader<'r> {
+    type Entity = UnlockWithdrawalToV1;
+    const NAME: &'static str = "UnlockWithdrawalToV1Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        UnlockWithdrawalToV1Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len > molecule::NUMBER_SIZE && !compatible {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, !0);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct UnlockWithdrawalToV1Builder {}
+impl UnlockWithdrawalToV1Builder {
+    pub const FIELD_COUNT: usize = 0;
+}
+impl molecule::prelude::Builder for UnlockWithdrawalToV1Builder {
+    type Entity = UnlockWithdrawalToV1;
+    const NAME: &'static str = "UnlockWithdrawalToV1Builder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        writer.write_all(&molecule::pack_number(
+            molecule::NUMBER_SIZE as molecule::Number,
+        ))?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        UnlockWithdrawalToV1::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -7130,6 +7130,7 @@ impl ::core::fmt::Display for V1DepositLockArgs {
         write!(f, "{}: {}", "owner_lock_hash", self.owner_lock_hash())?;
         write!(f, ", {}: {}", "layer2_lock", self.layer2_lock())?;
         write!(f, ", {}: {}", "cancel_timeout", self.cancel_timeout())?;
+        write!(f, ", {}: {}", "registry_id", self.registry_id())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -7140,16 +7141,17 @@ impl ::core::fmt::Display for V1DepositLockArgs {
 impl ::core::default::Default for V1DepositLockArgs {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            109, 0, 0, 0, 16, 0, 0, 0, 48, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 53, 0, 0, 0, 16, 0, 0,
-            0, 48, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            117, 0, 0, 0, 20, 0, 0, 0, 52, 0, 0, 0, 105, 0, 0, 0, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 53, 0, 0,
+            0, 16, 0, 0, 0, 48, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
         ];
         V1DepositLockArgs::new_unchecked(v.into())
     }
 }
 impl V1DepositLockArgs {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -7181,11 +7183,17 @@ impl V1DepositLockArgs {
     pub fn cancel_timeout(&self) -> Uint64 {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        Uint64::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn registry_id(&self) -> Uint32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
-            Uint64::new_unchecked(self.0.slice(start..end))
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            Uint32::new_unchecked(self.0.slice(start..end))
         } else {
-            Uint64::new_unchecked(self.0.slice(start..))
+            Uint32::new_unchecked(self.0.slice(start..))
         }
     }
     pub fn as_reader<'r>(&'r self) -> V1DepositLockArgsReader<'r> {
@@ -7218,6 +7226,7 @@ impl molecule::prelude::Entity for V1DepositLockArgs {
             .owner_lock_hash(self.owner_lock_hash())
             .layer2_lock(self.layer2_lock())
             .cancel_timeout(self.cancel_timeout())
+            .registry_id(self.registry_id())
     }
 }
 #[derive(Clone, Copy)]
@@ -7242,6 +7251,7 @@ impl<'r> ::core::fmt::Display for V1DepositLockArgsReader<'r> {
         write!(f, "{}: {}", "owner_lock_hash", self.owner_lock_hash())?;
         write!(f, ", {}: {}", "layer2_lock", self.layer2_lock())?;
         write!(f, ", {}: {}", "cancel_timeout", self.cancel_timeout())?;
+        write!(f, ", {}: {}", "registry_id", self.registry_id())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -7250,7 +7260,7 @@ impl<'r> ::core::fmt::Display for V1DepositLockArgsReader<'r> {
     }
 }
 impl<'r> V1DepositLockArgsReader<'r> {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -7282,11 +7292,17 @@ impl<'r> V1DepositLockArgsReader<'r> {
     pub fn cancel_timeout(&self) -> Uint64Reader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        Uint64Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn registry_id(&self) -> Uint32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
-            Uint64Reader::new_unchecked(&self.as_slice()[start..end])
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            Uint32Reader::new_unchecked(&self.as_slice()[start..end])
         } else {
-            Uint64Reader::new_unchecked(&self.as_slice()[start..])
+            Uint32Reader::new_unchecked(&self.as_slice()[start..])
         }
     }
 }
@@ -7342,6 +7358,7 @@ impl<'r> molecule::prelude::Reader<'r> for V1DepositLockArgsReader<'r> {
         Byte32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         ScriptReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
         Uint64Reader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        Uint32Reader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
         Ok(())
     }
 }
@@ -7350,9 +7367,10 @@ pub struct V1DepositLockArgsBuilder {
     pub(crate) owner_lock_hash: Byte32,
     pub(crate) layer2_lock: Script,
     pub(crate) cancel_timeout: Uint64,
+    pub(crate) registry_id: Uint32,
 }
 impl V1DepositLockArgsBuilder {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn owner_lock_hash(mut self, v: Byte32) -> Self {
         self.owner_lock_hash = v;
         self
@@ -7365,6 +7383,10 @@ impl V1DepositLockArgsBuilder {
         self.cancel_timeout = v;
         self
     }
+    pub fn registry_id(mut self, v: Uint32) -> Self {
+        self.registry_id = v;
+        self
+    }
 }
 impl molecule::prelude::Builder for V1DepositLockArgsBuilder {
     type Entity = V1DepositLockArgs;
@@ -7374,6 +7396,7 @@ impl molecule::prelude::Builder for V1DepositLockArgsBuilder {
             + self.owner_lock_hash.as_slice().len()
             + self.layer2_lock.as_slice().len()
             + self.cancel_timeout.as_slice().len()
+            + self.registry_id.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
@@ -7384,6 +7407,8 @@ impl molecule::prelude::Builder for V1DepositLockArgsBuilder {
         total_size += self.layer2_lock.as_slice().len();
         offsets.push(total_size);
         total_size += self.cancel_timeout.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.registry_id.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
@@ -7391,6 +7416,7 @@ impl molecule::prelude::Builder for V1DepositLockArgsBuilder {
         writer.write_all(self.owner_lock_hash.as_slice())?;
         writer.write_all(self.layer2_lock.as_slice())?;
         writer.write_all(self.cancel_timeout.as_slice())?;
+        writer.write_all(self.registry_id.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {

--- a/crates/types/src/generated/store.rs
+++ b/crates/types/src/generated/store.rs
@@ -3400,6 +3400,7 @@ impl ::core::fmt::Display for WithdrawalRequestExtra {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "request", self.request())?;
         write!(f, ", {}: {}", "owner_lock", self.owner_lock())?;
+        write!(f, ", {}: {}", "withdraw_to_v1", self.withdraw_to_v1())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -3410,20 +3411,21 @@ impl ::core::fmt::Display for WithdrawalRequestExtra {
 impl ::core::default::Default for WithdrawalRequestExtra {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            228, 0, 0, 0, 12, 0, 0, 0, 228, 0, 0, 0, 216, 0, 0, 0, 12, 0, 0, 0, 212, 0, 0, 0, 0, 0,
+            233, 0, 0, 0, 16, 0, 0, 0, 232, 0, 0, 0, 232, 0, 0, 0, 216, 0, 0, 0, 12, 0, 0, 0, 212,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
         ];
         WithdrawalRequestExtra::new_unchecked(v.into())
     }
 }
 impl WithdrawalRequestExtra {
-    pub const FIELD_COUNT: usize = 2;
+    pub const FIELD_COUNT: usize = 3;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -3449,11 +3451,17 @@ impl WithdrawalRequestExtra {
     pub fn owner_lock(&self) -> ScriptOpt {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        ScriptOpt::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn withdraw_to_v1(&self) -> Byte {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[12..]) as usize;
-            ScriptOpt::new_unchecked(self.0.slice(start..end))
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            Byte::new_unchecked(self.0.slice(start..end))
         } else {
-            ScriptOpt::new_unchecked(self.0.slice(start..))
+            Byte::new_unchecked(self.0.slice(start..))
         }
     }
     pub fn as_reader<'r>(&'r self) -> WithdrawalRequestExtraReader<'r> {
@@ -3485,6 +3493,7 @@ impl molecule::prelude::Entity for WithdrawalRequestExtra {
         Self::new_builder()
             .request(self.request())
             .owner_lock(self.owner_lock())
+            .withdraw_to_v1(self.withdraw_to_v1())
     }
 }
 #[derive(Clone, Copy)]
@@ -3508,6 +3517,7 @@ impl<'r> ::core::fmt::Display for WithdrawalRequestExtraReader<'r> {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "request", self.request())?;
         write!(f, ", {}: {}", "owner_lock", self.owner_lock())?;
+        write!(f, ", {}: {}", "withdraw_to_v1", self.withdraw_to_v1())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -3516,7 +3526,7 @@ impl<'r> ::core::fmt::Display for WithdrawalRequestExtraReader<'r> {
     }
 }
 impl<'r> WithdrawalRequestExtraReader<'r> {
-    pub const FIELD_COUNT: usize = 2;
+    pub const FIELD_COUNT: usize = 3;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -3542,11 +3552,17 @@ impl<'r> WithdrawalRequestExtraReader<'r> {
     pub fn owner_lock(&self) -> ScriptOptReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        ScriptOptReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn withdraw_to_v1(&self) -> ByteReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[12..]) as usize;
-            ScriptOptReader::new_unchecked(&self.as_slice()[start..end])
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            ByteReader::new_unchecked(&self.as_slice()[start..end])
         } else {
-            ScriptOptReader::new_unchecked(&self.as_slice()[start..])
+            ByteReader::new_unchecked(&self.as_slice()[start..])
         }
     }
 }
@@ -3601,6 +3617,7 @@ impl<'r> molecule::prelude::Reader<'r> for WithdrawalRequestExtraReader<'r> {
         }
         WithdrawalRequestReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         ScriptOptReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        ByteReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
         Ok(())
     }
 }
@@ -3608,8 +3625,289 @@ impl<'r> molecule::prelude::Reader<'r> for WithdrawalRequestExtraReader<'r> {
 pub struct WithdrawalRequestExtraBuilder {
     pub(crate) request: WithdrawalRequest,
     pub(crate) owner_lock: ScriptOpt,
+    pub(crate) withdraw_to_v1: Byte,
 }
 impl WithdrawalRequestExtraBuilder {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn request(mut self, v: WithdrawalRequest) -> Self {
+        self.request = v;
+        self
+    }
+    pub fn owner_lock(mut self, v: ScriptOpt) -> Self {
+        self.owner_lock = v;
+        self
+    }
+    pub fn withdraw_to_v1(mut self, v: Byte) -> Self {
+        self.withdraw_to_v1 = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for WithdrawalRequestExtraBuilder {
+    type Entity = WithdrawalRequestExtra;
+    const NAME: &'static str = "WithdrawalRequestExtraBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.request.as_slice().len()
+            + self.owner_lock.as_slice().len()
+            + self.withdraw_to_v1.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.request.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.owner_lock.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.withdraw_to_v1.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.request.as_slice())?;
+        writer.write_all(self.owner_lock.as_slice())?;
+        writer.write_all(self.withdraw_to_v1.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        WithdrawalRequestExtra::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct DeprecatedWithdrawRequestExtra(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for DeprecatedWithdrawRequestExtra {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for DeprecatedWithdrawRequestExtra {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for DeprecatedWithdrawRequestExtra {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "request", self.request())?;
+        write!(f, ", {}: {}", "owner_lock", self.owner_lock())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for DeprecatedWithdrawRequestExtra {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            228, 0, 0, 0, 12, 0, 0, 0, 228, 0, 0, 0, 216, 0, 0, 0, 12, 0, 0, 0, 212, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        DeprecatedWithdrawRequestExtra::new_unchecked(v.into())
+    }
+}
+impl DeprecatedWithdrawRequestExtra {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn request(&self) -> WithdrawalRequest {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        WithdrawalRequest::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn owner_lock(&self) -> ScriptOpt {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            ScriptOpt::new_unchecked(self.0.slice(start..end))
+        } else {
+            ScriptOpt::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> DeprecatedWithdrawRequestExtraReader<'r> {
+        DeprecatedWithdrawRequestExtraReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for DeprecatedWithdrawRequestExtra {
+    type Builder = DeprecatedWithdrawRequestExtraBuilder;
+    const NAME: &'static str = "DeprecatedWithdrawRequestExtra";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        DeprecatedWithdrawRequestExtra(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        DeprecatedWithdrawRequestExtraReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        DeprecatedWithdrawRequestExtraReader::from_compatible_slice(slice)
+            .map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .request(self.request())
+            .owner_lock(self.owner_lock())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct DeprecatedWithdrawRequestExtraReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for DeprecatedWithdrawRequestExtraReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for DeprecatedWithdrawRequestExtraReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for DeprecatedWithdrawRequestExtraReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "request", self.request())?;
+        write!(f, ", {}: {}", "owner_lock", self.owner_lock())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> DeprecatedWithdrawRequestExtraReader<'r> {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn request(&self) -> WithdrawalRequestReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        WithdrawalRequestReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn owner_lock(&self) -> ScriptOptReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            ScriptOptReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            ScriptOptReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for DeprecatedWithdrawRequestExtraReader<'r> {
+    type Entity = DeprecatedWithdrawRequestExtra;
+    const NAME: &'static str = "DeprecatedWithdrawRequestExtraReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        DeprecatedWithdrawRequestExtraReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        WithdrawalRequestReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        ScriptOptReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct DeprecatedWithdrawRequestExtraBuilder {
+    pub(crate) request: WithdrawalRequest,
+    pub(crate) owner_lock: ScriptOpt,
+}
+impl DeprecatedWithdrawRequestExtraBuilder {
     pub const FIELD_COUNT: usize = 2;
     pub fn request(mut self, v: WithdrawalRequest) -> Self {
         self.request = v;
@@ -3620,9 +3918,9 @@ impl WithdrawalRequestExtraBuilder {
         self
     }
 }
-impl molecule::prelude::Builder for WithdrawalRequestExtraBuilder {
-    type Entity = WithdrawalRequestExtra;
-    const NAME: &'static str = "WithdrawalRequestExtraBuilder";
+impl molecule::prelude::Builder for DeprecatedWithdrawRequestExtraBuilder {
+    type Entity = DeprecatedWithdrawRequestExtra;
+    const NAME: &'static str = "DeprecatedWithdrawRequestExtraBuilder";
     fn expected_length(&self) -> usize {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.request.as_slice().len()
@@ -3647,7 +3945,7 @@ impl molecule::prelude::Builder for WithdrawalRequestExtraBuilder {
         let mut inner = Vec::with_capacity(self.expected_length());
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        WithdrawalRequestExtra::new_unchecked(inner.into())
+        DeprecatedWithdrawRequestExtra::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/devtools/fetch-binaries.sh
+++ b/devtools/fetch-binaries.sh
@@ -6,7 +6,8 @@ docker pull nervos/godwoken-prebuilds:$GODWOKEN_TAG
 mkdir -p $dir_name && echo "Create dir"
 docker run --rm -v $(pwd)/$dir_name:/tmp nervos/godwoken-prebuilds:$GODWOKEN_TAG cp -r /scripts/godwoken-scripts /tmp && echo "Copy scripts"
 # TODO: Wait prebuilds update
-docker pull ghcr.io/zeroqn/godwoken-prebuilds:docker-publish-v0.8-unlock-withdrawal-to-owner
-docker run --rm -v $(pwd)/$dir_name:/tmp ghcr.io/zeroqn/godwoken-prebuilds:docker-publish-v0.8-unlock-withdrawal-to-owner cp /scripts/godwoken-scripts/withdrawal-lock /tmp/godwoken-scripts/withdrawal-lock && echo "Override withdrawal-lock"
-docker run --rm -v $(pwd)/$dir_name:/tmp ghcr.io/zeroqn/godwoken-prebuilds:docker-publish-v0.8-unlock-withdrawal-to-owner cp /scripts/godwoken-scripts/state-validator /tmp/godwoken-scripts/state-validator && echo "Override state-validator"
+docker pull ghcr.io/zeroqn/godwoken-prebuilds:dev-feat-fast-withdrawal-to-v1
+docker run --rm -v $(pwd)/$dir_name:/tmp ghcr.io/zeroqn/godwoken-prebuilds:dev-feat-fast-withdrawal-to-v1 cp /scripts/godwoken-scripts/withdrawal-lock /tmp/godwoken-scripts/withdrawal-lock && echo "Override withdrawal-lock"
+docker run --rm -v $(pwd)/$dir_name:/tmp ghcr.io/zeroqn/godwoken-prebuilds:dev-feat-fast-withdrawal-to-v1 cp /scripts/godwoken-scripts/state-validator /tmp/godwoken-scripts/state-validator && echo "Override state-validator"
 echo "Done"
+


### PR DESCRIPTION
- support generate and unlock withdrawal to v1 cell
- add withdrawal config

```rust
pub struct WithdrawalToV1Config {
    pub v1_rollup_type_hash: H256,
    pub v1_deposit_lock_code_hash: H256,
    pub v1_eth_lock_code_hash: H256,
    pub v1_deposit_minimal_cancel_timeout_msecs: u64,
}
```

- add `withdraw-to-v1` command to `gw-tools`
