### PR TITLE
chore: increase timeout of gw-tools waiting layer1 tx committed

### DIFF
--- a/crates/tools/src/deploy_genesis.rs
+++ b/crates/tools/src/deploy_genesis.rs
@@ -167,7 +167,7 @@ impl<'a> DeployContext<'a> {
         let tx_hash = H256::from_str(send_output.trim().trim_start_matches("0x"))?;
         log::info!("tx_hash: {:#x}", tx_hash);
         self.gw_ckb_client
-            .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 120)
+            .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 600)
             .await?;
         Ok(tx_hash)
     }

--- a/crates/tools/src/deploy_scripts.rs
+++ b/crates/tools/src/deploy_scripts.rs
@@ -88,7 +88,7 @@ pub async fn deploy_program(
     log::info!("tx_hash: {:#x}", tx_hash);
 
     gw_ckb_client
-        .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 300)
+        .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 600)
         .await?;
     let tx = gw_ckb_client
         .get_transaction(tx_hash.0.into())

--- a/crates/tools/src/deposit_ckb.rs
+++ b/crates/tools/src/deposit_ckb.rs
@@ -132,7 +132,7 @@ pub async fn deposit_ckb(
     log::info!("tx_hash: {:#x}", tx_hash);
 
     gw_rpc_client::ckb_client::CKBClient::with_url(ckb_rpc_url)?
-        .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 180)
+        .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 600)
         .await?;
 
     wait_for_balance_change(

--- a/crates/tools/src/update_cell.rs
+++ b/crates/tools/src/update_cell.rs
@@ -125,7 +125,7 @@ pub async fn update_cell<P: AsRef<Path>>(
         .map_err(|err| anyhow!("{}", err))?;
     println!("Send tx...");
     CKBClient::with_url(ckb_rpc_url)?
-        .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 180)
+        .wait_tx_committed_with_timeout_and_logging(tx_hash.0.into(), 600)
         .await?;
     println!("{}", update_message);
     println!("Cell is updated!");

--- a/crates/tools/src/utils/transaction.rs
+++ b/crates/tools/src/utils/transaction.rs
@@ -60,6 +60,7 @@ where
     log::debug!("[Execute]: {} {:?}", bin, args);
     let init_output = Command::new(bin.to_owned())
         .env("RUST_BACKTRACE", "full")
+        .env("RUST_LOG", "warn")
         .args(args)
         .output()
         .expect("Run command failed");


### PR DESCRIPTION
Why: CKB runs on poor CI machine may take too long to execute txs. Here
is an example: https://github.com/RetricSu/godwoken-kicker/runs/6586127378?check_suite_focus=true#step:15:50