### PR TITLE
Deposit to EOA account only

### DIFF
--- a/crates/mem-pool/src/deposit.rs
+++ b/crates/mem-pool/src/deposit.rs
@@ -154,10 +154,11 @@ fn check_deposit_cell(ctx: &RollupContext, cell: &DepositInfo, state: &MemStateT
             .into_iter()
             .any(|type_hash| type_hash.hash() == script.code_hash())
         {
-            return Err(anyhow!(
-                "Not an EOA type hash: {}, we can only deposit to EOA account",
-                hex::encode(&script.code_hash().as_bytes())
-            ));
+            return Err(
+                anyhow!("Invalid deposit account script: script.code_hash is not in configured allowed_eoa_type_hashes, script.code_hash: {}",
+                    hex::encode(&script.code_hash().as_bytes())
+                ),
+            );
         }
 
         let args: Bytes = script.args().unpack();
@@ -193,7 +194,10 @@ fn check_deposit_cell(ctx: &RollupContext, cell: &DepositInfo, state: &MemStateT
                 if let Some(script_hash) = state.get_script_hash_by_registry_address(&reg_addr)? {
                     if script.hash() != script_hash.as_slice() {
                         return Err(anyhow!(
-                            "RegistryAddress has been mapped with another script hash before."
+                            "The RegistryAddress {:?} was already occupied by script_hash {}, depositing script_hash: {}",
+                            hex::encode(reg_addr.to_bytes()),
+                            hex::encode(&script_hash.as_slice()),
+                            hex::encode(&script.hash()),
                         ));
                     }
                 }

--- a/crates/mem-pool/src/deposit.rs
+++ b/crates/mem-pool/src/deposit.rs
@@ -144,6 +144,20 @@ fn check_deposit_cell(ctx: &RollupContext, cell: &DepositInfo) -> Result<()> {
                 "Invalid deposit account script: unexpected hash_type: Data"
             ));
         }
+        // godwoken only allow to deposit to an EOA account
+        // check code hash of deposit reqeust is an EOA type hash
+        if !ctx
+            .rollup_config
+            .allowed_eoa_type_hashes()
+            .into_iter()
+            .any(|type_hash| type_hash.hash() == script.code_hash())
+        {
+            return Err(anyhow!(
+                "Not an EOA type hash: {}, we can only deposit to EOA account",
+                hex::encode(&script.code_hash().as_bytes())
+            ));
+        }
+
         let args: Bytes = script.args().unpack();
         if args.len() < 32 {
             return Err(anyhow!(

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -840,6 +840,7 @@ impl MemPool {
                 crate::deposit::sanitize_deposit_cells(
                     self.generator.rollup_context(),
                     cells.collect(),
+                    &state,
                 )
             };
             log::debug!(


### PR DESCRIPTION
Godwoken only accepts deposit requests from `EOA account`. Meantime, we need to make sure the `registry address` is absent before applying to deposit.
Because an eoa account and a contract account could point to the same registry address.