### PR TITLE
Refactor tx verification

### DIFF
--- a/crates/block-producer/src/withdrawal.rs
+++ b/crates/block-producer/src/withdrawal.rs
@@ -383,15 +383,14 @@ mod test {
         .unwrap();
         let (output, data) = generated.unwrap().outputs.first().unwrap().to_owned();
 
-        let (expected_output, expected_data) =
-            gw_generator::Generator::build_withdrawal_cell_output(
-                &rollup_context,
-                &withdrawal_extra,
-                &block.hash().into(),
-                block.raw().number().unpack(),
-                Some(sudt_script.clone()),
-            )
-            .unwrap();
+        let (expected_output, expected_data) = gw_generator::utils::build_withdrawal_cell_output(
+            &rollup_context,
+            &withdrawal_extra,
+            &block.hash().into(),
+            block.raw().number().unpack(),
+            Some(sudt_script.clone()),
+        )
+        .unwrap();
 
         assert_eq!(expected_output.as_slice(), output.as_slice());
         assert_eq!(expected_data, data);

--- a/crates/generator/src/constants.rs
+++ b/crates/generator/src/constants.rs
@@ -1,7 +1,7 @@
-// TODO ensure this value
-pub const MIN_WITHDRAWAL_CAPACITY: u64 = 1000_00000000;
-// TODO ensure this value
-pub const MIN_DEPOSIT_CAPACITY: u64 = 1000_00000000;
+/// MAX tx size 50 KB
+pub const MAX_TX_SIZE: usize = 50_000;
+/// MAX withdrawal size 50 KB
+pub const MAX_WITHDRAWAL_SIZE: usize = 50_000;
 // 25 KB
 pub const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25_000;
 // 2MB

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -72,6 +72,13 @@ pub enum WithdrawalError {
     NonPositiveSUDTAmount,
     #[error("Expected owner lock hash {0}")]
     OwnerLock(Byte32),
+    #[error(
+        "Exceeded maximum withdrawal size: max size {max_size}, withdrawal size {withdrawal_size}"
+    )]
+    ExceededMaxWithdrawalSize {
+        max_size: usize,
+        withdrawal_size: usize,
+    },
 }
 
 impl From<WithdrawalError> for Error {
@@ -140,6 +147,8 @@ pub enum TransactionError {
     BackendMustIncreaseNonce,
     #[error("ScriptHashNotFound")]
     ScriptHashNotFound,
+    #[error("Exceeded maximum tx size: max size {max_size}, tx size {tx_size}")]
+    ExceededMaxTxSize { max_size: usize, tx_size: usize },
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -72,6 +72,8 @@ pub enum WithdrawalError {
     NonPositiveSUDTAmount,
     #[error("Expected owner lock hash {0}")]
     OwnerLock(Byte32),
+    #[error("Insufficient capacity expected {expected} actual {actual}")]
+    InsufficientCapacity { expected: u128, actual: u64 },
     #[error(
         "Exceeded maximum withdrawal size: max size {max_size}, withdrawal size {withdrawal_size}"
     )]
@@ -89,8 +91,6 @@ impl From<WithdrawalError> for Error {
 
 #[derive(Error, Debug, PartialEq, Clone, Eq)]
 pub enum AccountError {
-    #[error("Insufficient capacity expected {expected} actual {actual}")]
-    InsufficientCapacity { expected: u128, actual: u64 },
     #[error("Invalid SUDT operation")]
     InvalidSUDTOperation,
     #[error("Unknown SUDT")]
@@ -149,6 +149,8 @@ pub enum TransactionError {
     ScriptHashNotFound,
     #[error("Exceeded maximum tx size: max size {max_size}, tx size {tx_size}")]
     ExceededMaxTxSize { max_size: usize, tx_size: usize },
+    #[error("Insufficient balance")]
+    InsufficientBalance,
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -151,6 +151,8 @@ pub enum TransactionError {
     ExceededMaxTxSize { max_size: usize, tx_size: usize },
     #[error("Insufficient balance")]
     InsufficientBalance,
+    #[error("Tx has no cost")]
+    NoCost,
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -78,11 +78,13 @@ pub enum WithdrawalCellError {
 impl From<WithdrawalCellError> for Error {
     fn from(err: WithdrawalCellError) -> Self {
         match err {
-            WithdrawalCellError::MinCapacity { min, req } => AccountError::InsufficientCapacity {
-                expected: min,
-                actual: req,
+            WithdrawalCellError::MinCapacity { min, req } => {
+                WithdrawalError::InsufficientCapacity {
+                    expected: min,
+                    actual: req,
+                }
+                .into()
             }
-            .into(),
             WithdrawalCellError::OwnerLock(hash) => WithdrawalError::OwnerLock(hash.pack()).into(),
         }
     }

--- a/crates/generator/src/lib.rs
+++ b/crates/generator/src/lib.rs
@@ -12,6 +12,8 @@ pub mod sudt;
 pub mod syscalls;
 pub mod traits;
 pub mod types;
+pub mod utils;
+pub mod verification;
 pub mod vm_cost_model;
 
 #[cfg(test)]

--- a/crates/generator/src/lib.rs
+++ b/crates/generator/src/lib.rs
@@ -11,6 +11,7 @@ pub mod genesis;
 pub mod sudt;
 pub mod syscalls;
 pub mod traits;
+pub mod typed_transaction;
 pub mod types;
 pub mod utils;
 pub mod verification;

--- a/crates/generator/src/typed_transaction/mod.rs
+++ b/crates/generator/src/typed_transaction/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/crates/generator/src/typed_transaction/types.rs
+++ b/crates/generator/src/typed_transaction/types.rs
@@ -1,0 +1,144 @@
+use std::convert::TryInto;
+
+use ckb_vm::Bytes;
+use gw_common::builtins::CKB_SUDT_ACCOUNT_ID;
+use gw_types::{
+    core::AllowedContractType,
+    packed::{ETHAddrRegArgs, L2Transaction, MetaContractArgs, SUDTArgs},
+    prelude::*,
+};
+
+use crate::error::{AccountError, TransactionValidateError};
+
+/// Types Transaction
+pub enum TypedTransaction {
+    EthAddrReg(EthAddrRegTx),
+    Meta(MetaTx),
+    SimpleUDT(SimpleUDTTx),
+    Polyjuice(PolyjuiceTx),
+}
+
+impl TypedTransaction {
+    pub fn from_tx(
+        tx: L2Transaction,
+        type_: AllowedContractType,
+    ) -> Result<Self, TransactionValidateError> {
+        let tx = match type_ {
+            AllowedContractType::EthAddrReg => Self::EthAddrReg(EthAddrRegTx(tx)),
+            AllowedContractType::Meta => Self::Meta(MetaTx(tx)),
+            AllowedContractType::Sudt => Self::SimpleUDT(SimpleUDTTx(tx)),
+            AllowedContractType::Polyjuice => Self::Polyjuice(PolyjuiceTx(tx)),
+            AllowedContractType::Unknown => return Err(AccountError::UnknownScript.into()),
+        };
+        Ok(tx)
+    }
+
+    /// Got expect cost of the tx, (transfer value + fee).
+    /// returns none if tx has no cost, it may happend when we call readonly interface of some Godwoken builtin contracts.
+    pub fn cost(&self) -> Option<u64> {
+        match self {
+            Self::EthAddrReg(tx) => tx.cost(),
+            Self::Meta(tx) => tx.cost(),
+            Self::SimpleUDT(tx) => tx.cost(),
+            Self::Polyjuice(tx) => tx.cost(),
+        }
+    }
+}
+
+pub struct EthAddrRegTx(L2Transaction);
+
+impl EthAddrRegTx {
+    pub fn cost(&self) -> Option<u64> {
+        use gw_types::packed::ETHAddrRegArgsUnion::*;
+
+        let args: Bytes = self.0.raw().args().unpack();
+        let args = ETHAddrRegArgs::from_slice(&args).ok()?;
+
+        match args.to_enum() {
+            EthToGw(_) | GwToEth(_) => None,
+            SetMapping(args) => Some(args.fee().amount().unpack()),
+            BatchSetMapping(args) => Some(args.fee().amount().unpack()),
+        }
+    }
+}
+
+pub struct MetaTx(L2Transaction);
+
+impl MetaTx {
+    pub fn cost(&self) -> Option<u64> {
+        use gw_types::packed::MetaContractArgsUnion::*;
+
+        let args: Bytes = self.0.raw().args().unpack();
+        let args = MetaContractArgs::from_slice(&args).ok()?;
+
+        match args.to_enum() {
+            CreateAccount(args) => Some(args.fee().amount().unpack()),
+        }
+    }
+}
+
+pub struct SimpleUDTTx(L2Transaction);
+
+impl SimpleUDTTx {
+    pub fn cost(&self) -> Option<u64> {
+        use gw_types::packed::SUDTArgsUnion::*;
+
+        let args: Bytes = self.0.raw().args().unpack();
+        let args = SUDTArgs::from_slice(&args).ok()?;
+
+        match args.to_enum() {
+            SUDTQuery(_) => None,
+            SUDTTransfer(args) => {
+                let fee = args.fee().amount().unpack();
+                let to_id: u32 = self.0.raw().to_id().unpack();
+                if to_id == CKB_SUDT_ACCOUNT_ID {
+                    // CKB transfer cost: transfer CKB value + fee
+                    let value = args.amount().unpack();
+                    let cost = value.checked_add(fee.into())?;
+                    cost.try_into().ok()
+                } else {
+                    // Simple UDT transfer cost: fee
+                    Some(fee)
+                }
+            }
+        }
+    }
+}
+
+pub struct PolyjuiceTx(L2Transaction);
+impl PolyjuiceTx {
+    pub fn cost(&self) -> Option<u64> {
+        let args: Bytes = self.0.raw().args().unpack();
+        if args.len() < 52 {
+            log::error!(
+                "[gw-generator] parse PolyjuiceTx error, wrong args.len expected: 52, actual: {}",
+                args.len()
+            );
+            return None;
+        }
+        if args[0..7] != b"\xFF\xFF\xFFPOLY"[..] {
+            log::error!("[gw-generator] parse PolyjuiceTx error, invalid args",);
+            return None;
+        }
+
+        // parse gas price, gas limit, value
+        let gas_price = {
+            let mut data = [0u8; 16];
+            data.copy_from_slice(&args[16..32]);
+            u128::from_le_bytes(data)
+        };
+        let gas_limit = {
+            let mut data = [0u8; 8];
+            data.copy_from_slice(&args[8..16]);
+            u64::from_le_bytes(data)
+        };
+
+        let value = {
+            let mut data = [0u8; 16];
+            data.copy_from_slice(&args[32..48]);
+            u128::from_le_bytes(data)
+        };
+        let cost = value.checked_add(gas_price.checked_mul(gas_limit.into())?)?;
+        cost.try_into().ok()
+    }
+}

--- a/crates/generator/src/typed_transaction/types.rs
+++ b/crates/generator/src/typed_transaction/types.rs
@@ -111,7 +111,7 @@ impl PolyjuiceTx {
         let args: Bytes = self.0.raw().args().unpack();
         if args.len() < 52 {
             log::error!(
-                "[gw-generator] parse PolyjuiceTx error, wrong args.len expected: 52, actual: {}",
+                "[gw-generator] parse PolyjuiceTx error, wrong args.len expected: >= 52, actual: {}",
                 args.len()
             );
             return None;

--- a/crates/generator/src/typed_transaction/types.rs
+++ b/crates/generator/src/typed_transaction/types.rs
@@ -4,7 +4,7 @@ use ckb_vm::Bytes;
 use gw_common::builtins::CKB_SUDT_ACCOUNT_ID;
 use gw_types::{
     core::AllowedContractType,
-    packed::{ETHAddrRegArgs, L2Transaction, MetaContractArgs, SUDTArgs},
+    packed::{ETHAddrRegArgsReader, L2Transaction, MetaContractArgsReader, SUDTArgsReader},
     prelude::*,
 };
 
@@ -49,10 +49,10 @@ pub struct EthAddrRegTx(L2Transaction);
 
 impl EthAddrRegTx {
     pub fn cost(&self) -> Option<u64> {
-        use gw_types::packed::ETHAddrRegArgsUnion::*;
+        use gw_types::packed::ETHAddrRegArgsUnionReader::*;
 
         let args: Bytes = self.0.raw().args().unpack();
-        let args = ETHAddrRegArgs::from_slice(&args).ok()?;
+        let args = ETHAddrRegArgsReader::from_slice(&args).ok()?;
 
         match args.to_enum() {
             EthToGw(_) | GwToEth(_) => None,
@@ -66,10 +66,10 @@ pub struct MetaTx(L2Transaction);
 
 impl MetaTx {
     pub fn cost(&self) -> Option<u64> {
-        use gw_types::packed::MetaContractArgsUnion::*;
+        use gw_types::packed::MetaContractArgsUnionReader::*;
 
         let args: Bytes = self.0.raw().args().unpack();
-        let args = MetaContractArgs::from_slice(&args).ok()?;
+        let args = MetaContractArgsReader::from_slice(&args).ok()?;
 
         match args.to_enum() {
             CreateAccount(args) => Some(args.fee().amount().unpack()),
@@ -81,10 +81,10 @@ pub struct SimpleUDTTx(L2Transaction);
 
 impl SimpleUDTTx {
     pub fn cost(&self) -> Option<u64> {
-        use gw_types::packed::SUDTArgsUnion::*;
+        use gw_types::packed::SUDTArgsUnionReader::*;
 
         let args: Bytes = self.0.raw().args().unpack();
-        let args = SUDTArgs::from_slice(&args).ok()?;
+        let args = SUDTArgsReader::from_slice(&args).ok()?;
 
         match args.to_enum() {
             SUDTQuery(_) => None,

--- a/crates/generator/src/utils.rs
+++ b/crates/generator/src/utils.rs
@@ -1,0 +1,241 @@
+use gw_common::H256;
+use gw_types::{
+    bytes::Bytes,
+    core::ScriptHashType,
+    offchain::RollupContext,
+    packed::{CellOutput, Script, WithdrawalLockArgs, WithdrawalRequestExtra},
+    prelude::*,
+};
+
+use crate::generator::WithdrawalCellError;
+
+pub fn build_withdrawal_cell_output(
+    rollup_context: &RollupContext,
+    req: &WithdrawalRequestExtra,
+    block_hash: &H256,
+    block_number: u64,
+    opt_asset_script: Option<Script>,
+) -> Result<(CellOutput, Bytes), WithdrawalCellError> {
+    let withdrawal_capacity: u64 = req.raw().capacity().unpack();
+    let lock_args: Bytes = {
+        let withdrawal_lock_args = WithdrawalLockArgs::new_builder()
+            .account_script_hash(req.raw().account_script_hash())
+            .withdrawal_block_hash(Into::<[u8; 32]>::into(*block_hash).pack())
+            .withdrawal_block_number(block_number.pack())
+            .owner_lock_hash(req.raw().owner_lock_hash())
+            .build();
+
+        let mut args = Vec::new();
+        args.extend_from_slice(rollup_context.rollup_script_hash.as_slice());
+        args.extend_from_slice(withdrawal_lock_args.as_slice());
+        let owner_lock = req.owner_lock();
+        let owner_lock_hash: [u8; 32] = req.raw().owner_lock_hash().unpack();
+        if owner_lock_hash != owner_lock.hash() {
+            return Err(WithdrawalCellError::OwnerLock(owner_lock_hash.into()));
+        }
+        args.extend_from_slice(&(owner_lock.as_slice().len() as u32).to_be_bytes());
+        args.extend_from_slice(owner_lock.as_slice());
+
+        Bytes::from(args)
+    };
+
+    let lock = Script::new_builder()
+        .code_hash(rollup_context.rollup_config.withdrawal_script_type_hash())
+        .hash_type(ScriptHashType::Type.into())
+        .args(lock_args.pack())
+        .build();
+
+    let (type_, data) = match opt_asset_script {
+        Some(type_) => (Some(type_).pack(), req.raw().amount().as_bytes()),
+        None => (None::<Script>.pack(), Bytes::new()),
+    };
+
+    let output = CellOutput::new_builder()
+        .capacity(withdrawal_capacity.pack())
+        .type_(type_)
+        .lock(lock)
+        .build();
+
+    match output.occupied_capacity(data.len()) {
+        Ok(min_capacity) if min_capacity > withdrawal_capacity => {
+            Err(WithdrawalCellError::MinCapacity {
+                min: min_capacity as u128,
+                req: req.raw().capacity().unpack(),
+            })
+        }
+        Err(err) => {
+            log::debug!("calculate withdrawal capacity {}", err); // Overflow
+            Err(WithdrawalCellError::MinCapacity {
+                min: u64::MAX as u128 + 1,
+                req: req.raw().capacity().unpack(),
+            })
+        }
+        _ => Ok((output, data)),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use gw_common::h256_ext::H256Ext;
+    use gw_common::H256;
+    use gw_types::bytes::Bytes;
+    use gw_types::core::ScriptHashType;
+    use gw_types::offchain::RollupContext;
+    use gw_types::packed::{
+        RawWithdrawalRequest, RollupConfig, Script, WithdrawalRequest, WithdrawalRequestExtra,
+    };
+    use gw_types::prelude::{Builder, Entity, Pack, Unpack};
+
+    use crate::generator::WithdrawalCellError;
+    use crate::utils::build_withdrawal_cell_output;
+    use crate::Generator;
+
+    #[test]
+    fn test_build_withdrawal_cell_output() {
+        let rollup_context = RollupContext {
+            rollup_script_hash: H256::from_u32(1),
+            rollup_config: RollupConfig::new_builder()
+                .withdrawal_script_type_hash(H256::from_u32(100).pack())
+                .build(),
+        };
+        let sudt_script = Script::new_builder()
+            .code_hash(H256::from_u32(1).pack())
+            .args(vec![3; 32].pack())
+            .build();
+        let owner_lock = Script::new_builder()
+            .code_hash(H256::from_u32(4).pack())
+            .args(vec![5; 32].pack())
+            .build();
+
+        // ## Fulfill withdrawal request
+        let req = {
+            let fee = 50u64;
+            let raw = RawWithdrawalRequest::new_builder()
+                .nonce(1u32.pack())
+                .capacity((500 * 10u64.pow(8)).pack())
+                .amount(20u128.pack())
+                .sudt_script_hash(sudt_script.hash().pack())
+                .account_script_hash(H256::from_u32(10).pack())
+                .owner_lock_hash(owner_lock.hash().pack())
+                .fee(fee.pack())
+                .build();
+            WithdrawalRequest::new_builder()
+                .raw(raw)
+                .signature(vec![6u8; 65].pack())
+                .build()
+        };
+        let withdrawal = WithdrawalRequestExtra::new_builder()
+            .request(req.clone())
+            .owner_lock(owner_lock.clone())
+            .build();
+
+        let block_hash = H256::from_u32(11);
+        let block_number = 11u64;
+        let (output, data) = build_withdrawal_cell_output(
+            &rollup_context,
+            &withdrawal,
+            &block_hash,
+            block_number,
+            Some(sudt_script.clone()),
+        )
+        .unwrap();
+
+        // Basic check
+        assert_eq!(output.capacity().unpack(), req.raw().capacity().unpack());
+        assert_eq!(
+            output.type_().as_slice(),
+            Some(sudt_script.clone()).pack().as_slice()
+        );
+        assert_eq!(
+            output.lock().code_hash(),
+            rollup_context.rollup_config.withdrawal_script_type_hash()
+        );
+        assert_eq!(output.lock().hash_type(), ScriptHashType::Type.into());
+        assert_eq!(data, req.raw().amount().as_bytes());
+
+        // Check lock args
+        let parsed_args =
+            gw_utils::withdrawal::parse_lock_args(&output.lock().args().unpack()).unwrap();
+        assert_eq!(
+            parsed_args.rollup_type_hash.pack(),
+            rollup_context.rollup_script_hash.pack()
+        );
+        assert_eq!(parsed_args.owner_lock.hash(), owner_lock.hash());
+
+        let lock_args = parsed_args.lock_args;
+        assert_eq!(
+            lock_args.account_script_hash(),
+            req.raw().account_script_hash()
+        );
+        assert_eq!(lock_args.withdrawal_block_hash(), block_hash.pack());
+        assert_eq!(lock_args.withdrawal_block_number().unpack(), block_number);
+        assert_eq!(lock_args.owner_lock_hash(), owner_lock.hash().pack());
+
+        // ## None asset script
+        let (output2, data2) = build_withdrawal_cell_output(
+            &rollup_context,
+            &withdrawal,
+            &block_hash,
+            block_number,
+            None,
+        )
+        .unwrap();
+
+        assert!(output2.type_().to_opt().is_none());
+        assert_eq!(data2, Bytes::new());
+
+        assert_eq!(output2.capacity().unpack(), output.capacity().unpack());
+        assert_eq!(output2.lock().hash(), output.lock().hash());
+
+        // ## Min capacity error
+        let err_req = {
+            let raw = req.raw().as_builder();
+            let err_raw = raw
+                .capacity(500u64.pack()) // ERROR: capacity not enough
+                .build();
+            req.clone().as_builder().raw(err_raw).build()
+        };
+
+        let err = build_withdrawal_cell_output(
+            &rollup_context,
+            &WithdrawalRequestExtra::new_builder()
+                .request(err_req)
+                .owner_lock(owner_lock)
+                .build(),
+            &block_hash,
+            block_number,
+            Some(sudt_script.clone()),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            WithdrawalCellError::MinCapacity { req: _, min: _ }
+        ));
+        if let WithdrawalCellError::MinCapacity { req, min: _ } = err {
+            assert_eq!(req, 500);
+        }
+
+        // ## Owner lock error
+        let err_owner_lock = Script::new_builder()
+            .code_hash([100u8; 32].pack())
+            .hash_type(ScriptHashType::Data.into())
+            .args(vec![99u8; 32].pack())
+            .build();
+        let err = build_withdrawal_cell_output(
+            &rollup_context,
+            &WithdrawalRequestExtra::new_builder()
+                .request(req.clone())
+                .owner_lock(err_owner_lock)
+                .build(),
+            &block_hash,
+            block_number,
+            Some(sudt_script),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, WithdrawalCellError::OwnerLock(_)));
+        if let WithdrawalCellError::OwnerLock(owner_lock_hash) = err {
+            assert_eq!(req.raw().owner_lock_hash(), owner_lock_hash.pack());
+        }
+    }
+}

--- a/crates/generator/src/utils.rs
+++ b/crates/generator/src/utils.rs
@@ -88,7 +88,6 @@ mod test {
 
     use crate::generator::WithdrawalCellError;
     use crate::utils::build_withdrawal_cell_output;
-    use crate::Generator;
 
     #[test]
     fn test_build_withdrawal_cell_output() {

--- a/crates/generator/src/verification/chain_id.rs
+++ b/crates/generator/src/verification/chain_id.rs
@@ -1,0 +1,22 @@
+use crate::error::LockAlgorithmError;
+
+pub struct ChainIdVerifier {
+    chain_id: u64,
+}
+
+impl ChainIdVerifier {
+    pub fn new(chain_id: u64) -> Self {
+        Self { chain_id }
+    }
+
+    /// check chain id
+    pub fn verify(&self, chain_id: u64) -> Result<(), LockAlgorithmError> {
+        if self.chain_id != chain_id {
+            return Err(LockAlgorithmError::InvalidSignature(format!(
+                "Wrong chain_id, expected: {} actual: {}",
+                self.chain_id, chain_id
+            )));
+        }
+        Ok(())
+    }
+}

--- a/crates/generator/src/verification/mod.rs
+++ b/crates/generator/src/verification/mod.rs
@@ -1,0 +1,3 @@
+pub mod chain_id;
+pub mod transaction;
+pub mod withdrawal;

--- a/crates/generator/src/verification/transaction.rs
+++ b/crates/generator/src/verification/transaction.rs
@@ -1,0 +1,63 @@
+use gw_common::state::State;
+use gw_traits::CodeStore;
+use gw_types::{offchain::RollupContext, packed::L2Transaction, prelude::*};
+use tracing::instrument;
+
+use crate::{
+    constants::MAX_TX_SIZE,
+    error::{TransactionError, TransactionValidateError},
+};
+
+use super::chain_id::ChainIdVerifier;
+
+pub struct TransactionVerifier<'a, S> {
+    state: &'a S,
+    rollup_context: &'a RollupContext,
+}
+
+impl<'a, S: State + CodeStore> TransactionVerifier<'a, S> {
+    pub fn new(state: &'a S, rollup_context: &'a RollupContext) -> Self {
+        Self {
+            state,
+            rollup_context,
+        }
+    }
+    /// verify transaction
+    /// Notice this function do not perform signature check
+    #[instrument(skip_all)]
+    pub fn verify(&self, tx: &L2Transaction) -> Result<(), TransactionValidateError> {
+        let raw_tx = tx.raw();
+        let sender_id: u32 = raw_tx.from_id().unpack();
+
+        // check tx size
+        if tx.as_slice().len() > MAX_TX_SIZE {
+            return Err(TransactionError::ExceededMaxTxSize {
+                max_size: MAX_TX_SIZE,
+                tx_size: tx.as_slice().len(),
+            }
+            .into());
+        }
+
+        // check chain_id
+        ChainIdVerifier::new(self.rollup_context.rollup_config.chain_id().unpack())
+            .verify(raw_tx.chain_id().unpack())?;
+
+        // verify nonce
+        let account_nonce: u32 = self.state.get_nonce(sender_id)?;
+        let nonce: u32 = raw_tx.nonce().unpack();
+        if nonce != account_nonce {
+            return Err(TransactionError::Nonce {
+                expected: account_nonce,
+                actual: nonce,
+                account_id: sender_id,
+            }
+            .into());
+        }
+
+        // verify balance
+        // TODO
+        // get balance
+
+        Ok(())
+    }
+}

--- a/crates/generator/src/verification/transaction.rs
+++ b/crates/generator/src/verification/transaction.rs
@@ -75,7 +75,11 @@ impl<'a, S: State + CodeStore> TransactionVerifier<'a, S> {
         let tx_cost = {
             let tx_type = self.get_tx_type(tx)?;
             let typed_tx = TypedTransaction::from_tx(tx.to_owned(), tx_type)?;
-            typed_tx.cost().map(Into::into).unwrap_or(u128::MAX)
+            // reject txs has no cost, these transaction can only be execute without modify state tree
+            typed_tx
+                .cost()
+                .map(Into::into)
+                .ok_or(TransactionError::NoCost)?
         };
         if balance < tx_cost {
             return Err(TransactionError::InsufficientBalance.into());

--- a/crates/generator/src/verification/withdrawal.rs
+++ b/crates/generator/src/verification/withdrawal.rs
@@ -1,0 +1,124 @@
+use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, h256_ext::H256Ext, state::State, H256};
+use gw_traits::CodeStore;
+use gw_types::{
+    offchain::RollupContext,
+    packed::{Script, WithdrawalRequestExtra},
+    prelude::*,
+};
+use tracing::instrument;
+
+use crate::{
+    constants::MAX_WITHDRAWAL_SIZE,
+    error::{AccountError, WithdrawalError},
+    sudt::build_l2_sudt_script,
+    utils::build_withdrawal_cell_output,
+    Error,
+};
+
+use super::chain_id::ChainIdVerifier;
+
+pub struct WithdrawalVerifier<'a, S> {
+    state: &'a S,
+    rollup_context: &'a RollupContext,
+}
+
+impl<'a, S: State + CodeStore> WithdrawalVerifier<'a, S> {
+    pub fn new(state: &'a S, rollup_context: &'a RollupContext) -> Self {
+        Self {
+            state,
+            rollup_context,
+        }
+    }
+
+    /// Verify withdrawal request
+    /// Notice this function do not perform signature check
+    #[instrument(skip_all)]
+    pub fn verify(
+        &self,
+        withdrawal: &WithdrawalRequestExtra,
+        asset_script: Option<Script>,
+    ) -> Result<(), Error> {
+        // check withdrawal size
+        if withdrawal.as_slice().len() > MAX_WITHDRAWAL_SIZE {
+            return Err(WithdrawalError::ExceededMaxWithdrawalSize {
+                max_size: MAX_WITHDRAWAL_SIZE,
+                withdrawal_size: withdrawal.as_slice().len(),
+            }
+            .into());
+        }
+
+        let raw = withdrawal.request().raw();
+
+        // check chain_id
+        ChainIdVerifier::new(self.rollup_context.rollup_config.chain_id().unpack())
+            .verify(raw.chain_id().unpack())?;
+
+        let account_script_hash: H256 = raw.account_script_hash().unpack();
+        let sudt_script_hash: H256 = raw.sudt_script_hash().unpack();
+        let amount: u128 = raw.amount().unpack();
+        let capacity: u64 = raw.capacity().unpack();
+        let fee: u64 = raw.fee().unpack();
+        let registry_address = self
+            .state
+            .get_registry_address_by_script_hash(raw.registry_id().unpack(), &account_script_hash)?
+            .ok_or(Error::Account(AccountError::UnknownAccount))?;
+
+        // check capacity (use dummy block hash and number)
+        build_withdrawal_cell_output(
+            self.rollup_context,
+            withdrawal,
+            &H256::one(),
+            1,
+            asset_script,
+        )?;
+
+        // find user account
+        let id = self
+            .state
+            .get_account_id_by_script_hash(&account_script_hash)?
+            .ok_or(AccountError::UnknownAccount)?; // find Simple UDT account
+
+        // check nonce
+        let expected_nonce = self.state.get_nonce(id)?;
+        let actual_nonce: u32 = raw.nonce().unpack();
+        if actual_nonce != expected_nonce {
+            return Err(WithdrawalError::Nonce {
+                expected: expected_nonce,
+                actual: actual_nonce,
+            }
+            .into());
+        }
+
+        // check CKB balance
+        let ckb_balance = self
+            .state
+            .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, &registry_address)?;
+        let required_ckb_capacity: u128 = capacity.saturating_add(fee).into();
+        if required_ckb_capacity > ckb_balance {
+            return Err(WithdrawalError::Overdraft.into());
+        }
+        let l2_sudt_script_hash =
+            build_l2_sudt_script(self.rollup_context, &sudt_script_hash).hash();
+        let sudt_id = self
+            .state
+            .get_account_id_by_script_hash(&l2_sudt_script_hash.into())?
+            .ok_or(AccountError::UnknownSUDT)?;
+        // The sUDT id must not be equals to the CKB sUDT id if amount isn't 0
+        if sudt_id != CKB_SUDT_ACCOUNT_ID {
+            // check SUDT balance
+            // user can't withdrawal 0 SUDT when non-CKB sudt_id exists
+            if amount == 0 {
+                return Err(WithdrawalError::NonPositiveSUDTAmount.into());
+            }
+            let balance = self.state.get_sudt_balance(sudt_id, &registry_address)?;
+            if amount > balance {
+                return Err(WithdrawalError::Overdraft.into());
+            }
+        } else if amount != 0 {
+            // user can't withdrawal CKB token via SUDT fields
+            return Err(WithdrawalError::WithdrawFakedCKB.into());
+        }
+
+        Ok(())
+    }
+}

--- a/crates/mem-pool/src/constants.rs
+++ b/crates/mem-pool/src/constants.rs
@@ -4,10 +4,6 @@ pub const MAX_MEM_BLOCK_DEPOSITS: usize = 50;
 pub const MAX_MEM_BLOCK_WITHDRAWALS: usize = 50;
 /// MAX withdrawals in the mem block
 pub const MAX_MEM_BLOCK_TXS: usize = 1000;
-/// MAX tx size 50 KB
-pub const MAX_TX_SIZE: usize = 50_000;
-/// MAX withdrawal size 50 KB
-pub const MAX_WITHDRAWAL_SIZE: usize = 50_000;
 /// MIN CKB deposit capacity, calculated from custodian cell size
 pub const MIN_CKB_DEPOSIT_CAPACITY: u64 = 290_00000000;
 /// MIN Simple UDT deposit capacity, calculated from custodian cell size + simple UDT script

--- a/crates/mem-pool/src/withdrawal.rs
+++ b/crates/mem-pool/src/withdrawal.rs
@@ -102,7 +102,7 @@ impl<'a> Generator<'a> {
         };
         let block_hash: H256 = block.hash().into();
         let block_number = block.raw().number().unpack();
-        let output = match gw_generator::Generator::build_withdrawal_cell_output(
+        let output = match gw_generator::utils::build_withdrawal_cell_output(
             self.rollup_context,
             req_extra,
             &block_hash,
@@ -361,15 +361,14 @@ mod test {
         // ## With owner lock
         let req_extra = req_extra.as_builder().owner_lock(owner_lock).build();
         let (output, data) = generator.verified_output(&req_extra, &block).unwrap();
-        let (expected_output, expected_data) =
-            gw_generator::Generator::build_withdrawal_cell_output(
-                &rollup_context,
-                &req_extra,
-                &block.hash().into(),
-                block.raw().number().unpack(),
-                Some(sudt_script),
-            )
-            .unwrap();
+        let (expected_output, expected_data) = gw_generator::utils::build_withdrawal_cell_output(
+            &rollup_context,
+            &req_extra,
+            &block.hash().into(),
+            block.raw().number().unpack(),
+            Some(sudt_script),
+        )
+        .unwrap();
 
         assert_eq!(output.as_slice(), expected_output.as_slice());
         assert_eq!(data, expected_data);

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -32,7 +32,7 @@ use lazy_static::lazy_static;
 use tokio::sync::Mutex;
 
 use std::{collections::HashSet, time::Duration};
-use std::{fs, io::Read, path::PathBuf, sync::Arc};
+use std::{fs, path::PathBuf, sync::Arc};
 
 use super::mem_pool_provider::DummyMemPoolProvider;
 
@@ -46,13 +46,10 @@ const ETH_ACCOUNT_LOCK_PATH: &str = "eth-account-lock";
 
 lazy_static! {
     pub static ref ALWAYS_SUCCESS_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
         let mut path = PathBuf::new();
         path.push(&SCRIPT_DIR);
         path.push(&ALWAYS_SUCCESS_PATH);
-        let mut f = fs::File::open(&path).expect("load program");
-        f.read_to_end(&mut buf).expect("read program");
-        Bytes::from(buf.to_vec())
+        fs::read(&path).expect("read program").into()
     };
     pub static ref ALWAYS_SUCCESS_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
@@ -62,14 +59,12 @@ lazy_static! {
         buf
     };
     pub static ref WITHDRAWAL_LOCK_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
         let mut path = PathBuf::new();
         path.push(&SCRIPT_DIR);
         path.push(&WITHDRAWAL_LOCK_PATH);
-        let mut f = fs::File::open(&path).expect("load withdrawal lock program");
-        f.read_to_end(&mut buf)
-            .expect("read withdrawal lock program");
-        Bytes::from(buf.to_vec())
+        fs::read(&path)
+            .expect("read withdrawal lock program")
+            .into()
     };
     pub static ref WITHDRAWAL_LOCK_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
@@ -79,14 +74,12 @@ lazy_static! {
         buf
     };
     pub static ref STATE_VALIDATOR_TYPE_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
         let mut path = PathBuf::new();
         path.push(&SCRIPT_DIR);
         path.push(&STATE_VALIDATOR_TYPE_PATH);
-        let mut f = fs::File::open(&path).expect("load state validator type program");
-        f.read_to_end(&mut buf)
-            .expect("read state validator type program");
-        Bytes::from(buf.to_vec())
+        fs::read(&path)
+            .expect("read state validator type program")
+            .into()
     };
     pub static ref STATE_VALIDATOR_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
@@ -96,13 +89,10 @@ lazy_static! {
         buf
     };
     pub static ref STAKE_LOCK_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
         let mut path = PathBuf::new();
         path.push(&SCRIPT_DIR);
         path.push(&STAKE_LOCK_PATH);
-        let mut f = fs::File::open(&path).expect("load stake lock program");
-        f.read_to_end(&mut buf).expect("read stake lock program");
-        Bytes::from(buf.to_vec())
+        fs::read(&path).expect("read stake lock program").into()
     };
     pub static ref STAKE_LOCK_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
@@ -112,14 +102,10 @@ lazy_static! {
         buf
     };
     pub static ref CUSTODIAN_LOCK_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
         let mut path = PathBuf::new();
         path.push(&SCRIPT_DIR);
         path.push(&CUSTODIAN_LOCK_PATH);
-        let mut f = fs::File::open(&path).expect("load custodian lock program");
-        f.read_to_end(&mut buf)
-            .expect("read custodian lock program");
-        Bytes::from(buf.to_vec())
+        fs::read(&path).expect("read custodian lock program").into()
     };
     pub static ref CUSTODIAN_LOCK_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
@@ -129,14 +115,12 @@ lazy_static! {
         buf
     };
     pub static ref ETH_ACCOUNT_LOCK_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
         let mut path = PathBuf::new();
         path.push(&SCRIPT_DIR);
         path.push(&ETH_ACCOUNT_LOCK_PATH);
-        let mut f = fs::File::open(&path).expect("load eth account lock program");
-        f.read_to_end(&mut buf)
-            .expect("read eth account lock program");
-        Bytes::from(buf.to_vec())
+        fs::read(&path)
+            .expect("read eth account lock program")
+            .into()
     };
     pub static ref ETH_ACCOUNT_LOCK_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
@@ -145,14 +129,9 @@ lazy_static! {
         hasher.finalize(&mut buf);
         buf
     };
-    pub static ref SUDT_VALIDATOR_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
-        let mut path = PathBuf::new();
-        path.push(&SUDT_VALIDATOR_PATH);
-        let mut f = fs::File::open(&path).expect("load SUDT program");
-        f.read_to_end(&mut buf).expect("read SUDT program");
-        Bytes::from(buf.to_vec())
-    };
+    pub static ref SUDT_VALIDATOR_PROGRAM: Bytes = fs::read(&SUDT_VALIDATOR_PATH)
+        .expect("read SUDT program")
+        .into();
     pub static ref SUDT_VALIDATOR_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
         let mut hasher = new_blake2b();
@@ -160,15 +139,10 @@ lazy_static! {
         hasher.finalize(&mut buf);
         buf
     };
-    pub static ref ETH_EOA_MAPPING_REGISTRY_VALIDATOR_PROGRAM: Bytes = {
-        let mut buf = Vec::new();
-        let mut path = PathBuf::new();
-        path.push(&ETH_REGISTRY_VALIDATOR_PATH);
-        let mut f = fs::File::open(&path).expect("load eth eoa mapping registry program");
-        f.read_to_end(&mut buf)
-            .expect("read eth eoa mapping registry program");
-        Bytes::from(buf.to_vec())
-    };
+    pub static ref ETH_EOA_MAPPING_REGISTRY_VALIDATOR_PROGRAM: Bytes =
+        fs::read(&ETH_REGISTRY_VALIDATOR_PATH)
+            .expect("read eth eoa mapping registry program")
+            .into();
     pub static ref ETH_EOA_MAPPING_REGISTRY_VALIDATOR_CODE_HASH: [u8; 32] = {
         let mut buf = [0u8; 32];
         let mut hasher = new_blake2b();

--- a/crates/tests/src/tests/restore_mem_block.rs
+++ b/crates/tests/src/tests/restore_mem_block.rs
@@ -152,7 +152,7 @@ async fn test_restore_mem_block() {
                 let args = SUDTArgs::new_builder().set(transfer).build();
                 let raw = RawL2Transaction::new_builder()
                     .from_id(from_id.unwrap().pack())
-                    .to_id(1u32.pack()) // 1 is reserved for sudt
+                    .to_id(gw_common::builtins::CKB_SUDT_ACCOUNT_ID.pack()) // 1 is reserved for sudt
                     .args(args.as_bytes().pack())
                     .build();
                 L2Transaction::new_builder().raw(raw).build()


### PR DESCRIPTION
1. Move tx & withdrawal verification code to a standalone module.
2. Reject tx if sender's balance is insufficient.