### PR TITLE
fix: handle VM InvalidCycles by generate a polyjuice system log

### DIFF
--- a/crates/generator/src/typed_transaction/types.rs
+++ b/crates/generator/src/typed_transaction/types.rs
@@ -126,6 +126,9 @@ impl SimpleUDTTx {
 
 pub struct PolyjuiceTx(RawL2Transaction);
 impl PolyjuiceTx {
+    pub fn new(raw_tx: RawL2Transaction) -> Self {
+        Self(raw_tx)
+    }
     pub fn parser(&self) -> Option<PolyjuiceParser> {
         PolyjuiceParser::from_raw_l2_tx(&self.0)
     }

--- a/crates/utils/src/script_log.rs
+++ b/crates/utils/src/script_log.rs
@@ -152,3 +152,23 @@ pub fn parse_log(item: &LogItem) -> Result<GwLog> {
         _ => Err(anyhow!("invalid log service flag: {}", service_flag)),
     }
 }
+
+pub fn generate_polyjuice_system_log(
+    account_id: u32,
+    gas_used: u64,
+    cumulative_gas_used: u64,
+    created_address: [u8; 20],
+    status_code: u32,
+) -> LogItem {
+    let service_flag: u8 = GW_LOG_POLYJUICE_SYSTEM;
+    let mut data = [0u8; 40];
+    data[0..8].copy_from_slice(&gas_used.to_le_bytes());
+    data[8..16].copy_from_slice(&cumulative_gas_used.to_le_bytes());
+    data[16..36].copy_from_slice(&created_address);
+    data[36..40].copy_from_slice(&status_code.to_le_bytes());
+    LogItem::new_builder()
+        .account_id(account_id.pack())
+        .service_flag(service_flag.into())
+        .data(data.pack())
+        .build()
+}


### PR DESCRIPTION
* Handle `ckb_vm::error::Error::InvalidCycles` error raise form CKB VM
* Set `run_result.exit_code` to `1` in that case.
* Generate a polyjuice system log `account: raw_tx.to_id, gas_used: gas, cumulative_gas_used: gas, created_address: [0u8; 20], status: 0,`.