### PR TITLE
chore: improve CLI error handling

### DIFF
--- a/crates/block-producer/src/main.rs
+++ b/crates/block-producer/src/main.rs
@@ -132,6 +132,6 @@ async fn run_cli() -> Result<()> {
 /// Godwoken entry
 /// Default to number of cpus, pass `worker_threads` to manually configure workers.
 #[tokio::main(flavor = "multi_thread")]
-async fn main() {
-    run_cli().await.expect("run cli");
+async fn main() -> Result<()> {
+    run_cli().await
 }

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use gw_common::H256;
 use gw_config::{BackendConfig, BackendType};
 use gw_types::bytes::Bytes;
@@ -42,8 +42,12 @@ impl BackendManage {
             validator_script_type_hash,
             backend_type,
         } = config;
-        let validator = fs::read(validator_path)?.into();
-        let generator = fs::read(generator_path)?.into();
+        let validator = fs::read(&validator_path)
+            .with_context(|| format!("load validator from {}", validator_path.to_string_lossy()))?
+            .into();
+        let generator = fs::read(generator_path)
+            .with_context(|| format!("load generator from {}", validator_path.to_string_lossy()))?
+            .into();
         let validator_script_type_hash = {
             let hash: [u8; 32] = validator_script_type_hash.into();
             hash.into()

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -45,8 +45,8 @@ impl BackendManage {
         let validator = fs::read(&validator_path)
             .with_context(|| format!("load validator from {}", validator_path.to_string_lossy()))?
             .into();
-        let generator = fs::read(generator_path)
-            .with_context(|| format!("load generator from {}", validator_path.to_string_lossy()))?
+        let generator = fs::read(&generator_path)
+            .with_context(|| format!("load generator from {}", generator_path.to_string_lossy()))?
             .into();
         let validator_script_type_hash = {
             let hash: [u8; 32] = validator_script_type_hash.into();

--- a/crates/replay-chain/src/main.rs
+++ b/crates/replay-chain/src/main.rs
@@ -135,6 +135,6 @@ async fn run_cli() -> Result<()> {
 }
 
 #[tokio::main(flavor = "multi_thread")]
-async fn main() {
-    run_cli().await.expect("cli");
+async fn main() -> Result<()> {
+    run_cli().await
 }

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -49,12 +49,9 @@ use crate::{setup::SetupArgs, sudt::account::build_l1_sudt_type_script};
 use self::types::OmniLockConfig;
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() {
+async fn main() -> Result<()> {
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
-    run_cli().await.unwrap();
-}
 
-async fn run_cli() -> Result<()> {
     let arg_privkey_path = Arg::with_name("privkey-path")
         .long("privkey-path")
         .short("k")


### PR DESCRIPTION
Now:

```
Error: config backends

Caused by:
    0: load validator from /scripts/godwoken-scripts/meta-contract-validator.invalid
    1: No such file or directory (os error 2)
```

Previously:

```
thread 'main' panicked at 'run cli: config backends

Caused by:
    No such file or directory (os error 2)', crates/block-producer/src/main.rs:136:21
stack backtrace:
...
[very long stacktrace that is not useful because the panic always happens in main]
...
```
