### PR TITLE
Fix backends aot_code loading

### DIFF
--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -157,7 +157,7 @@ impl Generator {
             #[cfg(has_asm)]
             let aot_code_opt = self
                 .backend_manage
-                .get_aot_code(&backend.validator_script_type_hash, global_vm_version);
+                .get_aot_code(&backend.checksum.generator, global_vm_version);
             #[cfg(has_asm)]
             if aot_code_opt.is_none() {
                 log::warn!("[machine_run] Not AOT mode!");

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use ckb_types::prelude::{Builder, Entity};
-use gw_common::{blake2b::new_blake2b, state::State, H256};
+use gw_common::{state::State, H256};
 use gw_config::{
     ChainConfig, ConsensusConfig, FeeConfig, MemPoolConfig, NodeMode, RPCMethods, RPCRateLimit,
     RPCServerConfig,
@@ -1365,23 +1365,11 @@ fn get_backend_info(generator: Arc<Generator>) -> Vec<BackendInfo> {
         .expect("backends")
         .1
         .values()
-        .map(|b| {
-            let mut validator_code_hash = [0u8; 32];
-            let mut hasher = new_blake2b();
-            hasher.update(&b.validator);
-            hasher.finalize(&mut validator_code_hash);
-            let mut generator_code_hash = [0u8; 32];
-            let mut hasher = new_blake2b();
-            hasher.update(&b.generator);
-            hasher.finalize(&mut generator_code_hash);
-            BackendInfo {
-                validator_code_hash: validator_code_hash.into(),
-                generator_code_hash: generator_code_hash.into(),
-                validator_script_type_hash: ckb_fixed_hash::H256(
-                    b.validator_script_type_hash.into(),
-                ),
-                backend_type: to_rpc_backend_type(&b.backend_type),
-            }
+        .map(|(b, checksum)| BackendInfo {
+            validator_code_hash: checksum.validator.into(),
+            generator_code_hash: checksum.generator.into(),
+            validator_script_type_hash: ckb_fixed_hash::H256(b.validator_script_type_hash.into()),
+            backend_type: to_rpc_backend_type(&b.backend_type),
         })
         .collect()
 }

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -1365,9 +1365,9 @@ fn get_backend_info(generator: Arc<Generator>) -> Vec<BackendInfo> {
         .expect("backends")
         .1
         .values()
-        .map(|(b, checksum)| BackendInfo {
-            validator_code_hash: checksum.validator.into(),
-            generator_code_hash: checksum.generator.into(),
+        .map(|b| BackendInfo {
+            validator_code_hash: ckb_fixed_hash::H256(b.checksum.validator.into()),
+            generator_code_hash: ckb_fixed_hash::H256(b.checksum.generator.into()),
             validator_script_type_hash: ckb_fixed_hash::H256(b.validator_script_type_hash.into()),
             backend_type: to_rpc_backend_type(&b.backend_type),
         })


### PR DESCRIPTION
- https://github.com/nervosnetwork/godwoken/pull/713 introduce a bug: 

If we setup a backend upgrade, the later version's aot binary will overwrite the previous one.

This PR fixed the bug, and introduce more logs of backend_manage module.