### PR TITLE
fix: clear non polyjuice system logs when transaction failed

### DIFF
--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -434,7 +434,7 @@ impl<'a, S: State, C: ChainView, Mac: SupportMachine> Syscalls<Mac> for L2Syscal
                 let data_addr = machine.registers()[A3].to_u64();
 
                 let data = load_bytes(machine, data_addr, data_len as usize)?;
-                self.result.logs.push(
+                self.result.write.logs.push(
                     LogItem::new_builder()
                         .account_id(account_id.pack())
                         .service_flag(service_flag.into())

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -1169,11 +1169,11 @@ pub struct RunResult {
 impl From<offchain::RunResult> for RunResult {
     fn from(data: offchain::RunResult) -> RunResult {
         let offchain::RunResult {
-            return_data, logs, ..
+            return_data, write, ..
         } = data;
         RunResult {
             return_data: JsonBytes::from_bytes(return_data),
-            logs: logs.into_iter().map(Into::into).collect(),
+            logs: write.logs.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -795,7 +795,7 @@ async fn execute_l2transaction(
             tx_hash: tx_hash.into(),
             block_number: number,
             return_data: run_result.return_data,
-            last_log: run_result.logs.pop(),
+            last_log: run_result.write.logs.pop(),
             exit_code: run_result.exit_code,
         };
 
@@ -904,7 +904,7 @@ async fn execute_raw_l2transaction(
             tx_hash,
             block_number,
             return_data: run_result.return_data,
-            last_log: run_result.logs.pop(),
+            last_log: run_result.write.logs.pop(),
             exit_code: run_result.exit_code,
         };
 

--- a/crates/types/src/offchain/extension.rs
+++ b/crates/types/src/offchain/extension.rs
@@ -46,7 +46,7 @@ impl TxReceipt {
                     .collect::<Vec<_>>()
                     .pack(),
             )
-            .logs(run_result.logs.pack())
+            .logs(run_result.write.logs.pack())
             .build()
     }
 }

--- a/crates/types/src/offchain/run_result.rs
+++ b/crates/types/src/offchain/run_result.rs
@@ -16,6 +16,8 @@ pub struct RunResultWriteState {
     pub account_count: Option<u32>,
     pub new_scripts: HashMap<H256, Script>,
     pub write_data: HashMap<H256, Bytes>,
+    // log data
+    pub logs: Vec<LogItem>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -26,8 +28,6 @@ pub struct RunResult {
     pub get_scripts: HashMap<H256, Script>,
     // data hash -> data full size
     pub read_data: HashMap<H256, Bytes>,
-    // log data
-    pub logs: Vec<LogItem>,
     // used cycles
     pub used_cycles: u64,
     pub exit_code: i8,


### PR DESCRIPTION
1. clear non polyjuice system logs when transaction failed.
- revert non polyjuice system logs when transaction failed