### PR TITLE
feat(rpc-server): get in queue requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,15 +2030,11 @@ name = "gw-rpc-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-channel",
- "async-jsonrpc-client",
  "async-trait",
  "bytes",
  "ckb-crypto",
  "ckb-fixed-hash",
  "ckb-types",
- "clap",
- "env_logger",
  "errno",
  "faster-hex 0.4.1",
  "futures",
@@ -2067,7 +2063,6 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tikv-jemalloc-sys",
  "tokio",
- "toml",
  "tracing",
 ]
 

--- a/crates/benches/benches/benchmarks/fee_queue.rs
+++ b/crates/benches/benches/benchmarks/fee_queue.rs
@@ -50,7 +50,7 @@ fn bench_add_full(b: &mut Bencher) {
             sender: 2,
             order: queue.len(),
         };
-        queue.add(entry1);
+        queue.add(entry1, ());
     }
 
     assert_eq!(queue.len(), MAX_QUEUE_SIZE);
@@ -71,7 +71,7 @@ fn bench_add_full(b: &mut Bencher) {
             sender: 2,
             order: queue.len(),
         };
-        queue.add(entry1);
+        queue.add(entry1, ());
     });
 }
 
@@ -107,7 +107,7 @@ fn bench_add_fetch_20(b: &mut Bencher) {
             sender: 2,
             order: queue.len(),
         };
-        queue.add(entry1);
+        queue.add(entry1, ());
     }
 
     let mem_store = MemStore::new(snap);
@@ -130,7 +130,7 @@ fn bench_add_fetch_20(b: &mut Bencher) {
                 sender: 2,
                 order: queue.len(),
             };
-            queue.add(entry1);
+            queue.add(entry1, ());
         }
         queue.fetch(&tree, 20)
     });

--- a/crates/mem-pool/src/fee/queue.rs
+++ b/crates/mem-pool/src/fee/queue.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use gw_common::state::State;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use tracing::instrument;
 
 /// Max queue size
@@ -11,16 +11,16 @@ const DROP_SIZE: usize = 100;
 use super::types::FeeEntry;
 
 /// Txs & withdrawals queue sorted by fee rate
-pub struct FeeQueue {
+pub struct FeeQueue<T> {
     // priority queue to store tx and withdrawal
-    queue: BTreeSet<FeeEntry>,
+    queue: BTreeMap<FeeEntry, T>,
 }
 
-impl FeeQueue {
+impl<T> FeeQueue<T> {
     #[inline]
     pub fn new() -> Self {
         Self {
-            queue: BTreeSet::new(),
+            queue: BTreeMap::new(),
         }
     }
 
@@ -34,9 +34,8 @@ impl FeeQueue {
         self.queue.is_empty()
     }
 
-    /// Add item to queue
     #[instrument(skip_all, fields(count = self.len()))]
-    pub fn add(&mut self, entry: FeeEntry) {
+    pub fn add(&mut self, entry: FeeEntry, handle: T) {
         // push to queue
         log::debug!(
             "QueueLen: {} | add entry: {:?} {}",
@@ -44,11 +43,11 @@ impl FeeQueue {
             entry.item.kind(),
             hex::encode(entry.item.hash().as_slice())
         );
-        self.queue.insert(entry);
+        self.queue.insert(entry, handle);
 
         // drop items if full
         if self.is_full() {
-            if let Some(first_to_keep) = self.queue.iter().nth(DROP_SIZE + 1).cloned() {
+            if let Some(first_to_keep) = self.queue.keys().nth(DROP_SIZE + 1).cloned() {
                 self.queue = self.queue.split_off(&first_to_keep);
             }
             log::debug!(
@@ -64,9 +63,9 @@ impl FeeQueue {
         self.queue.len() > MAX_QUEUE_SIZE
     }
 
-    fn pop_last(&mut self) -> Option<FeeEntry> {
-        if let Some(entry) = self.queue.iter().next_back().cloned() {
-            self.queue.take(&entry)
+    fn pop_last(&mut self) -> Option<(FeeEntry, T)> {
+        if let Some(entry) = self.queue.keys().next_back().cloned() {
+            self.queue.remove_entry(&entry)
         } else {
             None
         }
@@ -74,7 +73,7 @@ impl FeeQueue {
 
     /// Fetch items by fee sort
     #[instrument(skip_all, fields(count = count))]
-    pub fn fetch(&mut self, state: &impl State, count: usize) -> Result<Vec<FeeEntry>> {
+    pub fn fetch(&mut self, state: &impl State, count: usize) -> Result<Vec<(FeeEntry, T)>> {
         // sorted fee items
         let mut fetched_items = Vec::with_capacity(count as usize);
         let mut fetched_senders: HashMap<u32, u32> = Default::default();
@@ -82,7 +81,7 @@ impl FeeQueue {
         let mut future_queue = Vec::default();
 
         // Fetch item from PQ
-        while let Some(entry) = self.pop_last() {
+        while let Some((entry, t)) = self.pop_last() {
             let nonce = match fetched_senders.get(&entry.sender) {
                 Some(&nonce) => nonce,
                 None => state.get_nonce(entry.sender)?,
@@ -92,11 +91,11 @@ impl FeeQueue {
                     // update nonce
                     fetched_senders.insert(entry.sender, nonce.saturating_add(1));
                     // fetch this item
-                    fetched_items.push(entry);
+                    fetched_items.push((entry, t));
                 }
                 std::cmp::Ordering::Greater => {
                     // push item back if it still has change to get fetched
-                    future_queue.push(entry);
+                    future_queue.push((entry, t));
                 }
                 _ => {
                     log::debug!(
@@ -116,10 +115,10 @@ impl FeeQueue {
         }
 
         // Add back future items
-        for entry in future_queue {
+        for (entry, t) in future_queue {
             // Only add back if we fetched another item from the same sender
             if fetched_senders.contains_key(&entry.sender) {
-                self.add(entry);
+                self.add(entry, t);
             } else {
                 log::debug!(
                     "QueueLen: {} | drop future entry: {:?} {} entry_nonce {}",
@@ -142,7 +141,7 @@ impl FeeQueue {
     }
 }
 
-impl Default for FeeQueue {
+impl<T> Default for FeeQueue<T> {
     #[inline]
     fn default() -> Self {
         Self::new()
@@ -226,10 +225,10 @@ mod tests {
             order: queue.len(),
         };
 
-        queue.add(entry1);
-        queue.add(entry2);
-        queue.add(entry3);
-        queue.add(entry4);
+        queue.add(entry1, ());
+        queue.add(entry2, ());
+        queue.add(entry3, ());
+        queue.add(entry4, ());
 
         let mem_store = MemStore::new(snap);
         let tree = mem_store.state().unwrap();
@@ -238,15 +237,15 @@ mod tests {
         {
             let items = queue.fetch(&tree, 3).expect("fetch");
             assert_eq!(items.len(), 3);
-            assert_eq!(items[0].sender, 3);
-            assert_eq!(items[1].sender, 5);
-            assert_eq!(items[2].sender, 2);
+            assert_eq!(items[0].0.sender, 3);
+            assert_eq!(items[1].0.sender, 5);
+            assert_eq!(items[2].0.sender, 2);
         }
         // fetch 3
         {
             let items = queue.fetch(&tree, 3).expect("fetch");
             assert_eq!(items.len(), 1);
-            assert_eq!(items[0].sender, 4);
+            assert_eq!(items[0].0.sender, 4);
         }
         // fetch 3
         {
@@ -284,7 +283,7 @@ mod tests {
             order: queue.len(),
         };
 
-        queue.add(entry1);
+        queue.add(entry1, ());
 
         let entry2 = FeeEntry {
             item: FeeItem::Tx(Default::default()),
@@ -294,7 +293,7 @@ mod tests {
             order: queue.len(),
         };
 
-        queue.add(entry2);
+        queue.add(entry2, ());
 
         let entry3 = FeeEntry {
             item: FeeItem::Tx(Default::default()),
@@ -304,7 +303,7 @@ mod tests {
             order: queue.len(),
         };
 
-        queue.add(entry3);
+        queue.add(entry3, ());
 
         let entry4 = FeeEntry {
             item: FeeItem::Withdrawal(Default::default()),
@@ -314,7 +313,7 @@ mod tests {
             order: queue.len(),
         };
 
-        queue.add(entry4);
+        queue.add(entry4, ());
 
         let mem_store = MemStore::new(snap);
         let tree = mem_store.state().unwrap();
@@ -323,10 +322,10 @@ mod tests {
         {
             let items = queue.fetch(&tree, 5).expect("fetch");
             assert_eq!(items.len(), 4);
-            assert_eq!(items[0].sender, 5);
-            assert_eq!(items[1].sender, 2);
-            assert_eq!(items[2].sender, 3);
-            assert_eq!(items[3].sender, 4);
+            assert_eq!(items[0].0.sender, 5);
+            assert_eq!(items[1].0.sender, 2);
+            assert_eq!(items[2].0.sender, 3);
+            assert_eq!(items[3].0.sender, 4);
         }
     }
 
@@ -374,8 +373,8 @@ mod tests {
             order: queue.len(),
         };
 
-        queue.add(entry1);
-        queue.add(entry2);
+        queue.add(entry1, ());
+        queue.add(entry2, ());
 
         let snap = store.get_snapshot();
         let mem_store = MemStore::new(snap);
@@ -385,8 +384,8 @@ mod tests {
         {
             let items = queue.fetch(&tree, 3).expect("fetch");
             assert_eq!(items.len(), 2);
-            assert_eq!(items[0].item.nonce(), 0);
-            assert_eq!(items[1].item.nonce(), 1);
+            assert_eq!(items[0].0.item.nonce(), 0);
+            assert_eq!(items[1].0.item.nonce(), 1);
         }
     }
     #[test]
@@ -433,8 +432,8 @@ mod tests {
             order: queue.len(),
         };
 
-        queue.add(entry1);
-        queue.add(entry2);
+        queue.add(entry1, ());
+        queue.add(entry2, ());
 
         let snap = store.get_snapshot();
         let mem_store = MemStore::new(snap);
@@ -444,7 +443,7 @@ mod tests {
         {
             let items = queue.fetch(&tree, 3).expect("fetch");
             assert_eq!(items.len(), 1);
-            assert_eq!(items[0].fee, (101 * 1000u64).into());
+            assert_eq!(items[0].0.fee, (101 * 1000u64).into());
             // try fetch remain items
             let items = queue.fetch(&tree, 1).expect("fetch");
             assert_eq!(items.len(), 0);
@@ -483,7 +482,7 @@ mod tests {
                 sender: 2,
                 order: queue.len(),
             };
-            queue.add(entry1);
+            queue.add(entry1, ());
         }
 
         assert_eq!(queue.len(), MAX_QUEUE_SIZE);
@@ -505,7 +504,7 @@ mod tests {
                 sender: 2,
                 order: queue.len(),
             };
-            queue.add(entry1);
+            queue.add(entry1, ());
         }
 
         // we should trigger the drop

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -24,13 +24,8 @@ faster-hex = "0.4"
 ckb-crypto = "0.100.0"
 ckb-fixed-hash = "0.100.0"
 ckb-types = "0.100.0"
-toml = "0.5"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-async-channel = "1.4"
-async-jsonrpc-client = { version = "0.3.0", default-features = false, features = ["http-tokio"] }
-clap = "2.33.3"
-env_logger = "0.8.3"
 futures = "0.3.13"
 hyper = { version = "0.14", features = ["server"] }
 jsonrpc-v2 = { version = "0.10.0", default-features = false, features = ["hyper-integration", "easy-errors"] }

--- a/crates/rpc-server/src/in_queue_request_map.rs
+++ b/crates/rpc-server/src/in_queue_request_map.rs
@@ -1,0 +1,72 @@
+use std::sync::{Arc, RwLock};
+use std::{collections::HashMap, sync::Weak};
+
+use gw_common::H256;
+use gw_types::packed::{L2Transaction, WithdrawalRequestExtra};
+use tracing::instrument;
+
+use crate::registry::Request;
+
+/// Hold in queue transactions and withdrawal requests.
+///
+/// (For get_transaction and get_withdrawal RPC calls.)
+#[derive(Default)]
+pub struct InQueueRequestMap {
+    map: RwLock<HashMap<H256, Request>>,
+}
+
+impl InQueueRequestMap {
+    #[instrument(skip_all, fields(hash = %faster_hex::hex_string(k.as_slice()).expect("hex_string")))]
+    pub(crate) fn insert(self: &Arc<Self>, k: H256, v: Request) -> Option<InQueueRequestHandle> {
+        let mut map = self.map.write().unwrap();
+        let inserted = map.insert(k, v).is_none();
+        if inserted {
+            tracing::info!(map.len = map.len(), "inserted");
+            Some(InQueueRequestHandle {
+                map: Arc::downgrade(self),
+                hash: k,
+            })
+        } else {
+            None
+        }
+    }
+
+    #[instrument(skip_all, fields(hash = %faster_hex::hex_string(k.as_slice()).expect("hex_string")))]
+    fn remove(&self, k: &H256) {
+        let mut map = self.map.write().unwrap();
+        map.remove(k);
+        tracing::info!(map.len = map.len(), "removed");
+    }
+
+    pub(crate) fn get_transaction(&self, k: &H256) -> Option<L2Transaction> {
+        match self.map.read().unwrap().get(k)? {
+            Request::Tx(tx) => Some(tx.clone()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn get_withdrawal(&self, k: &H256) -> Option<WithdrawalRequestExtra> {
+        match self.map.read().unwrap().get(k)? {
+            Request::Withdrawal(w) => Some(w.clone()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn contains(&self, k: &H256) -> bool {
+        self.map.read().unwrap().contains_key(k)
+    }
+}
+
+/// RAII guard for the request in an InQueueRequestMap.
+pub(crate) struct InQueueRequestHandle {
+    map: Weak<InQueueRequestMap>,
+    hash: H256,
+}
+
+impl Drop for InQueueRequestHandle {
+    fn drop(&mut self) {
+        if let Some(map) = self.map.upgrade() {
+            map.remove(&self.hash);
+        }
+    }
+}

--- a/crates/rpc-server/src/lib.rs
+++ b/crates/rpc-server/src/lib.rs
@@ -1,2 +1,3 @@
+pub(crate) mod in_queue_request_map;
 pub mod registry;
 pub mod server;

--- a/docs/RPC.md
+++ b/docs/RPC.md
@@ -943,6 +943,41 @@ Response
 }
 ```
 
+### Method `gw_is_request_in_queue`
+
+- params:
+  - `hash`: [`H256`](#type-h256) - Transaction/Withdrawal Hash
+- result: [`bool`]
+
+Returns whether the request (transaction or withdrawal) is in the fee queue.
+
+Requests go through the fee queue before they are pushed to the mem pool.
+
+Only supported on full nodes.
+
+#### Examples
+
+Request
+
+```json
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "gw_is_request_in_queue",
+  "params": ["0x57c521ce4282fcf075862089d1bef4096723395ace63b4c0b8b9af5fa"]
+}
+```
+
+Response
+
+```json
+{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "result": true
+}
+```
+
 ### Method `gw_execute_l2transaction`
 * params:
     * `l2tx`: [`SerializedL2Transaction`](#type-serializedmoleculeschema) - Serialized L2 Transaction


### PR DESCRIPTION
Now on a full node the `gw_get_transaction`/`gw_get_withdrawal` RPC
calls will return status: pending instead of null for in queue
transactions/withdrawals.

Also added RPC method `gw_is_request_in_queue`, which returns whether a
transaction or withdrawal is in queue.
