### PR TITLE
fix/refactor some CKB/godwoken RPC related code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,7 +2324,6 @@ dependencies = [
  "ckb-types",
  "clap",
  "csv",
- "env_logger",
  "faster-hex 0.5.0",
  "gw-common",
  "gw-config",
@@ -2348,6 +2347,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -5472,11 +5472,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -5515,14 +5516,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -5666,6 +5667,12 @@ dependencies = [
  "getrandom 0.2.4",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,7 +2314,6 @@ name = "gw-tools"
 version = "1.1.1"
 dependencies = [
  "anyhow",
- "async-jsonrpc-client",
  "bech32",
  "ckb-crypto",
  "ckb-fixed-hash",

--- a/crates/block-producer/src/debugger.rs
+++ b/crates/block-producer/src/debugger.rs
@@ -110,9 +110,12 @@ pub async fn build_mock_transaction(
         .ok_or_else(|| anyhow!("can't find input cell"))?;
 
         let input_tx_hash = input.previous_output().tx_hash().unpack();
-        let input_block_hash = match rpc_client.get_transaction_status(input_tx_hash).await? {
+        let input_block_hash = match rpc_client.ckb.get_transaction_status(input_tx_hash).await? {
             Some(TxStatus::Committed) => {
-                let block_hash = rpc_client.get_transaction_block_hash(input_tx_hash).await?;
+                let block_hash = rpc_client
+                    .ckb
+                    .get_transaction_block_hash(input_tx_hash)
+                    .await?;
                 Some(block_hash.ok_or_else(|| anyhow!("not found input cell tx hash"))?)
             }
             _ => None,
@@ -160,9 +163,14 @@ pub async fn build_mock_transaction(
         }
         .ok_or_else(|| anyhow!("can't find dep cell"))?;
         let dep_cell_tx_hash = cell_dep.out_point().tx_hash().unpack();
-        let dep_cell_block_hash = match rpc_client.get_transaction_status(dep_cell_tx_hash).await? {
+        let dep_cell_block_hash = match rpc_client
+            .ckb
+            .get_transaction_status(dep_cell_tx_hash)
+            .await?
+        {
             Some(TxStatus::Committed) => {
                 let query = rpc_client
+                    .ckb
                     .get_transaction_block_hash(dep_cell_tx_hash)
                     .await?;
                 Some(query.ok_or_else(|| anyhow!("not found dep cell tx hash"))?)

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -413,6 +413,7 @@ impl BaseInitComponents {
         let secp_data: Bytes = {
             let out_point = config.genesis.secp_data_dep.out_point.clone();
             rpc_client
+                .ckb
                 .get_transaction(out_point.tx_hash.0.into())
                 .await?
                 .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?

--- a/crates/block-producer/src/withdrawal_unlocker.rs
+++ b/crates/block-producer/src/withdrawal_unlocker.rs
@@ -82,7 +82,7 @@ impl FinalizedWithdrawalUnlocker {
         // Check unlock tx
         let mut drop_txs = vec![];
         for (tx_hash, withdrawal_to_unlock) in self.unlock_txs.iter() {
-            match rpc_client.get_transaction_status(*tx_hash).await {
+            match rpc_client.ckb.get_transaction_status(*tx_hash).await {
                 Err(err) => {
                     // Always drop this unlock tx and retry to avoid "lock" withdrawal cell
                     log::info!("[unlock withdrawal] get unlock tx failed {}, drop it", err);

--- a/crates/replay-chain/src/setup.rs
+++ b/crates/replay-chain/src/setup.rs
@@ -77,6 +77,7 @@ pub async fn setup(args: SetupArgs) -> Result<Context> {
         };
         let out_point = config.genesis.secp_data_dep.out_point.clone();
         rpc_client
+            .ckb
             .get_transaction(out_point.tx_hash.0.into())
             .await?
             .ok_or_else(|| anyhow!("can not found transaction: {:?}", out_point.tx_hash))?

--- a/crates/rpc-client/src/ckb_client.rs
+++ b/crates/rpc-client/src/ckb_client.rs
@@ -1,12 +1,17 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::{
     error::RPCRequestError,
-    utils::{to_result, DEFAULT_HTTP_TIMEOUT},
+    utils::{to_jsonh256, to_result, DEFAULT_HTTP_TIMEOUT},
 };
 use anyhow::{anyhow, bail, Result};
 use async_jsonrpc_client::{HttpClient, Params as ClientParams, Transport};
-use gw_jsonrpc_types::blockchain::CellDep;
+use gw_common::H256;
+use gw_jsonrpc_types::{
+    blockchain::{CellDep, TransactionWithStatus},
+    ckb_jsonrpc_types,
+};
+use gw_types::{offchain::TxStatus, packed::Transaction, prelude::*};
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use tokio_metrics::TaskMonitor;
@@ -72,13 +77,124 @@ impl CKBClient {
         }
     }
 
+    #[instrument(skip_all, fields(tx_hash = %tx_hash.pack()))]
+    pub async fn get_transaction_block_hash(&self, tx_hash: H256) -> Result<Option<[u8; 32]>> {
+        let tx_with_status = self.get_transaction_with_status(tx_hash).await?;
+        Ok(tx_with_status
+            .and_then(|tx_with_status| tx_with_status.tx_status.block_hash)
+            .map(Into::into))
+    }
+
+    #[instrument(skip_all, fields(tx_hash = %tx_hash.pack()))]
+    pub async fn get_transaction_block_number(&self, tx_hash: H256) -> Result<Option<u64>> {
+        match self.get_transaction_block_hash(tx_hash).await? {
+            Some(block_hash) => {
+                let block = self.get_block(block_hash.into()).await?;
+                Ok(block.map(|b| b.header.inner.number.value()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    #[instrument(skip_all, fields(block_hash = %block_hash.pack()))]
+    pub async fn get_block(
+        &self,
+        block_hash: H256,
+    ) -> Result<Option<ckb_jsonrpc_types::BlockView>> {
+        let block: Option<ckb_jsonrpc_types::BlockView> = self
+            .request(
+                "get_block",
+                Some(ClientParams::Array(vec![json!(to_jsonh256(block_hash))])),
+            )
+            .await?;
+
+        Ok(block)
+    }
+
+    /// Get transaction with status.
+    pub async fn get_transaction_with_status(
+        &self,
+        tx_hash: H256,
+    ) -> Result<Option<TransactionWithStatus>> {
+        self.request(
+            "get_transaction",
+            Some(ClientParams::Array(vec![json!(to_jsonh256(tx_hash))])),
+        )
+        .await
+    }
+
+    #[instrument(skip_all, fields(tx_hash = %tx_hash.pack()))]
+    pub async fn get_transaction(&self, tx_hash: H256) -> Result<Option<Transaction>> {
+        let tx_with_status = self.get_transaction_with_status(tx_hash).await?;
+        Ok(tx_with_status
+            .and_then(|tx_with_status| tx_with_status.transaction)
+            .map(|tv| {
+                let tx: ckb_types::packed::Transaction = tv.inner.into();
+                Transaction::new_unchecked(tx.as_bytes())
+            }))
+    }
+
+    #[instrument(skip_all, fields(tx_hash = %tx_hash.pack()))]
+    pub async fn get_transaction_status(&self, tx_hash: H256) -> Result<Option<TxStatus>> {
+        let tx_with_status = self.get_transaction_with_status(tx_hash).await?;
+        Ok(tx_with_status.map(|tx_with_status| tx_with_status.tx_status.status.into()))
+    }
+
+    pub async fn wait_tx_proposed(&self, tx_hash: H256) -> Result<()> {
+        loop {
+            match self.get_transaction_status(tx_hash).await? {
+                Some(TxStatus::Proposed) | Some(TxStatus::Committed) => return Ok(()),
+                Some(TxStatus::Rejected) => bail!("rejected"),
+                _ => (),
+            }
+
+            tokio::time::sleep(Duration::new(3, 0)).await;
+        }
+    }
+
+    pub async fn wait_tx_committed(&self, tx_hash: H256) -> Result<()> {
+        loop {
+            match self.get_transaction_status(tx_hash).await? {
+                Some(TxStatus::Committed) => return Ok(()),
+                Some(TxStatus::Rejected) => bail!("rejected"),
+                _ => (),
+            }
+
+            tokio::time::sleep(Duration::new(3, 0)).await;
+        }
+    }
+
+    pub async fn wait_tx_committed_with_timeout_and_logging(
+        &self,
+        tx_hash: H256,
+        timeout_secs: u64,
+    ) -> Result<()> {
+        let timeout = Duration::new(timeout_secs, 0);
+        let now = Instant::now();
+
+        loop {
+            match self.get_transaction_status(tx_hash).await? {
+                Some(TxStatus::Committed) => return Ok(()),
+                Some(TxStatus::Rejected) => bail!("transaction rejected"),
+                Some(status) => log::info!("waiting for transaction, status: {:?}", status),
+                None => log::info!("waiting for transaction, not found"),
+            }
+
+            if now.elapsed() >= timeout {
+                bail!("timeout");
+            }
+
+            tokio::time::sleep(Duration::new(3, 0)).await;
+        }
+    }
+
     #[instrument(skip_all)]
     pub async fn query_type_script(
         &self,
         contract: &str,
         cell_dep: CellDep,
     ) -> Result<gw_jsonrpc_types::blockchain::Script> {
-        use gw_jsonrpc_types::ckb_jsonrpc_types::TransactionWithStatus;
+        use gw_jsonrpc_types::blockchain::TransactionWithStatus;
 
         let tx_hash = cell_dep.out_point.tx_hash;
         let tx_with_status: Option<TransactionWithStatus> = self
@@ -88,8 +204,11 @@ impl CKBClient {
             )
             .await?;
         let tx = match tx_with_status {
-            Some(tx_with_status) => tx_with_status.transaction.inner,
-            None => bail!("{} {} tx not found", contract, tx_hash),
+            Some(TransactionWithStatus {
+                transaction: Some(tv),
+                ..
+            }) => tv.inner,
+            _ => bail!("{} {} tx not found", contract, tx_hash),
         };
 
         match tx.outputs.get(cell_dep.out_point.index.value() as usize) {

--- a/crates/rpc-client/src/ckb_client.rs
+++ b/crates/rpc-client/src/ckb_client.rs
@@ -174,7 +174,10 @@ impl CKBClient {
 
         loop {
             match self.get_transaction_status(tx_hash).await? {
-                Some(TxStatus::Committed) => return Ok(()),
+                Some(TxStatus::Committed) => {
+                    log::info!("transaction committed");
+                    return Ok(());
+                }
                 Some(TxStatus::Rejected) => bail!("transaction rejected"),
                 Some(status) => log::info!("waiting for transaction, status: {:?}", status),
                 None => log::info!("waiting for transaction, not found"),

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-env_logger = "0.8"
 clap = "2.33"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -43,3 +42,4 @@ hex = "0.4"
 tokio = { version = "1.15", features = ["full"] }
 jsonrpc-core = "17"
 csv = "1.1.6"
+tracing-subscriber = { version = "0.3.11", features = ["tracing-log"] }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -19,7 +19,7 @@ tempfile = "3.1"
 lazy_static = "1.3"
 secp256k1 = "0.19"
 sha3 = "0.9.1"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json"] }
 ckb-jsonrpc-types = "0.100.0"
 ckb-types = "0.100.0"
 ckb-resource = "0.100.0"
@@ -36,7 +36,6 @@ gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-utils = { path = "../utils" }
 gw-rpc-client = { path = "../rpc-client" }
 gw-version = { path = "../version" }
-async-jsonrpc-client = { version = "0.3.0", default-features = false, features = ["http-tokio"] }
 url = "2.2"
 faster-hex = "0.5.0"
 rand = "0.8"

--- a/crates/tools/src/create_creator_account.rs
+++ b/crates/tools/src/create_creator_account.rs
@@ -135,7 +135,9 @@ pub async fn create_creator_account(
         .get_account_id_by_script_hash(l2_script_hash.into())
         .await?
         .expect("Creator account id not exist!");
-    log::info!("Creator account id: {}", account_id);
+    // Kicker relies on this output to determine that creator account creation
+    // is successful.
+    println!("Creator account id: {}", account_id);
 
     Ok(())
 }

--- a/crates/tools/src/deposit_ckb.rs
+++ b/crates/tools/src/deposit_ckb.rs
@@ -196,11 +196,12 @@ async fn get_balance_by_script_hash(
         .get_registry_address_by_script_hash(script_hash)
         .await;
     let balance = match addr {
-        Ok(reg_addr) => {
+        Ok(Some(reg_addr)) => {
             godwoken_rpc_client
                 .get_balance(&reg_addr, CKB_SUDT_ACCOUNT_ID)
                 .await?
         }
+        Ok(None) => U256::zero(),
         Err(e) => {
             log::warn!("failed to get_registry_address_by_script_hash, {}", e);
             U256::zero()

--- a/crates/tools/src/deposit_ckb.rs
+++ b/crates/tools/src/deposit_ckb.rs
@@ -2,7 +2,7 @@ use crate::account::{privkey_to_eth_address, read_privkey};
 use crate::godwoken_rpc::GodwokenRpcClient;
 use crate::hasher::CkbHasher;
 use crate::types::ScriptsDeploymentResult;
-use crate::utils::transaction::{get_network_type, read_config, run_cmd, wait_for_tx};
+use crate::utils::transaction::{get_network_type, read_config, run_cmd};
 use anyhow::{anyhow, Result};
 use ckb_fixed_hash::H256;
 use ckb_sdk::{Address, AddressPayload, HttpRpcClient, HumanCapacity, SECP256K1};
@@ -131,7 +131,9 @@ pub async fn deposit_ckb(
     let tx_hash = H256::from_str(output.trim().trim_start_matches("0x"))?;
     log::info!("tx_hash: {:#x}", tx_hash);
 
-    wait_for_tx(&mut rpc_client, &tx_hash, 180u64)?;
+    gw_rpc_client::ckb_client::CKBClient::with_url(ckb_rpc_url)?
+        .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 180)
+        .await?;
 
     wait_for_balance_change(
         &mut godwoken_rpc_client,

--- a/crates/tools/src/get_balance.rs
+++ b/crates/tools/src/get_balance.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use gw_types::U256;
 
 use crate::{account::parse_account_from_str, godwoken_rpc::GodwokenRpcClient};
 
@@ -8,7 +9,11 @@ pub async fn get_balance(godwoken_rpc_url: &str, account: &str, sudt_id: u32) ->
     let addr = godwoken_rpc_client
         .get_registry_address_by_script_hash(&script_hash)
         .await?;
-    let balance = godwoken_rpc_client.get_balance(&addr, sudt_id).await?;
+    let balance = if let Some(addr) = addr {
+        godwoken_rpc_client.get_balance(&addr, sudt_id).await?
+    } else {
+        U256::zero()
+    };
     log::info!("Balance: {}", balance);
 
     Ok(())

--- a/crates/tools/src/godwoken_rpc.rs
+++ b/crates/tools/src/godwoken_rpc.rs
@@ -66,14 +66,15 @@ impl GodwokenRpcClient {
     pub async fn get_registry_address_by_script_hash(
         &self,
         script_hash: &H256,
-    ) -> Result<RegistryAddress> {
+    ) -> Result<Option<RegistryAddress>> {
         let params = serde_json::to_value((script_hash, AccountID::from(ETH_REGISTRY_ACCOUNT_ID)))?;
-        self.rpc::<gw_jsonrpc_types::godwoken::RegistryAddress>(
-            "get_registry_address_by_script_hash",
-            params,
-        )
-        .await
-        .map(Into::into)
+        let opt_address = self
+            .rpc::<Option<gw_jsonrpc_types::godwoken::RegistryAddress>>(
+                "get_registry_address_by_script_hash",
+                params,
+            )
+            .await?;
+        Ok(opt_address.map(Into::into))
     }
 
     pub async fn get_script_hash_by_registry_address(

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -24,7 +24,6 @@ mod withdraw;
 
 use account::read_privkey;
 use anyhow::{anyhow, Result};
-use async_jsonrpc_client::HttpClient;
 use ckb_sdk::constants::ONE_CKB;
 use ckb_types::prelude::Unpack;
 use clap::{value_t, App, Arg, SubCommand};
@@ -868,7 +867,9 @@ async fn main() -> Result<()> {
                 let content = std::fs::read(input_path)?;
                 serde_json::from_slice(&content)?
             };
-            match deploy_scripts::deploy_scripts(privkey_path, ckb_rpc_url, &build_script_result) {
+            match deploy_scripts::deploy_scripts(privkey_path, ckb_rpc_url, &build_script_result)
+                .await
+            {
                 Ok(script_deployment) => {
                     output_json_file(&script_deployment, output_path);
                 }
@@ -914,7 +915,7 @@ async fn main() -> Result<()> {
                 timestamp,
             };
 
-            match deploy_genesis::deploy_rollup_cell(args) {
+            match deploy_genesis::deploy_rollup_cell(args).await {
                 Ok(rollup_deployment) => {
                     output_json_file(&rollup_deployment, output_path);
                 }
@@ -1436,7 +1437,7 @@ async fn main() -> Result<()> {
             let min_capacity: u64 = m.value_of("min-capacity").unwrap_or_default().parse()?;
             let tip_block_number: u64 =
                 m.value_of("tip-block-number").unwrap_or_default().parse()?;
-            let rpc_client = CKBIndexerClient::new(HttpClient::new(indexer_rpc_url)?);
+            let rpc_client = CKBIndexerClient::with_url(indexer_rpc_url)?;
 
             let alias: HashMap<ckb_types::bytes::Bytes, String> = [
                 (

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -38,6 +38,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use tracing_subscriber::prelude::*;
 use types::{
     BuildScriptsResult, RollupDeploymentResult, ScriptsDeploymentResult, UserRollupConfig,
 };
@@ -49,7 +50,12 @@ use self::types::OmniLockConfig;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
+    let env_filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new("info"))?;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_ansi(false))
+        .with(env_filter_layer)
+        .try_init()?;
 
     let arg_privkey_path = Arg::with_name("privkey-path")
         .long("privkey-path")

--- a/crates/tools/src/report_accounts.rs
+++ b/crates/tools/src/report_accounts.rs
@@ -32,7 +32,8 @@ async fn producer(client: GodwokenRpcClient, tx: tokio::sync::mpsc::Sender<Task>
             // balance
             let addr = client
                 .get_registry_address_by_script_hash(&script_hash)
-                .await?;
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("no registry address"))?;
             let ckb = client.get_balance(&addr, CKB_SUDT_ACCOUNT_ID).await?;
             let nonce = client.get_nonce(account_id).await?;
             Ok(Some(Account {

--- a/crates/tools/src/setup.rs
+++ b/crates/tools/src/setup.rs
@@ -99,6 +99,7 @@ pub async fn setup(args: SetupArgs<'_>) {
     let deploy_scripts_result = {
         let scripts_deploy_result = output_dir.join("scripts-result.json");
         let deploy_result = deploy_scripts(privkey_path, ckb_rpc_url, &build_scripts_result)
+            .await
             .expect("deploy scripts");
         let output_content =
             serde_json::to_string_pretty(&deploy_result).expect("serde json to string pretty");
@@ -141,7 +142,7 @@ pub async fn setup(args: SetupArgs<'_>) {
             timestamp: None,
             skip_config_check: false,
         };
-        let rollup_result = deploy_rollup_cell(args).expect("deploy rollup cell");
+        let rollup_result = deploy_rollup_cell(args).await.expect("deploy rollup cell");
         let output_content =
             serde_json::to_string_pretty(&rollup_result).expect("serde json to string pretty");
         fs::write(rollup_result_path, output_content.as_bytes())

--- a/crates/tools/src/withdraw.rs
+++ b/crates/tools/src/withdraw.rs
@@ -115,7 +115,8 @@ pub async fn withdraw(
 
     let from_addr = godwoken_rpc_client
         .get_registry_address_by_script_hash(&from_script_hash)
-        .await?;
+        .await?
+        .ok_or_else(|| anyhow!("registry address is not found"))?;
     let init_balance = godwoken_rpc_client.get_balance(&from_addr, 1).await?;
 
     let bytes = JsonBytes::from_bytes(withdrawal_request_extra.as_bytes());

--- a/crates/types/src/offchain/rpc.rs
+++ b/crates/types/src/offchain/rpc.rs
@@ -58,6 +58,12 @@ pub enum TxStatus {
     Proposed,
     /// Status "committed". The transaction has been committed to the canonical chain.
     Committed,
+    /// Status "unknown". The node has not seen the transaction,
+    /// or it should be rejected but was cleared due to storage limitations.
+    Unknown,
+    /// Status "rejected". The transaction has been recently removed from the pool.
+    /// Due to storage limitations, the node can only hold the most recently removed transactions.
+    Rejected,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
Fixed `get_transaction` CKB RPC response parsing, and `get_registry_address` godwoken RPC response parsing.

Refactored “get CKB transaction”/“wait CKB transaction” related code.

Switched to `tracing-subscriber` in tools too because `env_logger` gets quite noisy with all the traces.