### PR TITLE
fix: always refresh pending deposit cells

### DIFF
--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -607,8 +607,13 @@ impl MemPool {
 
         let db = self.store.begin_transaction();
 
+        let is_mem_pool_recovery = old_tip.is_none();
+
         // refresh pending deposits
-        self.refresh_deposit_cells(&db, new_tip).await?;
+        if !is_mem_pool_recovery {
+            self.refresh_deposit_cells(&db, new_tip).await?;
+        }
+
         // estimate next l2block timestamp
         let estimated_timestamp = {
             let estimated = self.provider.estimate_next_blocktime().await?;
@@ -674,7 +679,6 @@ impl MemPool {
         log::info!("[mem-pool] reset reinject txs: {} mem-block txs: {} reinject withdrawals: {} mem-block withdrawals: {}", reinject_txs.len(), mem_block_txs.len(), reinject_withdrawals.len(), mem_block_withdrawals.len());
         // re-inject txs
         let txs = reinject_txs.into_iter().chain(mem_block_txs).collect();
-        let is_mem_pool_recovery = old_tip.is_none();
 
         // re-inject withdrawals
         let mut withdrawals: Vec<_> = reinject_withdrawals.into_iter().collect();

--- a/devtools/fetch-binaries.sh
+++ b/devtools/fetch-binaries.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 dir_name='.tmp/binaries'
-image='ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.2-rc1'
+image='ghcr.io/nervosnetwork/godwoken-prebuilds:1.3.0-rc3'
 
 docker pull $image
 [ -d $dir_name ] && rm -rf $dir_name && echo "Delete old dir"

--- a/devtools/fetch-binaries.sh
+++ b/devtools/fetch-binaries.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 dir_name='.tmp/binaries'
-image='ghcr.io/zeroqn/godwoken-prebuilds:v1.1-feat-change-ckb-decimal-to-18'
+image='ghcr.io/nervosnetwork/godwoken-prebuilds:1.2.2-rc1'
 
 docker pull $image
 [ -d $dir_name ] && rm -rf $dir_name && echo "Delete old dir"


### PR DESCRIPTION
The `refresh_deposit_cells` function is introduced in the https://github.com/nervosnetwork/godwoken/pull/433 , the original intension is to keep consistent of `account id` during the mem-pool refreshing, otherwise, the following txs will invalid  due to the incorrect signature.

In the v1 version, we migrate signing method to the Ethereum & EIP-712, the `account id` is not included in the signature anymore, even the `account id` is changed, the following txs still passes the validate.