### PR TITLE
Redirect syscall debug logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "log",
  "rlp",
  "secp256k1 0.20.3",
+ "sentry",
  "sha3",
  "tempfile",
  "thiserror",

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -174,7 +174,12 @@ impl BenchExecutionEnvironment {
             manage
         };
 
-        let generator = Generator::new(backend_manage, account_lock_manage, rollup_context);
+        let generator = Generator::new(
+            backend_manage,
+            account_lock_manage,
+            rollup_context,
+            Default::default(),
+        );
 
         Self::init_genesis(&store, &genesis_config, accounts);
         let mem_pool_state = MemPoolState::new(Arc::new(MemStore::new(store.get_snapshot())), true);

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -89,7 +89,12 @@ fn run_contract_get_result<S: State + CodeStore>(
         rollup_config: rollup_config.clone(),
         rollup_script_hash: [42u8; 32].into(),
     };
-    let generator = Generator::new(backend_manage, account_lock_manage, rollup_ctx);
+    let generator = Generator::new(
+        backend_manage,
+        account_lock_manage,
+        rollup_ctx,
+        Default::default(),
+    );
     let chain_view = DummyChainStore;
     let run_result =
         generator.execute_transaction(&chain_view, tree, block_info, &raw_tx, L2TX_MAX_CYCLES)?;

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -478,6 +478,7 @@ impl BaseInitComponents {
                 backend_manage,
                 account_lock_manage,
                 rollup_context.clone(),
+                config.contract_log_config.clone(),
             ))
         };
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -45,6 +45,8 @@ pub struct Config {
     pub dynamic_config: DynamicConfig,
     #[serde(default)]
     pub p2p_network_config: Option<P2PNetworkConfig>,
+    #[serde(default)]
+    pub contract_log_config: ContractLogConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -410,4 +412,18 @@ pub struct GithubConfigUrl {
 pub struct DynamicConfig {
     pub fee_config: FeeConfig,
     pub rpc_config: RPCConfig,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContractLogConfig {
+    Default,       //print contract log in place
+    Redirect,      //print all of the contract logs, send error logs to sentry
+    RedirectError, //only print logs when the tx hit an error, send error logs to sentry
+}
+
+impl Default for ContractLogConfig {
+    fn default() -> Self {
+        ContractLogConfig::Default
+    }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,6 +20,7 @@ pub enum Trace {
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub node_mode: NodeMode,
+    #[serde(default)]
     pub contract_log_config: ContractLogConfig,
     pub backend_switches: Vec<BackendSwitchConfig>,
     pub genesis: GenesisConfig,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,6 +20,7 @@ pub enum Trace {
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub node_mode: NodeMode,
+    pub contract_log_config: ContractLogConfig,
     pub backend_switches: Vec<BackendSwitchConfig>,
     pub genesis: GenesisConfig,
     pub chain: ChainConfig,
@@ -45,8 +46,6 @@ pub struct Config {
     pub dynamic_config: DynamicConfig,
     #[serde(default)]
     pub p2p_network_config: Option<P2PNetworkConfig>,
-    #[serde(default)]
-    pub contract_log_config: ContractLogConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -33,7 +33,9 @@ tokio = "1.15"
 arc-swap = "1.5"
 ethabi = "16.0.0"
 tracing = { version = "0.1", features = ["attributes"] }
+sentry = { git = "https://github.com/getsentry/sentry-rust", rev = "df694a49595d6890c510d80b85cfbb4b5ae6159a" }
 
 [dev-dependencies]
 gw-utils = {path = "../utils" }
 tempfile = "3"
+sentry = { git = "https://github.com/getsentry/sentry-rust", rev = "df694a49595d6890c510d80b85cfbb4b5ae6159a", features=["test"] }

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -30,6 +30,7 @@ use gw_common::{
     },
     H256,
 };
+use gw_config::ContractLogConfig;
 use gw_store::{state::state_db::StateContext, transaction::StoreTransaction};
 use gw_traits::{ChainView, CodeStore};
 use gw_types::{
@@ -103,8 +104,9 @@ impl Generator {
         backend_manage: BackendManage,
         account_lock_manage: AccountLockManage,
         rollup_context: RollupContext,
+        contract_log_config: ContractLogConfig,
     ) -> Self {
-        let redir_log_handler = RedirLogHandler::new();
+        let redir_log_handler = RedirLogHandler::new(contract_log_config);
         Generator {
             backend_manage,
             account_lock_manage,

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -6,6 +6,7 @@ use crate::{
     constants::{L2TX_MAX_CYCLES, MAX_READ_DATA_BYTES_LIMIT, MAX_WRITE_DATA_BYTES_LIMIT},
     error::{BlockError, TransactionValidateError, WithdrawalError},
     run_result_state::RunResultState,
+    syscalls::redir_log::RedirLogHandler,
     typed_transaction::types::TypedRawTransaction,
     types::vm::VMVersion,
     utils::get_tx_type,
@@ -94,6 +95,7 @@ pub struct Generator {
     backend_manage: BackendManage,
     account_lock_manage: AccountLockManage,
     rollup_context: RollupContext,
+    redir_log_handler: RedirLogHandler,
 }
 
 impl Generator {
@@ -102,10 +104,12 @@ impl Generator {
         account_lock_manage: AccountLockManage,
         rollup_context: RollupContext,
     ) -> Self {
+        let redir_log_handler = RedirLogHandler::new();
         Generator {
             backend_manage,
             account_lock_manage,
             rollup_context,
+            redir_log_handler,
         }
     }
 
@@ -129,6 +133,7 @@ impl Generator {
     ) -> Result<RunResult, TransactionError> {
         const INVALID_CYCLES_EXIT_CODE: i8 = -1;
 
+        self.redir_log_handler.start(raw_tx.clone());
         let mut run_result = RunResult::default();
         let used_cycles;
         let exit_code;
@@ -151,6 +156,7 @@ impl Generator {
                     account_lock_manage: &self.account_lock_manage,
                     result: &mut run_result,
                     code_store: state,
+                    redir_log_handler: &self.redir_log_handler,
                 }))
                 .instruction_cycle_func(Box::new(instruction_cycles));
             let default_machine = machine_builder.build();
@@ -185,6 +191,7 @@ impl Generator {
                     return Err(err.into());
                 }
             }
+            self.redir_log_handler.flush(exit_code);
             log::debug!(
                 "[execute tx] VM machine_run time: {}ms, exit code: {} used_cycles: {}",
                 t.elapsed().as_millis(),

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -135,7 +135,7 @@ impl Generator {
     ) -> Result<RunResult, TransactionError> {
         const INVALID_CYCLES_EXIT_CODE: i8 = -1;
 
-        self.redir_log_handler.start(raw_tx.clone());
+        self.redir_log_handler.start(raw_tx);
         let mut run_result = RunResult::default();
         let used_cycles;
         let exit_code;

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -598,8 +598,8 @@ impl<'a, S: State, C: ChainView> L2Syscalls<'a, S, C> {
             buffer.push(byte);
             addr += 1;
         }
-
-        self.redir_log_handler.append_log(buffer);
+        let s = String::from_utf8(buffer).map_err(|_| VMError::ParseError)?;
+        self.redir_log_handler.append_log(s);
         Ok(())
     }
 }

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -24,12 +24,17 @@ use gw_types::{
 };
 use std::cmp;
 
-use self::error_codes::{
-    GW_ERROR_ACCOUNT_NOT_FOUND, GW_ERROR_DUPLICATED_SCRIPT_HASH, GW_ERROR_INVALID_ACCOUNT_SCRIPT,
-    GW_ERROR_NOT_FOUND, GW_ERROR_RECOVER, GW_ERROR_UNKNOWN_SCRIPT_CODE_HASH, SUCCESS,
+use self::{
+    error_codes::{
+        GW_ERROR_ACCOUNT_NOT_FOUND, GW_ERROR_DUPLICATED_SCRIPT_HASH,
+        GW_ERROR_INVALID_ACCOUNT_SCRIPT, GW_ERROR_NOT_FOUND, GW_ERROR_RECOVER,
+        GW_ERROR_UNKNOWN_SCRIPT_CODE_HASH, SUCCESS,
+    },
+    redir_log::RedirLogHandler,
 };
 
 pub mod error_codes;
+pub(crate) mod redir_log;
 
 /* Constants */
 // 25KB is max ethereum contract code size
@@ -66,6 +71,7 @@ pub(crate) struct L2Syscalls<'a, S, C> {
     pub(crate) raw_tx: &'a RawL2Transaction,
     pub(crate) code_store: &'a dyn CodeStore,
     pub(crate) result: &'a mut RunResult,
+    pub(crate) redir_log_handler: &'a RedirLogHandler,
 }
 
 #[allow(dead_code)]
@@ -593,8 +599,7 @@ impl<'a, S: State, C: ChainView> L2Syscalls<'a, S, C> {
             addr += 1;
         }
 
-        let s = String::from_utf8(buffer).map_err(|_| VMError::ParseError)?;
-        log::debug!("[contract debug]: {}", s);
+        self.redir_log_handler.append_log(buffer);
         Ok(())
     }
 }

--- a/crates/generator/src/syscalls/redir_log.rs
+++ b/crates/generator/src/syscalls/redir_log.rs
@@ -1,3 +1,4 @@
+use gw_config::ContractLogConfig;
 use gw_types::{
     bytes::{BufMut, BytesMut},
     packed::RawL2Transaction,
@@ -6,7 +7,7 @@ use tokio::sync::mpsc;
 
 #[derive(Debug)]
 pub(crate) enum RedirLogMsg {
-    Start(RawL2Transaction),
+    Session(RawL2Transaction),
     Log(Vec<u8>),
     Flush(i8), //exit code
 }
@@ -16,14 +17,14 @@ pub(crate) struct RedirLogActor {
 }
 
 impl RedirLogActor {
-    pub(crate) fn new(recv: mpsc::Receiver<RedirLogMsg>) -> Self {
-        let ctx = Context::init(None);
+    pub(crate) fn new(recv: mpsc::Receiver<RedirLogMsg>, config: ContractLogConfig) -> Self {
+        let ctx = Context::init(config);
         Self { recv, ctx }
     }
 
     fn handle_msg(&mut self, msg: RedirLogMsg) {
         match msg {
-            RedirLogMsg::Start(tx) => self.ctx.setup(tx),
+            RedirLogMsg::Session(tx) => self.ctx.setup(tx),
             RedirLogMsg::Log(log) => self.ctx.append_log(&log),
             RedirLogMsg::Flush(exit_code) => self.ctx.flush(exit_code),
         }
@@ -34,13 +35,15 @@ impl RedirLogActor {
 struct Context {
     tx: Option<RawL2Transaction>,
     sink: BytesMut,
+    config: ContractLogConfig,
 }
 
 impl Context {
-    fn init(tx: Option<RawL2Transaction>) -> Self {
+    fn init(config: ContractLogConfig) -> Self {
         Self {
-            tx,
+            tx: None,
             sink: BytesMut::with_capacity(1024),
+            config,
         }
     }
 
@@ -55,11 +58,29 @@ impl Context {
 
     fn flush(&mut self, exit_code: i8) {
         if let Ok(s) = std::str::from_utf8(&self.sink) {
-            log::debug!("[contract debug]: {}", s);
-            log::debug!("contract exit code: {}", exit_code);
-            //TODO
-            //1. send to senty if exit code != 0
-            //2. add more mode when print log, e.g only print log on error
+            if self.config == ContractLogConfig::Redirect
+                || (self.config == ContractLogConfig::RedirectError && exit_code != 0)
+            {
+                log::debug!("[contract debug]: {}", s);
+                log::debug!("contract exit code: {}", exit_code);
+            }
+            //send to senty if exit code != 0
+            //format:
+            //  tx_hash
+            //  [contrace logs]
+            //  ...
+            //  exit code: 3
+            if exit_code != 0 {
+                let mut entries: Vec<String> = Vec::with_capacity(3);
+                if let Some(tx) = &self.tx {
+                    let tx_hash = hex::encode(tx.as_reader().hash());
+                    entries.push(tx_hash);
+                }
+                entries.push(s.to_string());
+                entries.push(format!("exit code: {}", exit_code));
+                let msg = entries.join("\n");
+                sentry::capture_message(&msg, sentry::Level::Error);
+            }
         }
         self.sink.clear();
         self.tx = None;
@@ -74,19 +95,25 @@ async fn run_redir_log_actor(mut actor: RedirLogActor) {
 
 #[derive(Clone)]
 pub(crate) struct RedirLogHandler {
-    sender: mpsc::Sender<RedirLogMsg>,
+    sender: Option<mpsc::Sender<RedirLogMsg>>,
 }
 
 impl RedirLogHandler {
-    pub(crate) fn new() -> Self {
-        let (sender, receiver) = mpsc::channel(16);
-        let actor = RedirLogActor::new(receiver);
-        tokio::spawn(run_redir_log_actor(actor));
+    pub(crate) fn new(config: ContractLogConfig) -> Self {
+        //Don't spawn tokio task in default mode.
+        let sender = if config != ContractLogConfig::Default {
+            let (sender, receiver) = mpsc::channel(16);
+            let actor = RedirLogActor::new(receiver, config);
+            tokio::spawn(run_redir_log_actor(actor));
+            Some(sender)
+        } else {
+            None
+        };
         Self { sender }
     }
 
     pub(crate) fn start(&self, tx: RawL2Transaction) {
-        self.send_msg(RedirLogMsg::Start(tx));
+        self.send_msg(RedirLogMsg::Session(tx));
     }
 
     pub(crate) fn flush(&self, exit_code: i8) {
@@ -98,20 +125,71 @@ impl RedirLogHandler {
     }
 
     fn send_msg(&self, msg: RedirLogMsg) {
-        match self.sender.try_send(msg) {
-            Ok(_) => log::trace!("redir log msg was sent out."),
-            Err(mpsc::error::TrySendError::Closed(msg)) => {
-                log::warn!(
-                    "Discard redir log msg due to channel was closed. msg: {:?}",
-                    msg
-                )
-            }
-            Err(mpsc::error::TrySendError::Full(msg)) => {
-                log::warn!(
-                    "Discard redir log msg due to channel is full. msg: {:?}",
-                    msg
-                )
+        match &self.sender {
+            Some(sender) => match sender.try_send(msg) {
+                Ok(_) => log::trace!("redir log msg was sent out."),
+                Err(mpsc::error::TrySendError::Closed(msg)) => {
+                    log::warn!(
+                        "Discard redir log msg due to channel was closed. msg: {:?}",
+                        msg
+                    )
+                }
+                Err(mpsc::error::TrySendError::Full(msg)) => {
+                    log::warn!(
+                        "Discard redir log msg due to channel is full. msg: {:?}",
+                        msg
+                    )
+                }
+            },
+            None => {
+                if let RedirLogMsg::Log(log) = msg {
+                    if let Ok(s) = std::str::from_utf8(&log) {
+                        log::debug!("[contract debug]: {}", s);
+                    }
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gw_types::{packed::RawL2Transaction, prelude::*};
+
+    use super::{Context, RedirLogHandler};
+
+    #[test]
+    fn redir_sentry_test() {
+        let mut ctx = Context::init(gw_config::ContractLogConfig::Redirect);
+        let tx = RawL2Transaction::new_builder()
+            .chain_id(0.pack())
+            .from_id(1u32.pack())
+            .to_id(2u32.pack())
+            .nonce(0u32.pack())
+            .build();
+
+        let event = sentry::test::with_captured_events(|| {
+            ctx.setup(tx.clone());
+            ctx.append_log(b"debug log");
+            ctx.flush(1);
+        });
+        let target = Some("05bb2c2e17393dea8bd1206a0b2ab104dec2593f1b91be4d764d3904b3a56847\ndebug log\n\nexit code: 1".to_string());
+        assert_eq!(target, event[0].message);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"
+    )]
+    fn redir_panic_test() {
+        let _handler = RedirLogHandler::new(gw_config::ContractLogConfig::Redirect);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"
+    )]
+    fn redir_err_panic_test() {
+        let _handler = RedirLogHandler::new(gw_config::ContractLogConfig::RedirectError);
     }
 }

--- a/crates/generator/src/syscalls/redir_log.rs
+++ b/crates/generator/src/syscalls/redir_log.rs
@@ -1,0 +1,117 @@
+use gw_types::{
+    bytes::{BufMut, BytesMut},
+    packed::RawL2Transaction,
+};
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+pub(crate) enum RedirLogMsg {
+    Start(RawL2Transaction),
+    Log(Vec<u8>),
+    Flush(i8), //exit code
+}
+pub(crate) struct RedirLogActor {
+    recv: mpsc::Receiver<RedirLogMsg>,
+    ctx: Context,
+}
+
+impl RedirLogActor {
+    pub(crate) fn new(recv: mpsc::Receiver<RedirLogMsg>) -> Self {
+        let ctx = Context::init(None);
+        Self { recv, ctx }
+    }
+
+    fn handle_msg(&mut self, msg: RedirLogMsg) {
+        match msg {
+            RedirLogMsg::Start(tx) => self.ctx.setup(tx),
+            RedirLogMsg::Log(log) => self.ctx.append_log(&log),
+            RedirLogMsg::Flush(exit_code) => self.ctx.flush(exit_code),
+        }
+    }
+}
+
+// We can store the whole context of contract execution with tx, logs and exit code.
+struct Context {
+    tx: Option<RawL2Transaction>,
+    sink: BytesMut,
+}
+
+impl Context {
+    fn init(tx: Option<RawL2Transaction>) -> Self {
+        Self {
+            tx,
+            sink: BytesMut::with_capacity(1024),
+        }
+    }
+
+    fn setup(&mut self, tx: RawL2Transaction) {
+        self.tx = Some(tx);
+    }
+
+    fn append_log(&mut self, log: &[u8]) {
+        self.sink.put(log);
+        self.sink.put_u8(b'\n');
+    }
+
+    fn flush(&mut self, exit_code: i8) {
+        if let Ok(s) = std::str::from_utf8(&self.sink) {
+            log::debug!("[contract debug]: {}", s);
+            log::debug!("contract exit code: {}", exit_code);
+            //TODO
+            //1. send to senty if exit code != 0
+            //2. add more mode when print log, e.g only print log on error
+        }
+        self.sink.clear();
+        self.tx = None;
+    }
+}
+
+async fn run_redir_log_actor(mut actor: RedirLogActor) {
+    while let Some(msg) = actor.recv.recv().await {
+        actor.handle_msg(msg);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RedirLogHandler {
+    sender: mpsc::Sender<RedirLogMsg>,
+}
+
+impl RedirLogHandler {
+    pub(crate) fn new() -> Self {
+        let (sender, receiver) = mpsc::channel(16);
+        let actor = RedirLogActor::new(receiver);
+        tokio::spawn(run_redir_log_actor(actor));
+        Self { sender }
+    }
+
+    pub(crate) fn start(&self, tx: RawL2Transaction) {
+        self.send_msg(RedirLogMsg::Start(tx));
+    }
+
+    pub(crate) fn flush(&self, exit_code: i8) {
+        self.send_msg(RedirLogMsg::Flush(exit_code));
+    }
+
+    pub(crate) fn append_log(&self, log: Vec<u8>) {
+        self.send_msg(RedirLogMsg::Log(log));
+    }
+
+    fn send_msg(&self, msg: RedirLogMsg) {
+        match self.sender.try_send(msg) {
+            Ok(_) => log::trace!("redir log msg was sent out."),
+            Err(mpsc::error::TrySendError::Closed(msg)) => {
+                log::warn!(
+                    "Discard redir log msg due to channel was closed. msg: {:?}",
+                    msg
+                )
+            }
+            Err(mpsc::error::TrySendError::Full(msg)) => {
+                log::warn!(
+                    "Discard redir log msg due to channel is full. msg: {:?}",
+                    msg
+                )
+            }
+        }
+    }
+}

--- a/crates/replay-chain/src/setup.rs
+++ b/crates/replay-chain/src/setup.rs
@@ -121,6 +121,7 @@ pub async fn setup(args: SetupArgs) -> Result<Context> {
             backend_manage,
             account_lock_manage,
             rollup_context,
+            Default::default(),
         ))
     };
 

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -322,6 +322,7 @@ pub fn chain_generator(chain: &Chain, rollup_type_script: Script) -> Arc<Generat
         backend_manage,
         account_lock_manage,
         rollup_context,
+        Default::default(),
     ))
 }
 
@@ -364,6 +365,7 @@ pub async fn setup_chain_with_account_lock_manage(
         backend_manage,
         account_lock_manage,
         rollup_context,
+        Default::default(),
     ));
     let provider = opt_mem_pool_provider.unwrap_or_default();
     let args = MemPoolCreateArgs {

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -260,6 +260,7 @@ pub async fn generate_node_config(args: GenerateNodeConfigArgs<'_>) -> Result<Co
         reload_config_github_url: None,
         dynamic_config: Default::default(),
         p2p_network_config,
+        contract_log_config: Default::default(),
     };
 
     Ok(config)


### PR DESCRIPTION
Now we can send contract logs to `sentry` if we hit an error.
There are 3 modes In ContractLogConfig:
- Default - Just like the old times. And will not send to sentry.
- Redirect - Redirect logs to a spawned task and print them all.
- RedirectError - Redirect logs to a spawned task and only print logs if the exit code is not 0.