### PR TITLE
fix(tool): wait_for_l2_tx try to start a runtime within a runtime 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,8 +34,7 @@ jobs:
   integration-test:
     uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
     with:
-      # github.head_ref: The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.
       # github.ref: The branch or tag ref that triggered the workflow run. For branches this is the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>.
-      godwoken_ref: ${{ github.head_ref || github.ref }}
-      kicker_ref: v1.1 # https://github.com/RetricSu/godwoken-kicker/pull/221
-      tests_ref: develop  # https://github.com/nervosnetwork/godwoken-tests/commits/develop
+      godwoken_ref: ${{ github.ref }}
+      kicker_ref: v1.1   # https://github.com/RetricSu/godwoken-kicker/pull/221
+      tests_ref: develop # https://github.com/nervosnetwork/godwoken-tests/commits/develop

--- a/crates/tools/src/create_creator_account.rs
+++ b/crates/tools/src/create_creator_account.rs
@@ -130,7 +130,7 @@ pub async fn create_creator_account(
     let tx_hash = godwoken_rpc_client.submit_l2transaction(json_bytes).await?;
     log::info!("tx hash: 0x{}", hex::encode(tx_hash.as_bytes()));
 
-    wait_for_l2_tx(&mut godwoken_rpc_client, &tx_hash, 180, false)?;
+    wait_for_l2_tx(&mut godwoken_rpc_client, &tx_hash, 180, false).await?;
 
     let account_id = godwoken_rpc_client
         .get_account_id_by_script_hash(l2_script_hash.into())

--- a/crates/tools/src/polyjuice.rs
+++ b/crates/tools/src/polyjuice.rs
@@ -239,7 +239,7 @@ async fn send(
         .await?;
     log::info!("tx hash: 0x{}", hex::encode(tx_hash.as_bytes()));
 
-    let tx_receipt = wait_for_l2_tx(godwoken_rpc_client, &tx_hash, 180, false)?;
+    let tx_receipt = wait_for_l2_tx(godwoken_rpc_client, &tx_hash, 180, false).await?;
 
     if let (None, Some(receipt)) = (to_address, tx_receipt) {
         let polyjuice_system_log = receipt

--- a/crates/tools/src/sudt/account.rs
+++ b/crates/tools/src/sudt/account.rs
@@ -150,7 +150,9 @@ pub async fn create_sudt_account(
         log::info!("tx hash: 0x{}", hex::encode(tx_hash.as_bytes()));
     }
 
-    wait_for_l2_tx(rpc_client, &tx_hash, 180, quiet).map_err(|err| anyhow!("{}", err))?;
+    wait_for_l2_tx(rpc_client, &tx_hash, 180, quiet)
+        .await
+        .map_err(|err| anyhow!("{}", err))?;
 
     let account_id = rpc_client
         .get_account_id_by_script_hash(l2_script_hash.into())

--- a/crates/tools/src/sudt/transfer.rs
+++ b/crates/tools/src/sudt/transfer.rs
@@ -98,7 +98,7 @@ pub async fn transfer(
 
     log::info!("tx_hash: 0x{}", faster_hex::hex_string(tx_hash.as_bytes())?);
 
-    wait_for_l2_tx(&mut godwoken_rpc_client, &tx_hash, 300, false)?;
+    wait_for_l2_tx(&mut godwoken_rpc_client, &tx_hash, 300, false).await?;
 
     log::info!("transfer success!");
 

--- a/crates/tools/src/utils/transaction.rs
+++ b/crates/tools/src/utils/transaction.rs
@@ -148,7 +148,7 @@ pub fn read_config<P: AsRef<Path>>(path: P) -> Result<Config> {
     Ok(config)
 }
 
-pub fn wait_for_l2_tx(
+pub async fn wait_for_l2_tx(
     godwoken_rpc_client: &mut GodwokenRpcClient,
     tx_hash: &H256,
     timeout_secs: u64,
@@ -159,9 +159,7 @@ pub fn wait_for_l2_tx(
     while start_time.elapsed() < retry_timeout {
         std::thread::sleep(Duration::from_secs(2));
 
-        let receipt = tokio::runtime::Handle::current()
-            .block_on(godwoken_rpc_client.get_transaction_receipt(tx_hash))?;
-
+        let receipt = godwoken_rpc_client.get_transaction_receipt(tx_hash).await?;
         match receipt {
             Some(_) => {
                 if !quiet {


### PR DESCRIPTION
fix panic at 'Cannot start a runtime from within a runtime. This happens because
a function (like `block_on`) attempted to block the current thread while the
thread is being used to drive asynchronous tasks.',

> .cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/enter.rs:39:9

stack backtrace:
  13:     0x55e764eaa6cc - std::panicking::begin_panic::heb8864f57f1405f4
  14:     0x55e7659d70dc - tokio::runtime::enter::enter::had296fc67243945d
  15:     0x55e7650e992b - tokio::runtime::handle::Handle::block_on::h714e0b3977214f3c
  16:     0x55e7650dca81 - gw_tools::utils::transaction::wait_for_l2_tx::h44b9f048e3ad52dc
  17:     0x55e76506c8fe - gw_tools::run_cli::{{closure}}::h6b5f43e755a0093b
  18:     0x55e76503efd0 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hbbd9c58b7926a6f8
  19:     0x55e765123bfe - tokio::runtime::basic_scheduler::Context::enter::h3c10c211b7ee0d8e
  20:     0x55e764fe89b8 - tokio::macros::scoped_tls::ScopedKey<T>::set::hc126e74eed8c74b5
  21:     0x55e76512388a - tokio::runtime::basic_scheduler::BasicScheduler::block_on::h1d828411dc776176
  22:     0x55e7650e9d83 - tokio::runtime::Runtime::block_on::h788746a776c509c9
  23:     0x55e7650ad75f - gw_tools::main::h7cacd5fdaaf68ea3
