### PR TITLE
fix(tools): retry deposit if tx rejected

### DIFF
--- a/crates/tools/src/utils/transaction.rs
+++ b/crates/tools/src/utils/transaction.rs
@@ -60,6 +60,7 @@ where
     log::debug!("[Execute]: {} {:?}", bin, args);
     let init_output = Command::new(bin.to_owned())
         .env("RUST_BACKTRACE", "full")
+        .env("RUST_LOG", "warn")
         .args(args)
         .output()
         .expect("Run command failed");


### PR DESCRIPTION
If we initiate two deposits concurrently with the same private key, which happens quite often in kicker, one may fail because of cell double spending. We should retry building and sending the deposit transaction in this case.

In action:

```
2022-05-25T09:35:09.874906Z  INFO gw_tools::deposit_ckb: tx_hash: 0x533508dc47360a290ccc3a8c4d65cf8cffd84bdd46ede9b90cbae784b526f521    
2022-05-25T09:35:09.882503Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:12.884374Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:15.886526Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:18.888497Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:21.890714Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:24.892344Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:27.893463Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:30.895409Z  WARN gw_tools::deposit_ckb: Transaction is rejected. Retrying.    
2022-05-25T09:35:34.590859Z  WARN gw_tools::deposit_ckb: Running ckb-cli failed: Send transaction error: Server error: TransactionFailedToResolve: Resolve failed Dead(OutPoint(0x3d341e17c1e11373d473b4d260c607a1efb455c5c4a30034eb4c1bf76facec3900000000))
. Retrying.    
2022-05-25T09:35:38.292614Z  INFO gw_tools::deposit_ckb: tx_hash: 0x91683372c38c8178aac748867b5032751603b7c1ccd26e183d1e163091fe42ec    
2022-05-25T09:35:38.300655Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:41.302445Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:44.305325Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:47.306425Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:50.308631Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:53.310459Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:56.312439Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:35:59.314439Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Pending    
2022-05-25T09:36:02.316173Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Proposed    
2022-05-25T09:36:05.317804Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Proposed    
2022-05-25T09:36:08.319694Z  INFO gw_rpc_client::ckb_client: waiting for transaction, status: Proposed    
2022-05-25T09:36:11.321178Z  INFO gw_rpc_client::ckb_client: transaction committed    
```