### PR TITLE
fix(block-producer): exit during bad block challenge

### DIFF
--- a/crates/block-producer/src/challenger.rs
+++ b/crates/block-producer/src/challenger.rs
@@ -215,6 +215,7 @@ impl Challenger {
         let rollup_deps = vec![
             contracts_dep.rollup_cell_type.clone().into(),
             self.config.rollup_config_cell_dep.clone().into(),
+            contracts_dep.omni_lock.clone().into(),
         ];
         let rollup_output = (
             rollup_state.rollup_output(),
@@ -446,6 +447,7 @@ impl Challenger {
         let rollup_deps = vec![
             contracts_dep.rollup_cell_type.clone().into(),
             self.config.rollup_config_cell_dep.clone().into(),
+            contracts_dep.omni_lock.clone().into(),
         ];
         let rollup_output = (
             rollup_state.rollup_output(),
@@ -535,6 +537,7 @@ impl Challenger {
         let rollup_deps = vec![
             contracts_dep.rollup_cell_type.clone().into(),
             self.config.rollup_config_cell_dep.clone().into(),
+            contracts_dep.omni_lock.clone().into(),
         ];
         let rollup_output = (
             rollup_state.rollup_output(),

--- a/crates/block-producer/src/challenger.rs
+++ b/crates/block-producer/src/challenger.rs
@@ -238,8 +238,11 @@ impl Challenger {
 
         let tx = self.wallet.sign_tx_skeleton(tx_skeleton)?;
 
-        self.dry_run_transaction(&tx, "challenge block").await?;
-        utils::dump_transaction(&self.debug_config.debug_tx_dump_path, &self.rpc_client, &tx).await;
+        if let Err(err) = self.dry_run_transaction(&tx, "challenge block").await {
+            utils::dump_transaction(&self.debug_config.debug_tx_dump_path, &self.rpc_client, &tx)
+                .await;
+            bail!(err);
+        }
 
         let tx_hash = self.rpc_client.send_transaction(&tx).await?;
         log::info!("Challenge block {} in tx {}", block_numer, to_hex(&tx_hash));
@@ -334,8 +337,11 @@ impl Challenger {
             )
             .await?;
 
-        self.dry_run_transaction(&tx, "cancel challenge").await?;
-        utils::dump_transaction(&self.debug_config.debug_tx_dump_path, &self.rpc_client, &tx).await;
+        if let Err(err) = self.dry_run_transaction(&tx, "cancel challenge").await {
+            utils::dump_transaction(&self.debug_config.debug_tx_dump_path, &self.rpc_client, &tx)
+                .await;
+            bail!(err);
+        }
 
         let load_data_inputs = verifier_context.load_data_context.map(|d| d.inputs);
         let verifier = Verifier::new(
@@ -477,8 +483,11 @@ impl Challenger {
 
         let tx = self.wallet.sign_tx_skeleton(tx_skeleton)?;
 
-        self.dry_run_transaction(&tx, "revert block").await?;
-        utils::dump_transaction(&self.debug_config.debug_tx_dump_path, &self.rpc_client, &tx).await;
+        if let Err(err) = self.dry_run_transaction(&tx, "revert block").await {
+            utils::dump_transaction(&self.debug_config.debug_tx_dump_path, &self.rpc_client, &tx)
+                .await;
+            bail!(err);
+        }
 
         let tx_hash = self.rpc_client.send_transaction(&tx).await?;
         log::info!("Revert block in tx {}", to_hex(&tx_hash));

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -228,11 +228,15 @@ impl ChainTask {
                         log::error!("[polling] challenger event: {} error: {}", event, err);
                         return Ok(None);
                     }
-                    bail!(
-                        "Error occurred when polling challenger, event: {}, error: {}",
-                        event,
-                        err
-                    );
+                    if err.to_string().contains("TransactionFailedToResolve") {
+                        log::info!("[polling] challenger outdated rollup status, wait update");
+                    } else {
+                        bail!(
+                            "Error occurred when polling challenger, event: {}, error: {}",
+                            event,
+                            err
+                        );
+                    }
                 }
             }
 

--- a/crates/block-producer/src/withdrawal.rs
+++ b/crates/block-producer/src/withdrawal.rs
@@ -37,7 +37,7 @@ pub fn generate(
     contracts_dep: &ContractsCellDep,
     withdrawal_extras: &HashMap<H256, WithdrawalRequestExtra>,
 ) -> Result<Option<GeneratedWithdrawals>> {
-    if block.withdrawals().is_empty() && finalized_custodians.cells_info.is_empty() {
+    if block.withdrawals().is_empty() && finalized_custodians.cells_info.len() <= 1 {
         return Ok(None);
     }
     log::debug!("custodian inputs {:?}", finalized_custodians);

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -254,7 +254,10 @@ impl Chain {
         if let Some(mem_pool) = &self.mem_pool {
             if !self.complete_initial_syncing {
                 // Do first notify
-                let tip_block_hash: H256 = self.local_state.tip.hash().into();
+                let tip_block_hash: H256 = match self.challenge_target {
+                    Some(_) => self.store().get_last_valid_tip_block_hash()?,
+                    None => self.local_state.tip.hash().into(),
+                };
 
                 log::debug!("[complete_initial_syncing] acquire mem-pool",);
                 let t = Instant::now();


### PR DESCRIPTION
- fix: no dump on dry run challenge tx failed
- fix: invalid code hash for challenger tx (omni lock)
- fix: chain notify mem pool with bad block tip hash cause mem pool set snapshot assertion failure
- fix: pool duplicated challenger tx due to replace poa lock with omni lock
- fix: mem pool isn't reset after bad block is reverted
- fix: one finalized custodian with no withdrawal