### PR TITLE
feat: enable AOT by default

### DIFF
--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -69,6 +69,4 @@ console-subscriber = "0.1.3"
 tikv-jemallocator = { version = "0.4.0", features = ["unprefixed_malloc_on_supported_platforms"] }
 
 [features]
-default = ["aot-vm"]
 profiling = ["tikv-jemallocator/profiling"]
-aot-vm = ["gw-generator/aot"]

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 default = ["detect-asm"]
 detect-asm = ["ckb-vm/detect-asm"]
 enable-always-success-lock = []
-aot = ["detect-asm"]
 
 [dependencies]
 gw-types = { path = "../types" }

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -59,7 +59,7 @@ impl BackendManage {
     }
 
     pub fn register_backend(&mut self, backend: Backend) {
-        #[cfg(feature = "aot")]
+        #[cfg(has_asm)]
         {
             self.aot_codes.0.insert(
                 backend.validator_script_type_hash,
@@ -81,7 +81,7 @@ impl BackendManage {
         self.backends.get(code_hash)
     }
 
-    #[cfg(feature = "aot")]
+    #[cfg(has_asm)]
     fn aot_compile(&self, code_bytes: &Bytes, vm_version: u32) -> Result<AotCode, ckb_vm::Error> {
         log::info!("Compile AotCode with VMVersion::V{}", vm_version);
         let vm_version = match vm_version {

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -157,7 +157,7 @@ impl Generator {
             let aot_code_opt = self
                 .backend_manage
                 .get_aot_code(&backend.validator_script_type_hash, global_vm_version);
-            #[cfg(feature = "aot")]
+            #[cfg(has_asm)]
             if aot_code_opt.is_none() {
                 log::warn!("[machine_run] Not AOT mode!");
             }


### PR DESCRIPTION
This PR simplify the compiling condition of gw-generator:

1. always enabling the AOT feature under asm VM environment.
2. Remove the aot compiling condition.

This PR also fixes the compiling on mac.