### PR TITLE
fix(withdrawal_unlocker): rejected unlock tx isn't removed

### DIFF
--- a/crates/block-producer/src/withdrawal_unlocker.rs
+++ b/crates/block-producer/src/withdrawal_unlocker.rs
@@ -84,7 +84,9 @@ impl FinalizedWithdrawalUnlocker {
         for (tx_hash, withdrawal_to_unlock) in self.unlock_txs.iter() {
             match rpc_client.get_transaction_status(*tx_hash).await {
                 Err(err) => {
-                    log::debug!("[unlock withdrawal] get unlock tx failed {}", err);
+                    // Always drop this unlock tx and retry to avoid "lock" withdrawal cell
+                    log::info!("[unlock withdrawal] get unlock tx failed {}, drop it", err);
+                    drop_txs.push(*tx_hash);
                 }
                 Ok(None) => {
                     log::info!("[unlock withdrawal] dropped unlock tx {}", tx_hash.pack());


### PR DESCRIPTION
- fix ```get_transaction_status``` throw ```invalid type: null, expected struct TransactionView``` error for rejected tx, return  ```Ok(None)``` instead.
- always drop unlock tx and retry if ```get_transaction_status``` return error, avoid "lock" withdrawal cell.