### PR TITLE
fix(generator): exceeded MAX_WRITE_DATA_BYTES_LIMIT error

### DIFF
--- a/crates/generator/src/constants.rs
+++ b/crates/generator/src/constants.rs
@@ -3,7 +3,7 @@ pub const MAX_TX_SIZE: usize = 50_000;
 /// MAX withdrawal size 50 KB
 pub const MAX_WITHDRAWAL_SIZE: usize = 50_000;
 // 25 KB
-pub const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25_000;
+pub const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25 * 1024;
 // 2MB
 pub const MAX_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
 /// max cycles of a layer2 transaction

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -658,11 +658,14 @@ impl Generator {
         }
 
         // check write data bytes
-        let write_data_bytes: usize = run_result.write_data.values().map(|data| data.len()).sum();
-        if write_data_bytes > MAX_WRITE_DATA_BYTES_LIMIT {
+        if let Some(data) = run_result
+            .write_data
+            .values()
+            .find(|data| data.len() > MAX_WRITE_DATA_BYTES_LIMIT)
+        {
             return Err(TransactionError::ExceededMaxWriteData {
                 max_bytes: MAX_WRITE_DATA_BYTES_LIMIT,
-                used_bytes: write_data_bytes,
+                used_bytes: data.len(),
             });
         }
         // check read data bytes


### PR DESCRIPTION
- compare `MAX_WRITE_DATA_BYTES_LIMIT` with each data size instead of total write data size.
- align `MAX_WRITE_DATA_BYTES_LIMIT` to `25 * 1024`, same as `GW_MAX_DATA_SIZE` in godwoken-scripts.