### PR TITLE
feat(gw-tools): add command report-accounts to export account infos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,7 @@ dependencies = [
  "ckb-sdk",
  "ckb-types",
  "clap",
+ "csv",
  "env_logger",
  "faster-hex 0.5.0",
  "gw-common",

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -43,3 +43,4 @@ rand = "0.8"
 hex = "0.4"
 tokio = { version = "1.15", features = ["full"] }
 jsonrpc-core = "17"
+csv = "1.1.6"

--- a/crates/tools/src/account.rs
+++ b/crates/tools/src/account.rs
@@ -98,12 +98,15 @@ pub fn privkey_to_short_address(
     Ok(short_address)
 }
 
-pub fn short_address_to_account_id(
+pub async fn short_address_to_account_id(
     godwoken_rpc_client: &mut GodwokenRpcClient,
     short_address: &GwBytes,
 ) -> Result<Option<u32>> {
     let bytes = JsonBytes::from_bytes(short_address.clone());
-    let script_hash = match godwoken_rpc_client.get_script_hash_by_short_address(bytes)? {
+    let script_hash = match godwoken_rpc_client
+        .get_script_hash_by_short_address(bytes)
+        .await?
+    {
         Some(h) => h,
         None => {
             return Err(anyhow!(
@@ -112,13 +115,15 @@ pub fn short_address_to_account_id(
             ))
         }
     };
-    let account_id = godwoken_rpc_client.get_account_id_by_script_hash(script_hash)?;
+    let account_id = godwoken_rpc_client
+        .get_account_id_by_script_hash(script_hash)
+        .await?;
 
     Ok(account_id)
 }
 
 // address: 0x... / id: 1
-pub fn parse_account_short_address(
+pub async fn parse_account_short_address(
     godwoken: &mut GodwokenRpcClient,
     account: &str,
 ) -> Result<GwBytes> {
@@ -133,7 +138,7 @@ pub fn parse_account_short_address(
         Ok(a) => a,
         Err(_) => return Err(anyhow!("account id parse error!")),
     };
-    let script_hash = godwoken.get_script_hash(account_id)?;
+    let script_hash = godwoken.get_script_hash(account_id).await?;
     let short_address = GwBytes::from((&script_hash.as_bytes()[..20]).to_vec());
     Ok(short_address)
 }

--- a/crates/tools/src/address.rs
+++ b/crates/tools/src/address.rs
@@ -51,22 +51,26 @@ pub fn to_godwoken_short_address(
     Ok(())
 }
 
-pub fn to_eth_eoa_address(godwoken_rpc_url: &str, godwoken_short_address: &str) -> Result<()> {
+pub async fn to_eth_eoa_address(
+    godwoken_rpc_url: &str,
+    godwoken_short_address: &str,
+) -> Result<()> {
     if godwoken_short_address.len() != 42 || !godwoken_short_address.starts_with("0x") {
         return Err(anyhow!("godwoken short address format error!"));
     }
 
-    let mut godwoken_rpc_client = GodwokenRpcClient::new(godwoken_rpc_url);
+    let godwoken_rpc_client = GodwokenRpcClient::new(godwoken_rpc_url);
 
     let short_address = GwBytes::from(hex::decode(
         godwoken_short_address.trim_start_matches("0x").as_bytes(),
     )?);
 
     let script_hash = godwoken_rpc_client
-        .get_script_hash_by_short_address(JsonBytes::from_bytes(short_address))?;
+        .get_script_hash_by_short_address(JsonBytes::from_bytes(short_address))
+        .await?;
 
     let script = match script_hash {
-        Some(h) => godwoken_rpc_client.get_script(h)?,
+        Some(h) => godwoken_rpc_client.get_script(h).await?,
         None => return Err(anyhow!("script hash not found!")),
     };
 

--- a/crates/tools/src/dump_tx.rs
+++ b/crates/tools/src/dump_tx.rs
@@ -26,7 +26,7 @@ impl FromStr for ChallengeBlock {
     }
 }
 
-pub fn dump_tx(
+pub async fn dump_tx(
     godwoken_rpc_url: &str,
     block: ChallengeBlock,
     target_index: u32,
@@ -46,8 +46,10 @@ pub fn dump_tx(
         },
     };
 
-    let mut godwoken_rpc_client = GodwokenRpcClient::new(godwoken_rpc_url);
-    let dump_tx = godwoken_rpc_client.debug_dump_cancel_challenge_tx(challenge_target)?;
+    let godwoken_rpc_client = GodwokenRpcClient::new(godwoken_rpc_url);
+    let dump_tx = godwoken_rpc_client
+        .debug_dump_cancel_challenge_tx(challenge_target)
+        .await?;
 
     let json_tx = serde_json::to_string_pretty(&dump_tx)?;
     write(output, json_tx)?;

--- a/crates/tools/src/get_balance.rs
+++ b/crates/tools/src/get_balance.rs
@@ -3,11 +3,11 @@ use ckb_jsonrpc_types::JsonBytes;
 
 use crate::{account::parse_account_short_address, godwoken_rpc::GodwokenRpcClient};
 
-pub fn get_balance(godwoken_rpc_url: &str, account: &str, sudt_id: u32) -> Result<()> {
+pub async fn get_balance(godwoken_rpc_url: &str, account: &str, sudt_id: u32) -> Result<()> {
     let mut godwoken_rpc_client = GodwokenRpcClient::new(godwoken_rpc_url);
-    let short_address = parse_account_short_address(&mut godwoken_rpc_client, account)?;
+    let short_address = parse_account_short_address(&mut godwoken_rpc_client, account).await?;
     let addr = JsonBytes::from_bytes(short_address);
-    let balance = godwoken_rpc_client.get_balance(addr, sudt_id)?;
+    let balance = godwoken_rpc_client.get_balance(addr, sudt_id).await?;
     log::info!("Balance: {}", balance);
 
     Ok(())

--- a/crates/tools/src/godwoken_rpc.rs
+++ b/crates/tools/src/godwoken_rpc.rs
@@ -6,14 +6,30 @@ use gw_jsonrpc_types::{
     debugger::{DumpChallengeTarget, ReprMockTransaction},
     godwoken::{RunResult, TxReceipt},
 };
-use std::{u128, u32};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    u128, u32,
+};
 
 type AccountID = Uint32;
 
 pub struct GodwokenRpcClient {
     url: reqwest::Url,
-    client: reqwest::blocking::Client,
-    id: u64,
+    client: reqwest::Client,
+    id: Arc<AtomicU64>,
+}
+
+impl Clone for GodwokenRpcClient {
+    fn clone(&self) -> Self {
+        Self {
+            url: self.url.clone(),
+            client: self.client.clone(),
+            id: self.id.clone(),
+        }
+    }
 }
 
 impl GodwokenRpcClient {
@@ -21,119 +37,141 @@ impl GodwokenRpcClient {
         let url = reqwest::Url::parse(url).expect("godwoken uri, e.g. \"http://127.0.0.1:8119\"");
         GodwokenRpcClient {
             url,
-            id: 0,
-            client: reqwest::blocking::Client::new(),
+            id: Arc::new(AtomicU64::new(0)),
+            client: reqwest::Client::new(),
         }
     }
 }
 
 impl GodwokenRpcClient {
-    pub fn get_tip_block_hash(&mut self) -> Result<Option<H256>> {
+    pub async fn get_tip_block_hash(&self) -> Result<Option<H256>> {
         let params = serde_json::Value::Null;
         self.rpc::<Option<H256>>("get_tip_block_hash", params)
+            .await
             .map(|opt| opt.map(Into::into))
     }
 
-    pub fn get_balance(&mut self, short_address: JsonBytes, sudt_id: u32) -> Result<u128> {
+    pub async fn get_balance(&self, short_address: JsonBytes, sudt_id: u32) -> Result<u128> {
         let params = serde_json::to_value((short_address, AccountID::from(sudt_id)))?;
-        self.rpc::<Uint128>("get_balance", params).map(Into::into)
-    }
-
-    pub fn get_account_id_by_script_hash(&mut self, script_hash: H256) -> Result<Option<u32>> {
-        let params = serde_json::to_value((script_hash,))?;
-        self.rpc::<Option<Uint32>>("get_account_id_by_script_hash", params)
-            .map(|opt| opt.map(Into::into))
-    }
-
-    pub fn get_nonce(&mut self, account_id: u32) -> Result<u32> {
-        let params = serde_json::to_value((AccountID::from(account_id),))?;
-        self.rpc::<Uint32>("get_nonce", params).map(Into::into)
-    }
-
-    pub fn submit_withdrawal_request(&mut self, withdrawal_request: JsonBytes) -> Result<H256> {
-        let params = serde_json::to_value((withdrawal_request,))?;
-        self.rpc::<H256>("submit_withdrawal_request", params)
+        self.rpc::<Uint128>("get_balance", params)
+            .await
             .map(Into::into)
     }
 
-    pub fn get_script_hash(&mut self, account_id: u32) -> Result<H256> {
-        let params = serde_json::to_value((AccountID::from(account_id),))?;
-        self.rpc::<H256>("get_script_hash", params).map(Into::into)
-    }
-
-    pub fn get_script(&mut self, script_hash: H256) -> Result<Option<Script>> {
+    pub async fn get_account_id_by_script_hash(&self, script_hash: H256) -> Result<Option<u32>> {
         let params = serde_json::to_value((script_hash,))?;
-        self.rpc::<Option<Script>>("get_script", params)
+        self.rpc::<Option<Uint32>>("get_account_id_by_script_hash", params)
+            .await
             .map(|opt| opt.map(Into::into))
     }
 
-    pub fn get_script_hash_by_short_address(
-        &mut self,
+    pub async fn get_nonce(&self, account_id: u32) -> Result<u32> {
+        let params = serde_json::to_value((AccountID::from(account_id),))?;
+        self.rpc::<Uint32>("get_nonce", params)
+            .await
+            .map(Into::into)
+    }
+
+    pub async fn submit_withdrawal_request(&self, withdrawal_request: JsonBytes) -> Result<H256> {
+        let params = serde_json::to_value((withdrawal_request,))?;
+        self.rpc::<H256>("submit_withdrawal_request", params)
+            .await
+            .map(Into::into)
+    }
+
+    pub async fn get_script_hash(&self, account_id: u32) -> Result<H256> {
+        let params = serde_json::to_value((AccountID::from(account_id),))?;
+        self.rpc::<H256>("get_script_hash", params)
+            .await
+            .map(Into::into)
+    }
+
+    pub async fn get_script(&self, script_hash: H256) -> Result<Option<Script>> {
+        let params = serde_json::to_value((script_hash,))?;
+        self.rpc::<Option<Script>>("get_script", params)
+            .await
+            .map(|opt| opt.map(Into::into))
+    }
+
+    pub async fn get_script_hash_by_short_address(
+        &self,
         short_address: JsonBytes,
     ) -> Result<Option<H256>> {
         let params = serde_json::to_value((short_address,))?;
 
         self.rpc::<Option<H256>>("get_script_hash_by_short_address", params)
+            .await
             .map(|opt| opt.map(Into::into))
     }
 
-    pub fn submit_l2transaction(&mut self, l2tx: JsonBytes) -> Result<H256> {
+    pub async fn submit_l2transaction(&self, l2tx: JsonBytes) -> Result<H256> {
         let params = serde_json::to_value((l2tx,))?;
         self.rpc::<H256>("submit_l2transaction", params)
+            .await
             .map(Into::into)
     }
 
-    pub fn execute_l2transaction(&mut self, l2tx: JsonBytes) -> Result<RunResult> {
+    pub async fn execute_l2transaction(&self, l2tx: JsonBytes) -> Result<RunResult> {
         let params = serde_json::to_value((l2tx,))?;
         self.rpc::<RunResult>("execute_l2transaction", params)
+            .await
             .map(Into::into)
     }
 
-    pub fn execute_raw_l2transaction(&mut self, raw_l2tx: JsonBytes) -> Result<RunResult> {
+    pub async fn execute_raw_l2transaction(&self, raw_l2tx: JsonBytes) -> Result<RunResult> {
         let params = serde_json::to_value((raw_l2tx,))?;
         self.rpc::<RunResult>("execute_raw_l2transaction", params)
+            .await
             .map(Into::into)
     }
 
-    pub fn get_transaction_receipt(&mut self, tx_hash: &H256) -> Result<Option<TxReceipt>> {
+    pub async fn get_transaction_receipt(&self, tx_hash: &H256) -> Result<Option<TxReceipt>> {
         let params = serde_json::to_value((tx_hash,))?;
         self.rpc::<Option<TxReceipt>>("get_transaction_receipt", params)
+            .await
             .map(|opt| opt.map(Into::into))
     }
 
-    pub fn debug_dump_cancel_challenge_tx(
-        &mut self,
+    pub async fn debug_dump_cancel_challenge_tx(
+        &self,
         challenge_target: DumpChallengeTarget,
     ) -> Result<ReprMockTransaction> {
         let params = serde_json::to_value((challenge_target,))?;
         self.raw_rpc::<ReprMockTransaction>("debug_dump_cancel_challenge_tx", params)
+            .await
             .map(Into::into)
     }
 
-    fn rpc<SuccessResponse: serde::de::DeserializeOwned>(
-        &mut self,
+    async fn rpc<SuccessResponse: serde::de::DeserializeOwned>(
+        &self,
         method: &str,
         params: serde_json::Value,
     ) -> Result<SuccessResponse> {
         let method_name = format!("gw_{}", method);
         self.raw_rpc(&method_name, params)
+            .await
             .map_err(|err| anyhow!("{}", err))
     }
 
-    fn raw_rpc<SuccessResponse: serde::de::DeserializeOwned>(
-        &mut self,
+    async fn raw_rpc<SuccessResponse: serde::de::DeserializeOwned>(
+        &self,
         method: &str,
         params: serde_json::Value,
     ) -> Result<SuccessResponse> {
-        self.id += 1;
+        self.id.fetch_add(1, Ordering::SeqCst);
         let mut req_json = serde_json::Map::new();
         req_json.insert("id".to_owned(), serde_json::to_value(&self.id).unwrap());
         req_json.insert("jsonrpc".to_owned(), serde_json::to_value(&"2.0").unwrap());
         req_json.insert("method".to_owned(), serde_json::to_value(method).unwrap());
         req_json.insert("params".to_owned(), params);
 
-        let resp = self.client.post(self.url.clone()).json(&req_json).send()?;
-        let output = resp.json::<jsonrpc_core::response::Output>()?;
+        let resp = self
+            .client
+            .post(self.url.clone())
+            .json(&req_json)
+            .send()
+            .await?;
+        let output = resp.json::<jsonrpc_core::response::Output>().await?;
         match output {
             jsonrpc_core::response::Output::Success(success) => {
                 serde_json::from_value(success.result).map_err(Into::into)

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -13,6 +13,7 @@ pub mod godwoken_rpc;
 mod hasher;
 mod polyjuice;
 mod prepare_scripts;
+mod report_accounts;
 mod setup;
 mod stat;
 mod sudt;
@@ -772,6 +773,19 @@ async fn run_cli() -> Result<()> {
                 ),
         )
         .subcommand(
+            SubCommand::with_name("report-accounts")
+                .about("Report account to csv files")
+                .arg(arg_godwoken_rpc_url.clone())
+                .arg(
+                    Arg::with_name("output")
+                        .short("o")
+                        .long("output")
+                        .takes_value(true)
+                        .required(true)
+                        .help("output file"),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("stat-custodian-ckb")
                 .about("Output amount of layer2 custodian CKB")
                 .arg(arg_indexer_rpc.clone())
@@ -1002,7 +1016,9 @@ async fn run_cli() -> Result<()> {
                 ckb_rpc_url.as_str(),
                 eth_address,
                 godwoken_rpc_url,
-            ) {
+            )
+            .await
+            {
                 log::error!("Deposit CKB error: {}", err);
                 std::process::exit(-1);
             };
@@ -1028,7 +1044,9 @@ async fn run_cli() -> Result<()> {
                 owner_ckb_address,
                 config_path,
                 scripts_deployment_path,
-            ) {
+            )
+            .await
+            {
                 log::error!("Withdrawal error: {}", err);
                 std::process::exit(-1);
             };
@@ -1084,7 +1102,9 @@ async fn run_cli() -> Result<()> {
                 fee,
                 config_path,
                 scripts_deployment_path,
-            ) {
+            )
+            .await
+            {
                 log::error!("Transfer error: {}", err);
                 std::process::exit(-1);
             };
@@ -1108,7 +1128,9 @@ async fn run_cli() -> Result<()> {
                 fee,
                 config_path,
                 scripts_deployment_path,
-            ) {
+            )
+            .await
+            {
                 log::error!("Create creator account error: {}", err);
                 std::process::exit(-1);
             };
@@ -1163,7 +1185,9 @@ async fn run_cli() -> Result<()> {
                 &config,
                 &scripts_deployment,
                 quiet,
-            ) {
+            )
+            .await
+            {
                 Ok(account_id) => account_id,
                 Err(err) => {
                     log::error!("Create Simple UDT account error: {}", err);
@@ -1183,7 +1207,7 @@ async fn run_cli() -> Result<()> {
                 .parse()
                 .expect("sudt id format error");
 
-            if let Err(err) = get_balance::get_balance(godwoken_rpc_url, account, sudt_id) {
+            if let Err(err) = get_balance::get_balance(godwoken_rpc_url, account, sudt_id).await {
                 log::error!("Get balance error: {}", err);
                 std::process::exit(-1);
             };
@@ -1226,7 +1250,9 @@ async fn run_cli() -> Result<()> {
                 gas_price,
                 data,
                 value,
-            ) {
+            )
+            .await
+            {
                 log::error!("Polyjuice deploy error: {}", err);
                 std::process::exit(-1);
             };
@@ -1271,7 +1297,9 @@ async fn run_cli() -> Result<()> {
                 data,
                 value,
                 to_address,
-            ) {
+            )
+            .await
+            {
                 log::error!("Polyjuice send error: {}", err);
                 std::process::exit(-1);
             };
@@ -1306,7 +1334,9 @@ async fn run_cli() -> Result<()> {
                 value,
                 to_address,
                 from,
-            ) {
+            )
+            .await
+            {
                 log::error!("Polyjuice call error: {}", err);
                 std::process::exit(-1);
             };
@@ -1329,7 +1359,7 @@ async fn run_cli() -> Result<()> {
             let godwoken_rpc_url = m.value_of("godwoken-rpc-url").unwrap();
             let short_address = m.value_of("short-address").unwrap();
 
-            if let Err(err) = address::to_eth_eoa_address(godwoken_rpc_url, short_address) {
+            if let Err(err) = address::to_eth_eoa_address(godwoken_rpc_url, short_address).await {
                 log::error!("To eth address error: {}", err);
                 std::process::exit(-1);
             };
@@ -1346,7 +1376,8 @@ async fn run_cli() -> Result<()> {
             };
             let output = Path::new(m.value_of("output").unwrap());
 
-            if let Err(err) = dump_tx::dump_tx(godwoken_rpc_url, block, index, type_, output) {
+            if let Err(err) = dump_tx::dump_tx(godwoken_rpc_url, block, index, type_, output).await
+            {
                 log::error!("Dump offchain cancel challenge tx: {}", err);
                 std::process::exit(-1);
             };
@@ -1453,6 +1484,16 @@ async fn run_cli() -> Result<()> {
 
             let output = serde_json::to_string_pretty(&withdrawal_lock)?;
             println!("{}", output);
+        }
+        ("report-accounts", Some(m)) => {
+            let godwoken_rpc_url = m.value_of("godwoken-rpc-url").unwrap();
+            let output_path = m.value_of("output").unwrap();
+
+            if let Err(err) = report_accounts::report_accounts(godwoken_rpc_url, output_path).await
+            {
+                log::error!("Error: {}", err);
+                std::process::exit(-1);
+            };
         }
         _ => {
             app.print_help().expect("print help");

--- a/crates/tools/src/report_accounts.rs
+++ b/crates/tools/src/report_accounts.rs
@@ -20,7 +20,7 @@ async fn producer(client: GodwokenRpcClient, tx: tokio::sync::mpsc::Sender<Task>
         let client = client.clone();
         let task = tokio::spawn(async move {
             let script_hash = client.get_script_hash(account_id).await?;
-            if script_hash.as_bytes() == &[0u8; 32] {
+            if script_hash.as_bytes() == [0u8; 32] {
                 return Ok::<_, anyhow::Error>(None);
             }
             let script = client

--- a/crates/tools/src/report_accounts.rs
+++ b/crates/tools/src/report_accounts.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+use ckb_jsonrpc_types::{JsonBytes, Serialize};
+use gw_common::builtins::CKB_SUDT_ACCOUNT_ID;
+use std::path::Path;
+use tokio::task::JoinHandle;
+
+use crate::godwoken_rpc::GodwokenRpcClient;
+
+#[derive(Serialize, Debug)]
+struct Account {
+    pub id: u32,
+    pub code_hash: ckb_fixed_hash::H256,
+    pub ckb: u128,
+    pub nonce: u32,
+}
+
+type Task = JoinHandle<Result<Option<Account>, anyhow::Error>>;
+async fn producer(client: GodwokenRpcClient, tx: tokio::sync::mpsc::Sender<Task>) -> Result<()> {
+    for account_id in 0.. {
+        let client = client.clone();
+        let task = tokio::spawn(async move {
+            let script_hash = client.get_script_hash(account_id).await?;
+            if script_hash.as_bytes() == &[0u8; 32] {
+                return Ok::<_, anyhow::Error>(None);
+            }
+            let script = client
+                .get_script(script_hash.clone())
+                .await?
+                .expect("must hash script");
+            let code_hash = script.code_hash;
+            // balance
+            let addr = JsonBytes::from_vec(script_hash.as_bytes()[..20].to_vec());
+            let ckb = client.get_balance(addr, CKB_SUDT_ACCOUNT_ID).await?;
+            let nonce = client.get_nonce(account_id).await?;
+            Ok(Some(Account {
+                id: account_id,
+                code_hash,
+                ckb,
+                nonce,
+            }))
+        });
+        tx.send(task).await?;
+    }
+    Ok(())
+}
+
+pub async fn report_accounts<P: AsRef<Path>>(url: &str, output: P) -> Result<()> {
+    let client = GodwokenRpcClient::new(url);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Task>(20);
+    // start tasks
+    let producer_handle = tokio::spawn(producer(client, tx));
+
+    // wait tasks
+    let mut total_account = 0;
+    let mut wtr = csv::Writer::from_path(output)?;
+    while let Some(task) = rx.recv().await {
+        match task.await?? {
+            Some(account) => {
+                wtr.serialize(account)?;
+                total_account += 1;
+                print!(".")
+            }
+            None => {
+                producer_handle.abort();
+                break;
+            }
+        }
+    }
+    wtr.flush()?;
+    println!("Total accounts: {}", total_account);
+    Ok(())
+}

--- a/crates/tools/src/sudt/account.rs
+++ b/crates/tools/src/sudt/account.rs
@@ -45,7 +45,7 @@ fn build_l2_sudt_script(
         .build()
 }
 
-fn pk_to_account_id(
+async fn pk_to_account_id(
     rpc_client: &mut GodwokenRpcClient,
     rollup_type_hash: &H256,
     deployment: &ScriptsDeploymentResult,
@@ -53,12 +53,13 @@ fn pk_to_account_id(
 ) -> Result<u32> {
     let from_address = privkey_to_short_address(pk, rollup_type_hash, deployment)
         .map_err(|err| anyhow!("{}", err))?;
-    let from_id =
-        short_address_to_account_id(rpc_client, &from_address).map_err(|err| anyhow!("{}", err))?;
+    let from_id = short_address_to_account_id(rpc_client, &from_address)
+        .await
+        .map_err(|err| anyhow!("{}", err))?;
     Ok(from_id.expect("Account id of provided privkey not found!"))
 }
 
-pub fn create_sudt_account(
+pub async fn create_sudt_account(
     rpc_client: &mut GodwokenRpcClient,
     pk: &H256,
     sudt_type_hash: H256,
@@ -69,9 +70,10 @@ pub fn create_sudt_account(
 ) -> Result<u32> {
     let rollup_type_hash = &config.genesis.rollup_type_hash;
 
-    let from_id = pk_to_account_id(rpc_client, rollup_type_hash, deployment, pk)?;
+    let from_id = pk_to_account_id(rpc_client, rollup_type_hash, deployment, pk).await?;
     let nonce = rpc_client
         .get_nonce(from_id)
+        .await
         .map_err(|err| anyhow!("{}", err))?;
 
     // sudt contract
@@ -86,6 +88,7 @@ pub fn create_sudt_account(
 
     let account_id = rpc_client
         .get_account_id_by_script_hash(l2_script_hash.into())
+        .await
         .map_err(|err| anyhow!("{}", err))?;
     if let Some(id) = account_id {
         if !quiet {
@@ -115,9 +118,11 @@ pub fn create_sudt_account(
 
     let sender_script_hash = rpc_client
         .get_script_hash(from_id)
+        .await
         .map_err(|err| anyhow!("{}", err))?;
     let receiver_script_hash = rpc_client
         .get_script_hash(0)
+        .await
         .map_err(|err| anyhow!("{}", err))?;
 
     let message = generate_transaction_message_to_sign(
@@ -136,6 +141,7 @@ pub fn create_sudt_account(
     let json_bytes = JsonBytes::from_bytes(account_l2_transaction.as_bytes());
     let tx_hash = rpc_client
         .submit_l2transaction(json_bytes)
+        .await
         .map_err(|err| anyhow!("{}", err))?;
     if !quiet {
         log::info!("tx hash: 0x{}", hex::encode(tx_hash.as_bytes()));
@@ -145,6 +151,7 @@ pub fn create_sudt_account(
 
     let account_id = rpc_client
         .get_account_id_by_script_hash(l2_script_hash.into())
+        .await
         .map_err(|err| anyhow!("{}", err))?
         .expect("Simple UDT account id not exist!");
 

--- a/crates/tools/src/sudt/transfer.rs
+++ b/crates/tools/src/sudt/transfer.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::u128;
 
 #[allow(clippy::too_many_arguments)]
-pub fn transfer(
+pub async fn transfer(
     godwoken_rpc_url: &str,
     privkey_path: &Path,
     to: &str,
@@ -34,7 +34,7 @@ pub fn transfer(
 
     let mut godwoken_rpc_client = GodwokenRpcClient::new(godwoken_rpc_url);
 
-    let to_address = parse_account_short_address(&mut godwoken_rpc_client, to)?;
+    let to_address = parse_account_short_address(&mut godwoken_rpc_client, to).await?;
 
     let config = read_config(config_path)?;
     let rollup_type_hash = &config.genesis.rollup_type_hash;
@@ -43,10 +43,10 @@ pub fn transfer(
 
     // get from_id
     let from_address = privkey_to_short_address(&privkey, rollup_type_hash, &scripts_deployment)?;
-    let from_id = short_address_to_account_id(&mut godwoken_rpc_client, &from_address)?;
+    let from_id = short_address_to_account_id(&mut godwoken_rpc_client, &from_address).await?;
     let from_id = from_id.expect("from id not found!");
 
-    let nonce = godwoken_rpc_client.get_nonce(from_id)?;
+    let nonce = godwoken_rpc_client.get_nonce(from_id).await?;
 
     let sudt_transfer = SUDTTransfer::new_builder()
         .to(GwPack::pack(&to_address))
@@ -63,8 +63,8 @@ pub fn transfer(
         .args(GwPack::pack(&sudt_args.as_bytes()))
         .build();
 
-    let sender_script_hash = godwoken_rpc_client.get_script_hash(from_id)?;
-    let receiver_script_hash = godwoken_rpc_client.get_script_hash(sudt_id)?;
+    let sender_script_hash = godwoken_rpc_client.get_script_hash(from_id).await?;
+    let receiver_script_hash = godwoken_rpc_client.get_script_hash(sudt_id).await?;
 
     let message = generate_transaction_message_to_sign(
         &raw_l2transaction,
@@ -82,7 +82,8 @@ pub fn transfer(
     log::info!("l2 transaction: {}", l2_transaction);
 
     let bytes = JsonBytes::from_bytes(l2_transaction.as_bytes());
-    let tx_hash = godwoken_rpc_client.submit_l2transaction(bytes)?;
+    let tx_hash = tokio::runtime::Handle::current()
+        .block_on(godwoken_rpc_client.submit_l2transaction(bytes))?;
 
     log::info!("tx_hash: 0x{}", faster_hex::hex_string(tx_hash.as_bytes())?);
 

--- a/crates/tools/src/utils/transaction.rs
+++ b/crates/tools/src/utils/transaction.rs
@@ -162,7 +162,8 @@ pub fn wait_for_l2_tx(
     while start_time.elapsed() < retry_timeout {
         std::thread::sleep(Duration::from_secs(2));
 
-        let receipt = godwoken_rpc_client.get_transaction_receipt(tx_hash)?;
+        let receipt = tokio::runtime::Handle::current()
+            .block_on(godwoken_rpc_client.get_transaction_receipt(tx_hash))?;
 
         match receipt {
             Some(_) => {

--- a/crates/tools/src/withdraw.rs
+++ b/crates/tools/src/withdraw.rs
@@ -23,7 +23,7 @@ use std::u128;
 use std::{fs, path::Path};
 
 #[allow(clippy::too_many_arguments)]
-pub fn withdraw(
+pub async fn withdraw(
     godwoken_rpc_url: &str,
     privkey_path: &Path,
     capacity: &str,
@@ -78,12 +78,14 @@ pub fn withdraw(
     let from_address = privkey_to_short_address(&privkey, rollup_type_hash, &scripts_deployment)?;
 
     // get from_id
-    let from_id = short_address_to_account_id(&mut godwoken_rpc_client, &from_address)?;
+    let from_id = short_address_to_account_id(&mut godwoken_rpc_client, &from_address).await?;
     let from_id = from_id.expect("from id not found!");
-    let nonce = godwoken_rpc_client.get_nonce(from_id)?;
+    let nonce =
+        tokio::runtime::Handle::current().block_on(godwoken_rpc_client.get_nonce(from_id))?;
 
     // get account_script_hash
-    let account_script_hash = godwoken_rpc_client.get_script_hash(from_id)?;
+    let account_script_hash =
+        tokio::runtime::Handle::current().block_on(godwoken_rpc_client.get_script_hash(from_id))?;
 
     let raw_request = create_raw_withdrawal_request(
         &nonce,
@@ -113,11 +115,13 @@ pub fn withdraw(
 
     log::info!("withdrawal_request_extra: {}", withdrawal_request_extra);
 
-    let init_balance =
-        godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1)?;
+    let init_balance = tokio::runtime::Handle::current().block_on(
+        godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1),
+    )?;
 
     let bytes = JsonBytes::from_bytes(withdrawal_request_extra.as_bytes());
-    let withdrawal_hash = godwoken_rpc_client.submit_withdrawal_request(bytes)?;
+    let withdrawal_hash = tokio::runtime::Handle::current()
+        .block_on(godwoken_rpc_client.submit_withdrawal_request(bytes))?;
     log::info!("withdrawal_hash: {}", withdrawal_hash.pack());
 
     wait_for_balance_change(&mut godwoken_rpc_client, from_address, init_balance, 180u64)?;
@@ -195,8 +199,9 @@ fn wait_for_balance_change(
     while start_time.elapsed() < retry_timeout {
         std::thread::sleep(Duration::from_secs(2));
 
-        let balance =
-            godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1)?;
+        let balance = tokio::runtime::Handle::current().block_on(
+            godwoken_rpc_client.get_balance(JsonBytes::from_bytes(from_address.clone()), 1),
+        )?;
         log::info!(
             "current balance: {}, waiting for {} secs.",
             balance,


### PR DESCRIPTION
This PR provide a new command `report-accounts` to export accounts info into a csv file.

This PR also fix the crash problem when using some gw-tools commands under tokio runtime.