### PR TITLE
Fix: Improve the withdrawal packaging performance

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -221,7 +221,7 @@ fn default_enable_debug_rpc() -> bool {
 
 impl Default for DebugConfig {
     fn default() -> Self {
-        const EXPECTED_TX_UPPER_BOUND_CYCLES: u64 = 70000000u64;
+        const EXPECTED_TX_UPPER_BOUND_CYCLES: u64 = 350000000u64;
         const DEFAULT_DEBUG_TX_DUMP_PATH: &str = "debug-tx-dump";
 
         Self {

--- a/crates/mem-pool/src/constants.rs
+++ b/crates/mem-pool/src/constants.rs
@@ -1,7 +1,7 @@
 /// MAX deposits in the mem block
-pub const MAX_MEM_BLOCK_DEPOSITS: usize = 50;
+pub const MAX_MEM_BLOCK_DEPOSITS: usize = 100;
 /// MAX withdrawals in the mem block
-pub const MAX_MEM_BLOCK_WITHDRAWALS: usize = 50;
+pub const MAX_MEM_BLOCK_WITHDRAWALS: usize = 100;
 /// MAX withdrawals in the mem block
 pub const MAX_MEM_BLOCK_TXS: usize = 1000;
 /// MIN CKB deposit capacity, calculated from custodian cell size

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -422,27 +422,6 @@ impl MemPool {
         Ok(())
     }
 
-    /// FIXME
-    /// This function is a temporary mechanism
-    /// Try to recovery from invalid state by drop txs & deposit
-    pub fn try_to_recovery_from_invalid_state(&mut self) -> Result<()> {
-        log::warn!("[mem-pool] try to recovery from invalid state by drop txs & deposits");
-        log::warn!("[mem-pool] drop mem-block");
-        log::warn!(
-            "[mem-pool] drop withdrawals: {}",
-            self.mem_block.withdrawals().len()
-        );
-        log::warn!("[mem-pool] drop txs: {}", self.mem_block.txs().len());
-        for tx_hash in self.mem_block.txs() {
-            log::warn!("[mem-pool] drop tx: {}", hex::encode(tx_hash.as_slice()));
-        }
-        self.mem_block.clear();
-        log::warn!("[mem-pool] drop pending: {}", self.pending.len());
-        self.pending.clear();
-        log::warn!("[mem-pool] try_to_recovery - done");
-        Ok(())
-    }
-
     /// output mem block
     #[instrument(skip_all, fields(retry_count = output_param.retry_count))]
     pub fn output_mem_block(&self, output_param: &OutputParam) -> (MemBlock, AccountMerkleState) {

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -905,7 +905,7 @@ impl MemPool {
     async fn finalize_withdrawals(
         &mut self,
         state: &mut MemStateTree<'_>,
-        withdrawals: Vec<WithdrawalRequestExtra>,
+        mut withdrawals: Vec<WithdrawalRequestExtra>,
     ) -> Result<()> {
         // check mem block state
         assert!(self.mem_block.withdrawals().is_empty());
@@ -929,10 +929,7 @@ impl MemPool {
         }
 
         // find withdrawals from pending
-        let mut withdrawals: Vec<_> = withdrawals
-            .into_iter()
-            .filter(|withdrawal| filter_withdrawals(state, withdrawal))
-            .collect();
+        withdrawals.retain(|withdrawal| filter_withdrawals(state, withdrawal));
         // package withdrawals
         if withdrawals.len() < MAX_MEM_BLOCK_WITHDRAWALS {
             for entry in self.pending().values() {

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -459,7 +459,7 @@ pub async fn construct_block_with_timestamp(
     if !refresh_mem_pool {
         assert!(
             deposit_requests.is_empty(),
-            "skip refresh mem pool, bug deposits isn't empty"
+            "skip refresh mem pool, but deposits isn't empty"
         )
     }
     let stake_cell_owner_lock_hash = H256::zero();

--- a/crates/tests/src/tests/restore_mem_pool_pending_withdrawal.rs
+++ b/crates/tests/src/tests/restore_mem_pool_pending_withdrawal.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::testing_tool::chain::{build_sync_tx, construct_block, restart_chain, setup_chain};
+use crate::testing_tool::chain::{
+    build_sync_tx, construct_block, construct_block_with_timestamp, restart_chain, setup_chain,
+};
 use crate::testing_tool::common::random_always_success_script;
 use crate::testing_tool::mem_pool_provider::DummyMemPoolProvider;
 
@@ -188,7 +190,7 @@ async fn test_restore_mem_pool_pending_withdrawal() {
     let block_result = {
         let mem_pool = chain.mem_pool().as_ref().unwrap();
         let mut mem_pool = mem_pool.lock().await;
-        construct_block(&chain, &mut mem_pool, vec![])
+        construct_block_with_timestamp(&chain, &mut mem_pool, vec![], 0, false)
             .await
             .unwrap()
     };

--- a/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
+++ b/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
@@ -297,7 +297,7 @@ async fn test_build_unlock_to_owner_tx() {
     let withdrawal_block_result = {
         let mem_pool = chain.mem_pool().as_ref().unwrap();
         let mut mem_pool = mem_pool.lock().await;
-        construct_block_with_timestamp(&chain, &mut mem_pool, vec![], BLOCK_TIMESTAMP)
+        construct_block_with_timestamp(&chain, &mut mem_pool, vec![], BLOCK_TIMESTAMP, true)
             .await
             .unwrap()
     };
@@ -546,7 +546,7 @@ async fn test_build_unlock_to_owner_tx() {
         let provider = DummyMemPoolProvider::default();
         mem_pool.set_provider(Box::new(provider));
         mem_pool.reset_mem_block().await.unwrap();
-        construct_block_with_timestamp(&chain, &mut mem_pool, vec![], BLOCK_TIMESTAMP2)
+        construct_block_with_timestamp(&chain, &mut mem_pool, vec![], BLOCK_TIMESTAMP2, true)
             .await
             .unwrap()
     };


### PR DESCRIPTION
* Fix a bug of withdrawal packaging. Before the fix, Godwoken skip packaging withdrawals every two blocks. Now, it packages withdrawals in every block.
* Increase maximum deposits & withdraws of each block from 50 to 100(100 depostis + 100 withdrawals costs ~ 240_000_000 cycles).
* Increase the maximum cycles of layer1 submission transaction to 350_000_000 (1/10 of a CKB block).
* Improve the logging of block-produce