### PR TITLE
fix: workaround for tx temporally disappear after send_transaction

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,5 +37,4 @@ jobs:
       # github.head_ref: The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.
       # github.ref: The branch or tag ref that triggered the workflow run. For branches this is the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>.
       godwoken_ref: ${{ github.head_ref || github.ref }}
-      kicker_ref: 9ee4c8272974562d21124f7f10e9028aed78812d
-      tests_ref: 6e20527d3a5bc7a843c947366a64da4c97520795
+      kicker_ref: compatibility-changes

--- a/crates/tools/src/utils/transaction.rs
+++ b/crates/tools/src/utils/transaction.rs
@@ -88,22 +88,19 @@ pub fn wait_for_tx(
     let start_time = Instant::now();
     while start_time.elapsed() < retry_timeout {
         std::thread::sleep(Duration::from_secs(5));
-        match rpc_client
-            .get_transaction(tx_hash.clone())
-            .map_err(|err| anyhow!(err))?
-        {
-            Some(tx_with_status) if tx_with_status.tx_status.status == Status::Pending => {
+        match rpc_client.get_transaction(tx_hash.clone()) {
+            Ok(Some(tx_with_status)) if tx_with_status.tx_status.status == Status::Pending => {
                 log::info!("tx pending");
             }
-            Some(tx_with_status) if tx_with_status.tx_status.status == Status::Proposed => {
+            Ok(Some(tx_with_status)) if tx_with_status.tx_status.status == Status::Proposed => {
                 log::info!("tx proposed");
             }
-            Some(tx_with_status) if tx_with_status.tx_status.status == Status::Committed => {
+            Ok(Some(tx_with_status)) if tx_with_status.tx_status.status == Status::Committed => {
                 log::info!("tx commited");
                 return Ok(tx_with_status.transaction);
             }
-            err => {
-                log::error!("unexpected tx status: {:?}", err)
+            res => {
+                log::error!("unexpected response of get_transaction: {:?}", res)
             }
         }
     }


### PR DESCRIPTION
- fix https://github.com/RetricSu/godwoken-kicker/issues/215

Trigger ~~10~~ several times nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml, and consider this issue has been properly fixed if all runs are passed.