### PR TITLE
backport: fix(withdrawal_unlocker): rejected unlock tx isn't removed

### DIFF
--- a/crates/block-producer/src/withdrawal_unlocker.rs
+++ b/crates/block-producer/src/withdrawal_unlocker.rs
@@ -84,7 +84,9 @@ impl FinalizedWithdrawalUnlocker {
         for (tx_hash, withdrawal_to_unlock) in self.unlock_txs.iter() {
             match rpc_client.get_transaction_status(*tx_hash).await {
                 Err(err) => {
-                    log::debug!("[unlock withdrawal] get unlock tx failed {}", err);
+                    // Always drop this unlock tx and retry to avoid "lock" withdrawal cell
+                    log::info!("[unlock withdrawal] get unlock tx failed {}, drop it", err);
+                    drop_txs.push(*tx_hash);
                 }
                 Ok(None) => {
                     log::info!("[unlock withdrawal] dropped unlock tx {}", tx_hash.pack());

--- a/crates/rpc-client/src/rpc_client.rs
+++ b/crates/rpc-client/src/rpc_client.rs
@@ -1534,21 +1534,27 @@ impl RPCClient {
 
     #[instrument(skip_all, fields(tx_hash = %tx_hash.pack()))]
     pub async fn get_transaction_status(&self, tx_hash: H256) -> Result<Option<TxStatus>> {
-        let tx_with_status: Option<ckb_jsonrpc_types::TransactionWithStatus> = self
-            .ckb
-            .request(
-                "get_transaction",
-                Some(ClientParams::Array(vec![json!(to_jsonh256(tx_hash))])),
-            )
-            .await?;
+        let get_tx = self.ckb.request::<Option<serde_json::Value>>(
+            "get_transaction",
+            Some(ClientParams::Array(vec![json!(to_jsonh256(tx_hash))])),
+        );
 
-        Ok(
-            tx_with_status.map(|tx_with_status| match tx_with_status.tx_status.status {
-                ckb_jsonrpc_types::Status::Pending => TxStatus::Pending,
-                ckb_jsonrpc_types::Status::Committed => TxStatus::Committed,
-                ckb_jsonrpc_types::Status::Proposed => TxStatus::Proposed,
-            }),
-        )
+        let tx_with_status: ckb_jsonrpc_types::TransactionWithStatus = match get_tx.await? {
+            Some(ret) if ret["transaction"] == serde_json::Value::Null => {
+                log::debug!("get_transaction_status: tx {:x} {:?}", tx_hash.pack(), ret);
+                return Ok(None);
+            }
+            Some(ret) => serde_json::from_value(ret)?,
+            None => return Ok(None),
+        };
+
+        let status = match tx_with_status.tx_status.status {
+            ckb_jsonrpc_types::Status::Pending => TxStatus::Pending,
+            ckb_jsonrpc_types::Status::Committed => TxStatus::Committed,
+            ckb_jsonrpc_types::Status::Proposed => TxStatus::Proposed,
+        };
+
+        Ok(Some(status))
     }
 
     #[instrument(skip_all, fields(tx_hash = %tx.hash().pack()))]


### PR DESCRIPTION
- fix ```get_transaction_status``` throw ```invalid type: null, expected struct TransactionView``` error for rejected tx, return  ```Ok(None)``` instead.
- always drop unlock tx and retry if ```get_transaction_status``` return error, avoid "lock" withdrawal cell.