### PR TITLE
fix: don't set TCP keepalive on listening sockets

### DIFF
--- a/crates/p2p-network/src/lib.rs
+++ b/crates/p2p-network/src/lib.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
 use gw_config::P2PNetworkConfig;
-use socket2::{SockRef, TcpKeepalive};
+use socket2::SockRef;
 use tentacle::{
     async_trait,
     builder::ServiceBuilder,
@@ -42,12 +42,6 @@ impl P2PNetwork {
                 let sock_ref = SockRef::from(&socket);
                 sock_ref.set_reuse_address(true)?;
                 sock_ref.set_nodelay(true)?;
-                sock_ref.set_tcp_keepalive(
-                    &TcpKeepalive::new()
-                        .with_interval(Duration::from_secs(15))
-                        .with_time(Duration::from_secs(5))
-                        .with_retries(3),
-                )?;
                 Ok(socket)
             })
             // TODO: allow config keypair.


### PR DESCRIPTION
On Mac OS X, it causes the listening socket to be “closed” after the
keepalive timeout and future connections to fail with “connection
refused” errors. We suspect the same may happen on linux in some
circumstances because we see similar errors in CI.

For hyper, we switch to use `AddrIncoming::set_keepalive`. It sets TCP
keepalive options on sockets returned by `accept` instead of on the
listening socket.

Tentacle unfortunately does not seem to allow setting options on
accepted sockets, so TCP keepalive setting is removed for now.
