### PR TITLE
feat: support switch backend binaries by height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,6 +2040,7 @@ dependencies = [
  "rlp",
  "secp256k1 0.20.3",
  "sha3",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -8,7 +8,7 @@ use gw_common::{
     state::State,
     H256,
 };
-use gw_config::{BackendConfig, GenesisConfig, StoreConfig};
+use gw_config::{BackendConfig, BackendSwitchConfig, GenesisConfig, StoreConfig};
 use gw_db::{schema::COLUMNS, RocksDB};
 use gw_generator::{
     account_lock_manage::{always_success::AlwaysSuccess, AccountLockManage},
@@ -160,7 +160,11 @@ impl BenchExecutionEnvironment {
                     backend_type: gw_config::BackendType::Sudt,
                 },
             ];
-            BackendManage::from_config(configs).expect("bench backend")
+            BackendManage::from_config(vec![BackendSwitchConfig {
+                switch_height: 0,
+                backends: configs,
+            }])
+            .expect("bench backend")
         };
 
         let account_lock_manage = {

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -2,7 +2,7 @@ use criterion::*;
 use gw_common::{
     builtins::ETH_REGISTRY_ACCOUNT_ID, registry_address::RegistryAddress, state::State, H256,
 };
-use gw_config::BackendConfig;
+use gw_config::{BackendConfig, BackendSwitchConfig};
 use gw_generator::{
     account_lock_manage::AccountLockManage, backend_manage::BackendManage,
     constants::L2TX_MAX_CYCLES, dummy_state::DummyState, error::TransactionError, traits::StateExt,
@@ -47,7 +47,11 @@ fn build_backend_manage(rollup_config: &RollupConfig) -> BackendManage {
             backend_type: gw_config::BackendType::Sudt,
         },
     ];
-    BackendManage::from_config(configs).expect("default backend")
+    BackendManage::from_config(vec![BackendSwitchConfig {
+        switch_height: 0,
+        backends: configs,
+    }])
+    .expect("default backend")
 }
 
 struct DummyChainStore;

--- a/crates/block-producer/src/main.rs
+++ b/crates/block-producer/src/main.rs
@@ -5,7 +5,7 @@ static GLOBAL_ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use anyhow::{Context, Result};
 use clap::{App, Arg, SubCommand};
 use gw_block_producer::{db_block_validator, runner, trace};
-use gw_config::Config;
+use gw_config::{BackendSwitchConfig, Config};
 use gw_version::Version;
 use std::{env, fs, path::Path};
 
@@ -27,7 +27,10 @@ fn read_config<P: AsRef<Path>>(path: P) -> Result<Config> {
 
 fn generate_example_config<P: AsRef<Path>>(path: P) -> Result<()> {
     let mut config = Config::default();
-    config.backends.push(Default::default());
+    config.backend_switches.push(BackendSwitchConfig {
+        switch_height: 0,
+        backends: Default::default(),
+    });
     config.block_producer = Some(Default::default());
     let content = toml::to_string_pretty(&config)?;
     fs::write(path, content)?;

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -442,7 +442,7 @@ impl BaseInitComponents {
         }
         let rollup_config_hash: H256 = rollup_config.hash().into();
         let generator = {
-            let backend_manage = BackendManage::from_config(config.backends.clone())
+            let backend_manage = BackendManage::from_config(config.backend_switches.clone())
                 .with_context(|| "config backends")?;
             let mut account_lock_manage = AccountLockManage::default();
             let allowed_eoa_type_hashes = rollup_config.as_reader().allowed_eoa_type_hashes();

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,7 +20,7 @@ pub enum Trace {
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub node_mode: NodeMode,
-    pub backends: Vec<BackendConfig>,
+    pub backend_switches: Vec<BackendSwitchConfig>,
     pub genesis: GenesisConfig,
     pub chain: ChainConfig,
     pub rpc_client: RPCClientConfig,
@@ -194,6 +194,12 @@ impl Default for BackendType {
     fn default() -> Self {
         BackendType::Unknown
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct BackendSwitchConfig {
+    pub switch_height: u64,
+    pub backends: Vec<BackendConfig>,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -36,3 +36,4 @@ tracing = { version = "0.1", features = ["attributes"] }
 
 [dev-dependencies]
 gw-utils = {path = "../utils" }
+tempfile = "3"

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -95,12 +95,12 @@ impl BackendManage {
     fn compile_backend(&mut self, backend: &Backend) {
         self.aot_codes.0.insert(
             backend.validator_script_type_hash,
-            self.aot_compile(backend.generator, 0)
+            self.aot_compile(&backend.generator, 0)
                 .expect("Ahead-of-time compile"),
         );
         self.aot_codes.1.insert(
             backend.validator_script_type_hash,
-            self.aot_compile(backend.generator, 1)
+            self.aot_compile(&backend.generator, 1)
                 .expect("Ahead-of-time compile"),
         );
     }

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use gw_common::H256;
-use gw_config::{BackendConfig, BackendType};
+use gw_config::{BackendConfig, BackendSwitchConfig, BackendType};
 use gw_types::bytes::Bytes;
 use std::{collections::HashMap, fs};
 
@@ -17,7 +17,7 @@ pub struct Backend {
 
 #[derive(Default)]
 pub struct BackendManage {
-    backends: HashMap<H256, Backend>,
+    backend_switches: Vec<(u64, HashMap<H256, Backend>)>,
     /// define here not in backends,
     /// so we don't need to implement the trait `Clone` of AotCode
     #[cfg(has_asm)]
@@ -25,64 +25,99 @@ pub struct BackendManage {
 }
 
 impl BackendManage {
-    pub fn from_config(configs: Vec<BackendConfig>) -> Result<Self> {
+    pub fn from_config(configs: Vec<BackendSwitchConfig>) -> Result<Self> {
         let mut backend_manage: BackendManage = Default::default();
-
         for config in configs {
-            backend_manage.register_backend_config(config)?;
+            backend_manage.register_backend_switch(config, true)?;
         }
 
         Ok(backend_manage)
     }
 
-    pub fn register_backend_config(&mut self, config: BackendConfig) -> Result<()> {
-        let BackendConfig {
-            validator_path,
-            generator_path,
-            validator_script_type_hash,
-            backend_type,
-        } = config;
-        let validator = fs::read(&validator_path)
-            .with_context(|| format!("load validator from {}", validator_path.to_string_lossy()))?
-            .into();
-        let generator = fs::read(&generator_path)
-            .with_context(|| format!("load generator from {}", generator_path.to_string_lossy()))?
-            .into();
-        let validator_script_type_hash = {
-            let hash: [u8; 32] = validator_script_type_hash.into();
-            hash.into()
-        };
-        let backend = Backend {
-            validator,
-            generator,
-            validator_script_type_hash,
-            backend_type,
-        };
-        self.register_backend(backend);
+    fn register_backend_switch(
+        &mut self,
+        config: BackendSwitchConfig,
+        #[allow(unused_variables)] compile: bool,
+    ) -> Result<()> {
+        if let Some((height, _backends)) = self.backend_switches.last() {
+            if config.switch_height <= *height {
+                bail!("BackendSwitchConfig with switch_height {} is less or equals to the last switch_height {}", config.switch_height, height);
+            }
+        }
+        // inherit backends
+        let mut backends = self
+            .backend_switches
+            .last()
+            .map(|(_height, backends)| backends)
+            .cloned()
+            .unwrap_or_default();
+
+        // register backends
+        for config in config.backends {
+            let BackendConfig {
+                validator_path,
+                generator_path,
+                validator_script_type_hash,
+                backend_type,
+            } = config;
+            let validator = fs::read(&validator_path)
+                .with_context(|| {
+                    format!("load validator from {}", validator_path.to_string_lossy())
+                })?
+                .into();
+            let generator = fs::read(&generator_path)
+                .with_context(|| {
+                    format!("load generator from {}", generator_path.to_string_lossy())
+                })?
+                .into();
+            let validator_script_type_hash = {
+                let hash: [u8; 32] = validator_script_type_hash.into();
+                hash.into()
+            };
+            let backend = Backend {
+                validator,
+                generator,
+                validator_script_type_hash,
+                backend_type,
+            };
+            #[cfg(has_asm)]
+            if compile {
+                self.compile_backend(&backend);
+            }
+            backends.insert(backend.validator_script_type_hash, backend);
+        }
+
+        self.backend_switches.push((config.switch_height, backends));
         Ok(())
     }
 
-    pub fn register_backend(&mut self, backend: Backend) {
-        #[cfg(has_asm)]
-        {
-            self.aot_codes.0.insert(
-                backend.validator_script_type_hash,
-                self.aot_compile(&backend.generator, 0)
-                    .expect("Ahead-of-time compile"),
-            );
-            self.aot_codes.1.insert(
-                backend.validator_script_type_hash,
-                self.aot_compile(&backend.generator, 1)
-                    .expect("Ahead-of-time compile"),
-            );
-        }
-
-        self.backends
-            .insert(backend.validator_script_type_hash, backend);
+    #[cfg(has_asm)]
+    fn compile_backend(&mut self, backend: &Backend) {
+        self.aot_codes.0.insert(
+            backend.validator_script_type_hash,
+            self.aot_compile(backend.generator, 0)
+                .expect("Ahead-of-time compile"),
+        );
+        self.aot_codes.1.insert(
+            backend.validator_script_type_hash,
+            self.aot_compile(backend.generator, 1)
+                .expect("Ahead-of-time compile"),
+        );
     }
 
-    pub fn get_backend(&self, code_hash: &H256) -> Option<&Backend> {
-        self.backends.get(code_hash)
+    pub fn get_backends_at_height(
+        &self,
+        block_number: u64,
+    ) -> Option<&(u64, HashMap<H256, Backend>)> {
+        self.backend_switches
+            .iter()
+            .rev()
+            .find(|(height, _)| block_number >= *height)
+    }
+
+    pub fn get_backend(&self, block_number: u64, code_hash: &H256) -> Option<&Backend> {
+        self.get_backends_at_height(block_number)
+            .and_then(|(_number, backends)| backends.get(code_hash))
     }
 
     #[cfg(has_asm)]
@@ -114,8 +149,139 @@ impl BackendManage {
             }
         }
     }
+}
 
-    pub fn get_backends(&self) -> &HashMap<H256, Backend> {
-        &self.backends
+#[cfg(test)]
+mod tests {
+    use gw_config::{BackendConfig, BackendSwitchConfig, BackendType};
+
+    use super::BackendManage;
+
+    #[test]
+    fn test_get_backend() {
+        let mut m = BackendManage::default();
+        // prepare fake binaries
+        let dir = tempfile::tempdir().unwrap().into_path();
+        let sudt_v0 = dir.join("sudt_v0");
+        let sudt_v1 = dir.join("sudt_v1");
+        let meta_v0 = dir.join("meta_v0");
+        let addr_v0 = dir.join("addr_v0");
+        std::fs::write(&sudt_v0, "sudt_v0").unwrap();
+        std::fs::write(&sudt_v1, "sudt_v1").unwrap();
+        std::fs::write(&meta_v0, "meta_v0").unwrap();
+        std::fs::write(&addr_v0, "addr_v0").unwrap();
+
+        let config = BackendSwitchConfig {
+            switch_height: 1,
+            backends: vec![
+                BackendConfig {
+                    validator_script_type_hash: [42u8; 32].into(),
+                    backend_type: BackendType::Sudt,
+                    generator_path: format!("{}/sudt_v0", dir.to_string_lossy()).into(),
+                    validator_path: format!("{}/sudt_v0", dir.to_string_lossy()).into(),
+                },
+                BackendConfig {
+                    validator_script_type_hash: [43u8; 32].into(),
+                    backend_type: BackendType::EthAddrReg,
+                    generator_path: format!("{}/addr_v0", dir.to_string_lossy()).into(),
+                    validator_path: format!("{}/addr_v0", dir.to_string_lossy()).into(),
+                },
+            ],
+        };
+        m.register_backend_switch(config, false).unwrap();
+        assert!(m.get_backends_at_height(0).is_none(), "no backends at 0");
+        assert!(
+            m.get_backend(1, &[42u8; 32].into()).is_some(),
+            "get backend at 1"
+        );
+        assert!(
+            m.get_backend(100, &[42u8; 32].into()).is_some(),
+            "get backend at 100"
+        );
+        assert!(
+            m.get_backend(0, &[43u8; 32].into()).is_none(),
+            "get backend at 0"
+        );
+        assert!(
+            m.get_backend(1, &[43u8; 32].into()).is_some(),
+            "get backend at 1"
+        );
+        assert!(
+            m.get_backend(100, &[43u8; 32].into()).is_some(),
+            "get backend at 100"
+        );
+
+        let config = BackendSwitchConfig {
+            switch_height: 5,
+            backends: vec![
+                BackendConfig {
+                    validator_script_type_hash: [41u8; 32].into(),
+                    backend_type: BackendType::Meta,
+                    generator_path: format!("{}/meta_v0", dir.to_string_lossy()).into(),
+                    validator_path: format!("{}/meta_v0", dir.to_string_lossy()).into(),
+                },
+                BackendConfig {
+                    validator_script_type_hash: [42u8; 32].into(),
+                    backend_type: BackendType::Sudt,
+                    generator_path: format!("{}/sudt_v1", dir.to_string_lossy()).into(),
+                    validator_path: format!("{}/sudt_v1", dir.to_string_lossy()).into(),
+                },
+            ],
+        };
+        m.register_backend_switch(config, false).unwrap();
+        assert!(m.get_backends_at_height(0).is_none(), "no backends at 0");
+        // sudt
+        assert_eq!(
+            m.get_backend(4, &[42u8; 32].into())
+                .unwrap()
+                .generator
+                .to_vec(),
+            b"sudt_v0".to_vec(),
+        );
+        assert_eq!(
+            m.get_backend(5, &[42u8; 32].into())
+                .unwrap()
+                .generator
+                .to_vec(),
+            b"sudt_v1".to_vec(),
+        );
+        assert_eq!(
+            m.get_backend(42, &[42u8; 32].into())
+                .unwrap()
+                .generator
+                .to_vec(),
+            b"sudt_v1".to_vec(),
+        );
+        // meta
+        assert!(m.get_backend(1, &[41u8; 32].into()).is_none());
+        assert_eq!(
+            m.get_backend(5, &[41u8; 32].into())
+                .unwrap()
+                .generator
+                .to_vec(),
+            b"meta_v0".to_vec(),
+        );
+        assert_eq!(
+            m.get_backend(42, &[41u8; 32].into())
+                .unwrap()
+                .generator
+                .to_vec(),
+            b"meta_v0".to_vec(),
+        );
+        // addr
+        assert_eq!(
+            m.get_backend(1, &[43u8; 32].into())
+                .unwrap()
+                .generator
+                .to_vec(),
+            b"addr_v0".to_vec(),
+        );
+        assert_eq!(
+            m.get_backend(42, &[43u8; 32].into())
+                .unwrap()
+                .generator
+                .to_vec(),
+            b"addr_v0".to_vec(),
+        );
     }
 }

--- a/crates/replay-chain/src/setup.rs
+++ b/crates/replay-chain/src/setup.rs
@@ -96,7 +96,7 @@ pub async fn setup(args: SetupArgs) -> Result<Context> {
     )
     .with_context(|| "init genesis")?;
     let generator = {
-        let backend_manage = BackendManage::from_config(config.backends.clone())
+        let backend_manage = BackendManage::from_config(config.backend_switches.clone())
             .with_context(|| "config backends")?;
         let mut account_lock_manage = AccountLockManage::default();
         let allowed_eoa_type_hashes = rollup_config.as_reader().allowed_eoa_type_hashes();

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -393,7 +393,7 @@ fn req_to_entry(
             let receiver: u32 = tx.raw().to_id().unpack();
             let script_hash = state.get_script_hash(receiver)?;
             let backend_type = generator
-                .load_backend(state, &script_hash)
+                .load_backend(0, state, &script_hash)
                 .ok_or_else(|| anyhow!("can't find backend for receiver: {}", receiver))?
                 .backend_type;
             FeeEntry::from_tx(tx, fee_config, backend_type, order)
@@ -1342,7 +1342,10 @@ async fn compute_l2_sudt_script_hash(
 
 fn get_backend_info(generator: Arc<Generator>) -> Vec<BackendInfo> {
     generator
-        .get_backends()
+        .backend_manage()
+        .get_backends_at_height(0)
+        .expect("backends")
+        .1
         .values()
         .map(|b| {
             let mut validator_code_hash = [0u8; 32];

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -5,7 +5,7 @@ use gw_block_producer::produce_block::{
 };
 use gw_chain::chain::{Chain, L1Action, L1ActionContext, SyncParam};
 use gw_common::{blake2b::new_blake2b, H256};
-use gw_config::{BackendConfig, ChainConfig, GenesisConfig, MemPoolConfig};
+use gw_config::{BackendConfig, BackendSwitchConfig, ChainConfig, GenesisConfig, MemPoolConfig};
 use gw_generator::{
     account_lock_manage::{
         always_success::AlwaysSuccess, secp256k1::Secp256k1Eth, AccountLockManage,
@@ -175,7 +175,7 @@ pub const DEFAULT_FINALITY_BLOCKS: u64 = 6;
 pub fn build_backend_manage(rollup_config: &RollupConfig) -> BackendManage {
     let sudt_validator_script_type_hash: [u8; 32] =
         rollup_config.l2_sudt_validator_script_type_hash().unpack();
-    let configs = vec![
+    let backends = vec![
         BackendConfig {
             validator_path: META_VALIDATOR_PATH.into(),
             generator_path: META_GENERATOR_PATH.into(),
@@ -195,7 +195,11 @@ pub fn build_backend_manage(rollup_config: &RollupConfig) -> BackendManage {
             backend_type: gw_config::BackendType::EthAddrReg,
         },
     ];
-    BackendManage::from_config(configs).expect("default backend")
+    BackendManage::from_config(vec![BackendSwitchConfig {
+        switch_height: 0,
+        backends,
+    }])
+    .expect("default backend")
 }
 
 pub async fn setup_chain(rollup_type_script: Script) -> Chain {

--- a/crates/tools/src/create_creator_account.rs
+++ b/crates/tools/src/create_creator_account.rs
@@ -47,7 +47,7 @@ pub async fn create_creator_account(
     log::info!("from id: {}", from_id);
 
     let polyjuice_validator_script_hash = {
-        let mut backends = config.backends.iter();
+        let mut backends = config.backend_switches[0].backends.iter();
         let polyjuice_backend = backends
             .find(|backend| backend.backend_type == BackendType::Polyjuice)
             .ok_or_else(|| anyhow!("polyjuice backend not found in config"))?;

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -10,9 +10,9 @@ use ckb_sdk::HttpRpcClient;
 use ckb_types::prelude::{Builder, Entity};
 use gw_common::builtins::ETH_REGISTRY_ACCOUNT_ID;
 use gw_config::{
-    BackendConfig, BlockProducerConfig, ChainConfig, ChallengerConfig, Config, ConsensusConfig,
-    ContractTypeScriptConfig, GenesisConfig, NodeMode, RPCClientConfig, RPCServerConfig,
-    RegistryAddressConfig, StoreConfig, WalletConfig, Web3IndexerConfig,
+    BackendConfig, BackendSwitchConfig, BlockProducerConfig, ChainConfig, ChallengerConfig, Config,
+    ConsensusConfig, ContractTypeScriptConfig, GenesisConfig, NodeMode, RPCClientConfig,
+    RPCServerConfig, RegistryAddressConfig, StoreConfig, WalletConfig, Web3IndexerConfig,
 };
 use gw_jsonrpc_types::godwoken::{AllowedEoaType, L2BlockCommittedInfo};
 use gw_rpc_client::ckb_client::CKBClient;
@@ -178,6 +178,10 @@ pub async fn generate_node_config(args: GenerateNodeConfigArgs<'_>) -> Result<Co
             backend_type: gw_config::BackendType::EthAddrReg,
         },
     ];
+    let backend_switches = vec![BackendSwitchConfig {
+        switch_height: 0,
+        backends,
+    }];
 
     let store = StoreConfig {
         path: "".into(),
@@ -246,7 +250,7 @@ pub async fn generate_node_config(args: GenerateNodeConfigArgs<'_>) -> Result<Co
     });
 
     let config: Config = Config {
-        backends,
+        backend_switches,
         genesis,
         chain,
         rpc_client,

--- a/crates/tools/src/sudt/account.rs
+++ b/crates/tools/src/sudt/account.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use ckb_fixed_hash::H256;
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_types::prelude::{Builder, Entity};
-use gw_config::Config;
+use gw_config::{BackendType, Config};
 use gw_types::{
     core::ScriptHashType,
     packed::{CreateAccount, Fee, L2Transaction, MetaContractArgs, RawL2Transaction, Script},
@@ -81,7 +81,12 @@ pub async fn create_sudt_account(
 
     // sudt contract
     let l2_script = {
-        let l2_validator_script_hash = &config.backends[1].validator_script_type_hash;
+        let l2_validator_script_hash = &config.backend_switches[0]
+            .backends
+            .iter()
+            .find(|b| b.backend_type == BackendType::Sudt)
+            .expect("sudt")
+            .validator_script_type_hash;
         build_l2_sudt_script(rollup_type_hash, l2_validator_script_hash, &sudt_type_hash)
     };
     let l2_script_hash = l2_script.hash();


### PR DESCRIPTION
This PR support upgrade backend binaries by height.

Now, instead of define `backends` in the `config.toml` we define `backend_switch`:

``` rust
pub struct BackendSwitchConfig {
    pub switch_height: u64,
    pub backends: Vec<BackendConfig>,
}
```

`switch_height` means in which height we use the new version of backend. For example:

To upgrade godwoken config file, we should move all the `backends` fields into a backend switch clause such as: `BackendSwitchConfig {switch_height: 0, backends}`, when we need to upgrade a backend, we define a new backend switch item follows the original one such as: `BackendSwitchConfig {switch_height: 1000, backends: <new SUDT backend>}`. Then when the tip block arrives the 1000 height, the new SUDT backend will be loaded instead the old one, the other backends are not change.

This change affects the following API:

https://github.com/nervosnetwork/godwoken/blob/develop/docs/RPC.md#method-gw_get_node_info

Consider mostly use-case of this API is to use the `validator_script_type_hash ` field of a backend, I think we can only returns backends at 0 height for now.