### PR TITLE
feat: Introduce `max_cycles_limit` of a Godwoken block

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Copy contracts from prebuild docker images
         run: devtools/fetch-binaries.sh
       - name: Tests
-        run: RUST_BACKTRACE=1 cargo test --all-targets
+        run: RUST_LOG=debug RUST_BACKTRACE=1 cargo test --all-targets
       - name: Test TOML serialization
         run: cargo run --bin godwoken -- generate-example-config -o test.toml

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -14,7 +14,6 @@ use gw_generator::{
     account_lock_manage::{always_success::AlwaysSuccess, AccountLockManage},
     backend_manage::BackendManage,
     constants::L2TX_MAX_CYCLES,
-    generator::CyclesPool,
     genesis::build_genesis_from_store,
     traits::StateExt,
     Generator,
@@ -260,7 +259,7 @@ impl BenchExecutionEnvironment {
                     &block_info,
                     &raw_tx,
                     L2TX_MAX_CYCLES,
-                    CyclesPool::none(),
+                    None,
                 )
                 .unwrap();
 

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -14,6 +14,7 @@ use gw_generator::{
     account_lock_manage::{always_success::AlwaysSuccess, AccountLockManage},
     backend_manage::BackendManage,
     constants::L2TX_MAX_CYCLES,
+    generator::CyclesPool,
     genesis::build_genesis_from_store,
     traits::StateExt,
     Generator,
@@ -253,7 +254,14 @@ impl BenchExecutionEnvironment {
 
             let run_result = self
                 .generator
-                .execute_transaction(&self.chain, &state, &block_info, &raw_tx, L2TX_MAX_CYCLES)
+                .execute_transaction(
+                    &self.chain,
+                    &state,
+                    &block_info,
+                    &raw_tx,
+                    L2TX_MAX_CYCLES,
+                    &mut CyclesPool::unlimit_cycles(),
+                )
                 .unwrap();
 
             state.apply_run_result(&run_result.write).unwrap();

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -260,7 +260,7 @@ impl BenchExecutionEnvironment {
                     &block_info,
                     &raw_tx,
                     L2TX_MAX_CYCLES,
-                    &mut CyclesPool::unlimit_cycles(),
+                    CyclesPool::none(),
                 )
                 .unwrap();
 

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -5,8 +5,8 @@ use gw_common::{
 use gw_config::{BackendConfig, BackendSwitchConfig};
 use gw_generator::{
     account_lock_manage::AccountLockManage, backend_manage::BackendManage,
-    constants::L2TX_MAX_CYCLES, dummy_state::DummyState, error::TransactionError, traits::StateExt,
-    Generator,
+    constants::L2TX_MAX_CYCLES, dummy_state::DummyState, error::TransactionError,
+    generator::CyclesPool, traits::StateExt, Generator,
 };
 use gw_traits::{ChainView, CodeStore};
 use gw_types::{
@@ -96,8 +96,14 @@ fn run_contract_get_result<S: State + CodeStore>(
         Default::default(),
     );
     let chain_view = DummyChainStore;
-    let run_result =
-        generator.execute_transaction(&chain_view, tree, block_info, &raw_tx, L2TX_MAX_CYCLES)?;
+    let run_result = generator.execute_transaction(
+        &chain_view,
+        tree,
+        block_info,
+        &raw_tx,
+        L2TX_MAX_CYCLES,
+        &mut CyclesPool::unlimit_cycles(),
+    )?;
     tree.apply_run_result(&run_result.write)
         .expect("update state");
     Ok(run_result)

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -5,8 +5,8 @@ use gw_common::{
 use gw_config::{BackendConfig, BackendSwitchConfig};
 use gw_generator::{
     account_lock_manage::AccountLockManage, backend_manage::BackendManage,
-    constants::L2TX_MAX_CYCLES, dummy_state::DummyState, error::TransactionError,
-    generator::CyclesPool, traits::StateExt, Generator,
+    constants::L2TX_MAX_CYCLES, dummy_state::DummyState, error::TransactionError, traits::StateExt,
+    Generator,
 };
 use gw_traits::{ChainView, CodeStore};
 use gw_types::{
@@ -102,7 +102,7 @@ fn run_contract_get_result<S: State + CodeStore>(
         block_info,
         &raw_tx,
         L2TX_MAX_CYCLES,
-        CyclesPool::none(),
+        None,
     )?;
     tree.apply_run_result(&run_result.write)
         .expect("update state");

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -102,7 +102,7 @@ fn run_contract_get_result<S: State + CodeStore>(
         block_info,
         &raw_tx,
         L2TX_MAX_CYCLES,
-        &mut CyclesPool::unlimit_cycles(),
+        CyclesPool::none(),
     )?;
     tree.apply_run_result(&run_result.write)
         .expect("update state");

--- a/crates/block-producer/src/replay_block.rs
+++ b/crates/block-producer/src/replay_block.rs
@@ -5,6 +5,7 @@ use gw_common::registry_address::RegistryAddress;
 use gw_common::state::State;
 use gw_common::H256;
 use gw_generator::constants::L2TX_MAX_CYCLES;
+use gw_generator::generator::CyclesPool;
 use gw_generator::traits::StateExt;
 use gw_generator::Generator;
 use gw_store::chain_view::ChainView;
@@ -112,6 +113,7 @@ impl ReplayBlock {
                 &block_info,
                 &raw_tx,
                 L2TX_MAX_CYCLES,
+                &mut CyclesPool::unlimit_cycles(),
             )?;
 
             state.apply_run_result(&run_result.write)?;

--- a/crates/block-producer/src/replay_block.rs
+++ b/crates/block-producer/src/replay_block.rs
@@ -5,7 +5,6 @@ use gw_common::registry_address::RegistryAddress;
 use gw_common::state::State;
 use gw_common::H256;
 use gw_generator::constants::L2TX_MAX_CYCLES;
-use gw_generator::generator::CyclesPool;
 use gw_generator::traits::StateExt;
 use gw_generator::Generator;
 use gw_store::chain_view::ChainView;
@@ -113,7 +112,7 @@ impl ReplayBlock {
                 &block_info,
                 &raw_tx,
                 L2TX_MAX_CYCLES,
-                CyclesPool::none(),
+                None,
             )?;
 
             state.apply_run_result(&run_result.write)?;

--- a/crates/block-producer/src/replay_block.rs
+++ b/crates/block-producer/src/replay_block.rs
@@ -113,7 +113,7 @@ impl ReplayBlock {
                 &block_info,
                 &raw_tx,
                 L2TX_MAX_CYCLES,
-                &mut CyclesPool::unlimit_cycles(),
+                CyclesPool::none(),
             )?;
 
             state.apply_run_result(&run_result.write)?;

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -159,10 +159,10 @@ pub enum TransactionError {
     NonceOverflow,
     #[error("Intrinsic gas: {0}")]
     IntrinsicGas(Cow<'static, str>),
-    #[error("Block cycles limit reached: cycles {cycles:?}, limit {limit}")]
-    BlockCyclesLimitReached { cycles: RunResultCycles, limit: u64 },
-    #[error("Exceeded block max cycles limit: cycles {cycles:?}, limit {limit}")]
-    ExceededBlockMaxCycles { cycles: RunResultCycles, limit: u64 },
+    #[error("Insufficient pool cycles: cycles {cycles:?}, limit {limit}")]
+    InsufficientPoolCycles { cycles: RunResultCycles, limit: u64 },
+    #[error("Exceeded max block cycles: cycles {cycles:?}, limit {limit}")]
+    ExceededMaxBlockCycles { cycles: RunResultCycles, limit: u64 },
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -159,6 +159,8 @@ pub enum TransactionError {
     NonceOverflow,
     #[error("Intrinsic gas: {0}")]
     IntrinsicGas(Cow<'static, str>),
+    #[error("Cycles limit reached: limit {limit}")]
+    CyclesLimitReached { limit: u64 },
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use ckb_vm::Error as VMError;
 use gw_common::{error::Error as StateError, sparse_merkle_tree::error::Error as SMTError, H256};
-use gw_types::packed::Byte32;
+use gw_types::{offchain::RunResultCycles, packed::Byte32};
 use thiserror::Error;
 
 /// Error
@@ -159,8 +159,10 @@ pub enum TransactionError {
     NonceOverflow,
     #[error("Intrinsic gas: {0}")]
     IntrinsicGas(Cow<'static, str>),
-    #[error("Block cycles limit reached: limit {limit}")]
-    BlockCyclesLimitReached { limit: u64 },
+    #[error("Block cycles limit reached: cycles {cycles:?}, limit {limit}")]
+    BlockCyclesLimitReached { cycles: RunResultCycles, limit: u64 },
+    #[error("Exceeded block max cycles limit: cycles {cycles:?}, limit {limit}")]
+    ExceededBlockMaxCycles { cycles: RunResultCycles, limit: u64 },
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -159,8 +159,8 @@ pub enum TransactionError {
     NonceOverflow,
     #[error("Intrinsic gas: {0}")]
     IntrinsicGas(Cow<'static, str>),
-    #[error("Cycles limit reached: limit {limit}")]
-    CyclesLimitReached { limit: u64 },
+    #[error("Block cycles limit reached: limit {limit}")]
+    BlockCyclesLimitReached { limit: u64 },
 }
 
 impl From<VMError> for TransactionError {

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -680,14 +680,14 @@ impl Generator {
 
     /// execute a layer2 tx
     #[instrument(skip_all)]
-    pub fn execute_transaction<'a, S: State + CodeStore, C: ChainView>(
-        &'a self,
-        chain: &'a C,
-        state: &'a S,
-        block_info: &'a BlockInfo,
-        raw_tx: &'a RawL2Transaction,
+    pub fn execute_transaction<S: State + CodeStore, C: ChainView>(
+        &self,
+        chain: &C,
+        state: &S,
+        block_info: &BlockInfo,
+        raw_tx: &RawL2Transaction,
         max_cycles: u64,
-        cycles_pool: Option<&'a mut CyclesPool>,
+        cycles_pool: Option<&mut CyclesPool>,
     ) -> Result<RunResult, TransactionError> {
         let run_result = self.unchecked_execute_transaction(
             chain,
@@ -702,14 +702,14 @@ impl Generator {
 
     /// execute a layer2 tx, doesn't check exit code
     #[instrument(skip_all, fields(block = block_info.number().unpack(), tx_hash = %raw_tx.hash().pack()))]
-    pub fn unchecked_execute_transaction<'a, S: State + CodeStore, C: ChainView>(
-        &'a self,
-        chain: &'a C,
-        state: &'a S,
-        block_info: &'a BlockInfo,
-        raw_tx: &'a RawL2Transaction,
+    pub fn unchecked_execute_transaction<S: State + CodeStore, C: ChainView>(
+        &self,
+        chain: &C,
+        state: &S,
+        block_info: &BlockInfo,
+        raw_tx: &RawL2Transaction,
         max_cycles: u64,
-        cycles_pool: Option<&'a mut CyclesPool>,
+        cycles_pool: Option<&mut CyclesPool>,
     ) -> Result<RunResult, TransactionError> {
         let account_id = raw_tx.to_id().unpack();
         let script_hash = state.get_script_hash(account_id)?;

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -135,6 +135,10 @@ impl CyclesPool {
     }
 
     pub fn sub_cycles(&mut self, cycles: u64) {
+        if self.limit_reached {
+            return;
+        }
+
         match self.cycles.checked_sub(cycles) {
             Some(cycles) => self.cycles = cycles,
             None => {
@@ -142,10 +146,6 @@ impl CyclesPool {
                 self.limit_reached = true;
             }
         }
-    }
-
-    pub fn add_cycles(&mut self, cycles: u64) {
-        self.cycles.saturating_add(cycles);
     }
 }
 

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -261,7 +261,7 @@ impl Generator {
             let used_syscall_cycles = cycles_pool_bak.cycles() - cycles_pool.cycles();
             cycles_pool.sub_cycles(used_cycles.saturating_sub(used_syscall_cycles));
             if cycles_pool.limit_reached() {
-                return Err(TransactionError::CyclesLimitReached {
+                return Err(TransactionError::BlockCyclesLimitReached {
                     limit: cycles_pool.limit,
                 });
             }

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -250,7 +250,8 @@ impl Generator {
                     let limit = cycles_pool.limit;
 
                     if cycles.total() > limit {
-                        // Restore cycles pool, because we will not treat this tx as failed tx
+                        // Restore cycles pool, because we will not treat this tx as failed tx, it
+                        // will be dropped.
                         assert!(org_cycles_pool.is_some());
                         **cycles_pool = org_cycles_pool.unwrap();
 

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -30,7 +30,7 @@ use gw_common::{
     },
     H256,
 };
-use gw_config::ContractLogConfig;
+use gw_config::{ContractLogConfig, SyscallCyclesConfig};
 use gw_store::{state::state_db::StateContext, transaction::StoreTransaction};
 use gw_traits::{ChainView, CodeStore};
 use gw_types::{
@@ -92,6 +92,69 @@ impl From<WithdrawalCellError> for Error {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct CyclesPool {
+    limit: u64,
+    cycles: u64,
+    syscall_config: SyscallCyclesConfig,
+    limit_reached: bool,
+}
+
+impl CyclesPool {
+    pub fn new(limit: u64, syscall_config: SyscallCyclesConfig) -> Self {
+        CyclesPool {
+            limit,
+            cycles: limit,
+            syscall_config,
+            limit_reached: false,
+        }
+    }
+
+    pub fn unlimit_cycles() -> Self {
+        Self::new(u64::MAX, SyscallCyclesConfig::all_zero())
+    }
+
+    pub fn limit(&self) -> u64 {
+        self.limit
+    }
+
+    pub fn cycles(&self) -> u64 {
+        self.cycles
+    }
+
+    pub fn cycles_used(&self) -> u64 {
+        self.limit - self.cycles
+    }
+
+    pub fn limit_reached(&self) -> bool {
+        self.limit_reached
+    }
+
+    pub fn syscall_config(&self) -> &SyscallCyclesConfig {
+        &self.syscall_config
+    }
+
+    pub fn sub_cycles(&mut self, cycles: u64) {
+        match self.cycles.checked_sub(cycles) {
+            Some(cycles) => self.cycles = cycles,
+            None => {
+                self.cycles = 0;
+                self.limit_reached = true;
+            }
+        }
+    }
+}
+
+pub struct MachineRunArgs<'a, C, S> {
+    chain: &'a C,
+    state: &'a S,
+    block_info: &'a BlockInfo,
+    raw_tx: &'a RawL2Transaction,
+    max_cycles: u64,
+    backend: Backend,
+    cycles_pool: &'a mut CyclesPool,
+}
+
 pub struct Generator {
     backend_manage: BackendManage,
     account_lock_manage: AccountLockManage,
@@ -123,22 +186,28 @@ impl Generator {
         &self.account_lock_manage
     }
 
-    #[instrument(skip_all, fields(backend = ?backend.backend_type))]
-    fn machine_run<'a, S: State + CodeStore, C: ChainView>(
-        &'a self,
-        chain: &'a C,
-        state: &'a S,
-        block_info: &'a BlockInfo,
-        raw_tx: &'a RawL2Transaction,
-        max_cycles: u64,
-        backend: Backend,
+    #[instrument(skip_all, fields(backend = ?args.backend.backend_type))]
+    fn machine_run<S: State + CodeStore, C: ChainView>(
+        &self,
+        args: MachineRunArgs<'_, C, S>,
     ) -> Result<RunResult, TransactionError> {
         const INVALID_CYCLES_EXIT_CODE: i8 = -1;
 
+        let MachineRunArgs {
+            chain,
+            state,
+            block_info,
+            raw_tx,
+            max_cycles,
+            backend,
+            cycles_pool,
+        } = args;
+
         self.redir_log_handler.start(raw_tx);
         let mut run_result = RunResult::default();
-        let used_cycles;
+        let mut used_cycles;
         let exit_code;
+        let cycles_pool_bak = cycles_pool.clone();
         {
             let t = Instant::now();
             let global_vm_version = GLOBAL_VM_VERSION.load(SeqCst);
@@ -159,6 +228,7 @@ impl Generator {
                     result: &mut run_result,
                     code_store: state,
                     redir_log_handler: &self.redir_log_handler,
+                    cycles_pool,
                 }))
                 .instruction_cycle_func(Box::new(instruction_cycles));
             let default_machine = machine_builder.build();
@@ -179,16 +249,26 @@ impl Generator {
             let mut machine = TraceMachine::new(default_machine);
 
             machine.load_program(&backend.generator, &[])?;
-            match machine.run() {
+            let maybe_ok = machine.run();
+            used_cycles = machine.machine.cycles();
+            drop(machine);
+            cycles_pool.sub_cycles(used_cycles);
+
+            match maybe_ok {
                 Ok(_exit_code) => {
                     exit_code = _exit_code;
-                    used_cycles = machine.machine.cycles();
                 }
                 Err(ckb_vm::error::Error::InvalidCycles) => {
                     exit_code = INVALID_CYCLES_EXIT_CODE;
                     used_cycles = max_cycles;
                 }
+                Err(ckb_vm::error::Error::LimitReached) if cycles_pool.limit_reached() => {
+                    return Err(TransactionError::CyclesLimitReached {
+                        limit: cycles_pool.limit,
+                    })
+                }
                 Err(err) => {
+                    *cycles_pool = cycles_pool_bak;
                     // unexpected VM error
                     return Err(err.into());
                 }
@@ -460,6 +540,7 @@ impl Generator {
                 &block_info,
                 &raw_tx,
                 L2TX_MAX_CYCLES,
+                &mut CyclesPool::unlimit_cycles(),
             ) {
                 Ok(run_result) => run_result,
                 Err(err) => {
@@ -599,9 +680,16 @@ impl Generator {
         block_info: &BlockInfo,
         raw_tx: &RawL2Transaction,
         max_cycles: u64,
+        cycles_pool: &mut CyclesPool,
     ) -> Result<RunResult, TransactionError> {
-        let run_result =
-            self.unchecked_execute_transaction(chain, state, block_info, raw_tx, max_cycles)?;
+        let run_result = self.unchecked_execute_transaction(
+            chain,
+            state,
+            block_info,
+            raw_tx,
+            max_cycles,
+            cycles_pool,
+        )?;
         Ok(run_result)
     }
 
@@ -614,6 +702,7 @@ impl Generator {
         block_info: &BlockInfo,
         raw_tx: &RawL2Transaction,
         max_cycles: u64,
+        cycles_pool: &mut CyclesPool,
     ) -> Result<RunResult, TransactionError> {
         let account_id = raw_tx.to_id().unpack();
         let script_hash = state.get_script_hash(account_id)?;
@@ -621,8 +710,17 @@ impl Generator {
             .load_backend(block_info.number().unpack(), state, &script_hash)
             .ok_or(TransactionError::BackendNotFound { script_hash })?;
 
-        let run_result: RunResult =
-            self.machine_run(chain, state, block_info, raw_tx, max_cycles, backend)?;
+        let args = MachineRunArgs {
+            chain,
+            state,
+            block_info,
+            raw_tx,
+            max_cycles,
+            backend,
+            cycles_pool,
+        };
+
+        let run_result: RunResult = self.machine_run(args)?;
         self.handle_run_result(state, block_info, raw_tx, run_result)
     }
 

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -143,6 +143,10 @@ impl CyclesPool {
             }
         }
     }
+
+    pub fn add_cycles(&mut self, cycles: u64) {
+        self.cycles.saturating_add(cycles);
+    }
 }
 
 pub struct MachineRunArgs<'a, C, S> {

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -145,6 +145,7 @@ impl<'a, S: State, C: ChainView, Mac: SupportMachine> Syscalls<Mac> for L2Syscal
 
         let syscall_cycles = self.get_syscall_cycles(code);
         if 0 != syscall_cycles {
+            // Sub cycles here to interrupt execution
             self.sub_cycles(syscall_cycles)?;
             machine.add_cycles(syscall_cycles)?;
         }

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -156,7 +156,7 @@ impl<'a, 'b, S: State, C: ChainView, Mac: SupportMachine> Syscalls<Mac>
                 let execution_and_virtual = machine
                     .cycles()
                     .saturating_add(self.result.cycles.r#virtual);
-                if cycles_pool.checked_sub_cycles(syscall_cycles).is_none()
+                if cycles_pool.consume_cycles(syscall_cycles).is_none()
                     || execution_and_virtual > cycles_pool.limit()
                 {
                     return Err(VMError::LimitReached);

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -153,7 +153,12 @@ impl<'a, 'b, S: State, C: ChainView, Mac: SupportMachine> Syscalls<Mac>
                     self.result.cycles.r#virtual.saturating_add(syscall_cycles);
 
                 // Subtract cycles to interrupt execution eariler
-                if cycles_pool.checked_sub_cycles(syscall_cycles).is_none() {
+                let execution_and_virtual = machine
+                    .cycles()
+                    .saturating_add(self.result.cycles.r#virtual);
+                if cycles_pool.checked_sub_cycles(syscall_cycles).is_none()
+                    || execution_and_virtual > cycles_pool.limit()
+                {
                     return Err(VMError::LimitReached);
                 }
             }

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -1134,17 +1134,20 @@ impl MemPool {
             }
         }
 
-        // execute tx
-        let raw_tx = tx.raw();
+        // Use block max cycles if it's smaller than L2TX_MAX_CYCLES
+        let l2tx_max_cycles = min(L2TX_MAX_CYCLES, self.mem_block_config.max_cycles_limit);
         let cycles_pool = &mut self.cycles_pool;
         let generator = Arc::clone(&self.generator);
+
+        // execute tx
+        let raw_tx = tx.raw();
         let run_result = tokio::task::block_in_place(|| {
             generator.unchecked_execute_transaction(
                 &chain_view,
                 state,
                 block_info,
                 &raw_tx,
-                L2TX_MAX_CYCLES,
+                l2tx_max_cycles,
                 cycles_pool,
             )
         })?;

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -239,6 +239,10 @@ impl MemPool {
         &self.cycles_pool
     }
 
+    pub fn cycles_pool_mut(&mut self) -> &mut CyclesPool {
+        &mut self.cycles_pool
+    }
+
     pub fn restore_manager(&self) -> &RestoreManager {
         &self.restore_manager
     }

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -719,15 +719,13 @@ impl MemPool {
         )
         .await?;
 
-        // Update block cycles
-        let remained_block_cycles = self
-            .mem_block_config
-            .max_cycles_limit
-            .saturating_sub(self.cycles_pool.cycles_used());
+        // Update block remained cycles
+        let used_cycles = self.cycles_pool.cycles_used();
         self.cycles_pool = CyclesPool::new(
-            remained_block_cycles,
+            self.mem_block_config.max_cycles_limit,
             self.mem_block_config.syscall_cycles.clone(),
         );
+        self.cycles_pool.sub_cycles(used_cycles);
 
         // store mem state
         self.mem_pool_state.store(Arc::new(mem_store));

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -725,7 +725,7 @@ impl MemPool {
             self.mem_block_config.max_cycles_limit,
             self.mem_block_config.syscall_cycles.clone(),
         );
-        self.cycles_pool.checked_sub_cycles(used_cycles);
+        self.cycles_pool.consume_cycles(used_cycles);
 
         // store mem state
         self.mem_pool_state.store(Arc::new(mem_store));

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -658,9 +658,6 @@ impl RequestSubmitter {
                 let state = snap.state().expect("get mem state");
                 let mut block_cycles_limit_reached = false;
 
-                // Note: don't change `_handle` to `_`. The request should be
-                // removed from the in queue request map after pushed to mem
-                // pool.
                 for (entry, handle) in items {
                     if let FeeItemKind::Tx = entry.item.kind() {
                         if !block_cycles_limit_reached

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -559,7 +559,11 @@ impl RequestSubmitter {
                 match req_to_entry(fee_config, self.generator.clone(), req, &state, queue.len()) {
                     Ok(entry) => {
                         if entry.cycles_limit > self.mem_pool_config.mem_block.max_cycles_limit {
-                            log::info!("tx {} exceeded mem block max cycles limit, drop it", hash);
+                            log::info!(
+                                "req kind {} hash {} exceeded mem block max cycles limit, drop it",
+                                kind,
+                                hash,
+                            );
                         } else {
                             queue.add(entry, handle);
                         }
@@ -586,7 +590,11 @@ impl RequestSubmitter {
                 match req_to_entry(fee_config, self.generator.clone(), req, &state, queue.len()) {
                     Ok(entry) => {
                         if entry.cycles_limit > self.mem_pool_config.mem_block.max_cycles_limit {
-                            log::info!("tx {} exceeded mem block max cycles limit, drop it", hash);
+                            log::info!(
+                                "req kind {} hash {} exceeded mem block max cycles limit, drop it",
+                                kind,
+                                hash,
+                            );
                         } else {
                             queue.add(entry, handle);
                         }
@@ -648,7 +656,7 @@ impl RequestSubmitter {
                         log::info!("[tx from zero] mem block cycles limit reached, retry later");
 
                         for (entry, handle) in items {
-                            self.queue.add(entry, handle);
+                            queue.add(entry, handle);
                         }
                         continue;
                     }

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -508,7 +508,7 @@ impl RequestSubmitter {
             }
 
             // Update remained block cycles
-            org_cycles_pool.checked_sub_cycles(mem_pool.cycles_pool().cycles_used());
+            org_cycles_pool.consume_cycles(mem_pool.cycles_pool().cycles_used());
             *mem_pool.cycles_pool_mut() = org_cycles_pool;
         }
 
@@ -642,7 +642,7 @@ impl RequestSubmitter {
                     Ok(None) => Ok(()),
                     Err(err) => Err(err),
                 } {
-                    if let Some(TransactionError::BlockCyclesLimitReached { .. }) =
+                    if let Some(TransactionError::InsufficientPoolCycles { .. }) =
                         err.downcast_ref::<TransactionError>()
                     {
                         log::info!("[tx from zero] mem block cycles limit reached, retry later");
@@ -709,7 +709,7 @@ impl RequestSubmitter {
                     if let Err(err) = maybe_ok {
                         let hash: Byte32 = entry.item.hash().pack();
 
-                        if let Some(TransactionError::BlockCyclesLimitReached { .. }) =
+                        if let Some(TransactionError::InsufficientPoolCycles { .. }) =
                             err.downcast_ref::<TransactionError>()
                         {
                             log::info!("mem block cycles limit reached for tx {}", hash);

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -666,6 +666,9 @@ impl RequestSubmitter {
                         if !block_cycles_limit_reached
                             && entry.cycles_limit > mem_pool.cycles_pool().cycles()
                         {
+                            let hash: Byte32 = entry.item.hash().pack();
+                            log::info!("mem block cycles limit reached for tx {}", hash);
+
                             block_cycles_limit_reached = true;
                         }
 

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -557,7 +557,7 @@ impl RequestSubmitter {
                 match req_to_entry(fee_config, self.generator.clone(), req, &state, queue.len()) {
                     Ok(entry) => {
                         if entry.cycles_limit > self.mem_pool_config.mem_block.max_cycles_limit {
-                            log::error!("tx {} exceeded mem block max cycles limit, drop it", hash);
+                            log::info!("tx {} exceeded mem block max cycles limit, drop it", hash);
                         } else {
                             queue.add(entry, handle);
                         }
@@ -584,7 +584,7 @@ impl RequestSubmitter {
                 match req_to_entry(fee_config, self.generator.clone(), req, &state, queue.len()) {
                     Ok(entry) => {
                         if entry.cycles_limit > self.mem_pool_config.mem_block.max_cycles_limit {
-                            log::error!("tx {} exceeded mem block max cycles limit, drop it", hash);
+                            log::info!("tx {} exceeded mem block max cycles limit, drop it", hash);
                         } else {
                             queue.add(entry, handle);
                         }

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -640,7 +640,7 @@ impl RequestSubmitter {
                     Ok(None) => Ok(()),
                     Err(err) => Err(err),
                 } {
-                    if let Some(TransactionError::CyclesLimitReached { .. }) =
+                    if let Some(TransactionError::BlockCyclesLimitReached { .. }) =
                         err.downcast_ref::<TransactionError>()
                     {
                         log::info!("[tx from zero] mem block cycles limit reached, retry later");
@@ -707,7 +707,7 @@ impl RequestSubmitter {
                     if let Err(err) = maybe_ok {
                         let hash: Byte32 = entry.item.hash().pack();
 
-                        if let Some(TransactionError::CyclesLimitReached { .. }) =
+                        if let Some(TransactionError::BlockCyclesLimitReached { .. }) =
                             err.downcast_ref::<TransactionError>()
                         {
                             log::info!("mem block cycles limit reached for tx {}", hash);

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -203,6 +203,47 @@ impl TestChain {
         }
     }
 
+    pub async fn update_mem_pool_config(self, mut mem_pool_config: MemPoolConfig) -> Self {
+        let Self {
+            l1_committed_block_number,
+            rollup_type_script,
+            inner: chain,
+        } = self;
+
+        let rollup_config = chain.generator().rollup_context().rollup_config.to_owned();
+        let mut account_lock_manage = AccountLockManage::default();
+        account_lock_manage
+            .register_lock_algorithm((*ALWAYS_SUCCESS_CODE_HASH).into(), Box::new(AlwaysSuccess));
+        account_lock_manage.register_lock_algorithm(
+            (*ETH_ACCOUNT_LOCK_CODE_HASH).into(),
+            Box::new(Secp256k1Eth::default()),
+        );
+
+        let restore_path = {
+            let mem_pool = chain.mem_pool().as_ref().unwrap();
+            let mem_pool = mem_pool.lock().await;
+            mem_pool.restore_manager().path().to_path_buf()
+        };
+        mem_pool_config.restore_path = restore_path;
+
+        let mut inner = setup_chain_with_account_lock_manage(
+            rollup_type_script.clone(),
+            rollup_config,
+            account_lock_manage,
+            Some(chain.store().to_owned()),
+            Some(mem_pool_config),
+            None,
+        )
+        .await;
+        inner.complete_initial_syncing().await.unwrap();
+
+        Self {
+            l1_committed_block_number,
+            rollup_type_script,
+            inner,
+        }
+    }
+
     pub fn chain_id(&self) -> u64 {
         let config = &self.inner.generator().rollup_context().rollup_config;
         config.chain_id().unpack()

--- a/crates/tests/src/tests/rpc_server/execute_l2transaction.rs
+++ b/crates/tests/src/tests/rpc_server/execute_l2transaction.rs
@@ -19,6 +19,8 @@ use crate::testing_tool::{
     rpc_server::RPCServer,
 };
 
+pub mod block_max_cycles_limit;
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_polyjuice_erc20_tx() {
     let _ = env_logger::builder().is_test(true).try_init();

--- a/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
@@ -77,7 +77,7 @@ async fn test_block_max_cycles_limit() {
     let system_log = PolyjuiceSystemLog::parse_logs(logs).unwrap();
     assert_eq!(system_log.status_code, 0);
 
-    // Test TransactionError::BlockCyclesLimitReached
+    // Test TransactionError::ExceededBlockMaxCycles
     let mem_pool_config = MemPoolConfig {
         mem_block: MemBlockConfig {
             max_cycles_limit: 1000,
@@ -129,6 +129,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = "invalid exit code -1";
+    let expected_err = "Exceeded block max cycles limit";
     assert!(err.to_string().contains(expected_err));
 }

--- a/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
@@ -129,6 +129,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = "Exceeded block max cycles limit";
+    let expected_err = "Exceeded max block cycles";
     assert!(err.to_string().contains(expected_err));
 }

--- a/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
@@ -1,7 +1,6 @@
 use ckb_types::prelude::{Builder, Entity};
 use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, registry_address::RegistryAddress};
 use gw_config::{MemBlockConfig, MemPoolConfig};
-use gw_generator::error::TransactionError;
 use gw_types::{
     bytes::Bytes,
     packed::{RawL2Transaction, Script},
@@ -130,6 +129,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = TransactionError::BlockCyclesLimitReached { limit: 1000 };
-    assert!(err.to_string().contains(&expected_err.to_string()));
+    let expected_err = "invalid exit code -1";
+    assert!(err.to_string().contains(expected_err));
 }

--- a/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
@@ -1,0 +1,135 @@
+use ckb_types::prelude::{Builder, Entity};
+use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, registry_address::RegistryAddress};
+use gw_config::{MemBlockConfig, MemPoolConfig};
+use gw_generator::error::TransactionError;
+use gw_types::{
+    bytes::Bytes,
+    packed::{RawL2Transaction, Script},
+    prelude::{Pack, Unpack},
+};
+
+use crate::testing_tool::{
+    chain::TestChain,
+    eth_wallet::EthWallet,
+    polyjuice::{erc20::SudtErc20ArgsBuilder, PolyjuiceAccount, PolyjuiceSystemLog},
+    rpc_server::RPCServer,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_max_cycles_limit() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mem_pool_config = MemPoolConfig {
+        mem_block: MemBlockConfig {
+            max_cycles_limit: 200_0000,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let rollup_type_script = Script::default();
+    let mut chain = {
+        let chain = TestChain::setup(rollup_type_script).await;
+        chain.update_mem_pool_config(mem_pool_config.clone()).await
+    };
+    let rpc_server = {
+        let mut args = RPCServer::default_registry_args(
+            &chain.inner,
+            chain.rollup_type_script.to_owned(),
+            None,
+        );
+        args.mem_pool_config = mem_pool_config;
+        RPCServer::build_from_registry_args(args).await.unwrap()
+    };
+
+    // Check block producer is valid registry address
+    chain.produce_block(vec![], vec![]).await.unwrap();
+    let block_producer: Bytes = chain.last_valid_block().raw().block_producer().unpack();
+    assert!(RegistryAddress::from_slice(&block_producer).is_some());
+
+    let mem_pool_state = chain.mem_pool_state().await;
+    let snap = mem_pool_state.load();
+    let mut state = snap.state().unwrap();
+
+    let test_wallet = EthWallet::random(chain.rollup_type_hash());
+    let test_account_id = test_wallet
+        .create_account(&mut state, 1000000u128.into())
+        .unwrap();
+
+    let polyjuice_account = PolyjuiceAccount::create(chain.rollup_type_hash(), &mut state).unwrap();
+
+    state.submit_tree_to_mem_block();
+
+    // Deploy erc20 contract
+    let deploy_args = SudtErc20ArgsBuilder::deploy(CKB_SUDT_ACCOUNT_ID, 18).finish();
+    let raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(test_account_id.pack())
+        .to_id(polyjuice_account.id.pack())
+        .nonce(0u32.pack())
+        .args(deploy_args.pack())
+        .build();
+    let deploy_tx = test_wallet.sign_polyjuice_tx(&state, raw_tx).unwrap();
+
+    mem_pool_state.store(snap.into());
+    let run_result = rpc_server.execute_l2transaction(&deploy_tx).await.unwrap();
+
+    let logs = run_result.logs.into_iter().map(Into::into);
+    let system_log = PolyjuiceSystemLog::parse_logs(logs).unwrap();
+    assert_eq!(system_log.status_code, 0);
+
+    // Test TransactionError::CyclesLimitReached
+    let mem_pool_config = MemPoolConfig {
+        mem_block: MemBlockConfig {
+            max_cycles_limit: 1000,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let rollup_type_script = Script::default();
+    let chain = {
+        let chain = TestChain::setup(rollup_type_script).await;
+        chain.update_mem_pool_config(mem_pool_config.clone()).await
+    };
+    let rpc_server = {
+        let mut args = RPCServer::default_registry_args(
+            &chain.inner,
+            chain.rollup_type_script.to_owned(),
+            None,
+        );
+        args.mem_pool_config = mem_pool_config;
+        RPCServer::build_from_registry_args(args).await.unwrap()
+    };
+
+    let mem_pool_state = chain.mem_pool_state().await;
+    let snap = mem_pool_state.load();
+    let mut state = snap.state().unwrap();
+
+    let test_wallet = EthWallet::random(chain.rollup_type_hash());
+    let test_account_id = test_wallet
+        .create_account(&mut state, 1000000u128.into())
+        .unwrap();
+
+    let polyjuice_account = PolyjuiceAccount::create(chain.rollup_type_hash(), &mut state).unwrap();
+    state.submit_tree_to_mem_block();
+
+    let raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(test_account_id.pack())
+        .to_id(polyjuice_account.id.pack())
+        .nonce(0u32.pack())
+        .args(deploy_args.pack())
+        .build();
+    let deploy_tx = test_wallet.sign_polyjuice_tx(&state, raw_tx).unwrap();
+
+    mem_pool_state.store(snap.into());
+    let err = rpc_server
+        .execute_l2transaction(&deploy_tx)
+        .await
+        .unwrap_err();
+    eprintln!("err {}", err);
+
+    let expected_err = TransactionError::CyclesLimitReached { limit: 1000 };
+    assert!(err.to_string().contains(&expected_err.to_string()));
+}

--- a/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
@@ -78,7 +78,7 @@ async fn test_block_max_cycles_limit() {
     let system_log = PolyjuiceSystemLog::parse_logs(logs).unwrap();
     assert_eq!(system_log.status_code, 0);
 
-    // Test TransactionError::CyclesLimitReached
+    // Test TransactionError::BlockCyclesLimitReached
     let mem_pool_config = MemPoolConfig {
         mem_block: MemBlockConfig {
             max_cycles_limit: 1000,
@@ -130,6 +130,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = TransactionError::CyclesLimitReached { limit: 1000 };
+    let expected_err = TransactionError::BlockCyclesLimitReached { limit: 1000 };
     assert!(err.to_string().contains(&expected_err.to_string()));
 }

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction.rs
@@ -23,6 +23,8 @@ use crate::testing_tool::{
     rpc_server::RPCServer,
 };
 
+pub mod block_max_cycles_limit;
+
 const META_CONTRACT_ACCOUNT_ID: u32 = RESERVED_ACCOUNT_ID;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
@@ -1,0 +1,138 @@
+use ckb_types::prelude::{Builder, Entity};
+use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, registry_address::RegistryAddress};
+use gw_config::{MemBlockConfig, MemPoolConfig};
+use gw_generator::error::TransactionError;
+use gw_types::{
+    bytes::Bytes,
+    packed::{RawL2Transaction, Script},
+    prelude::{Pack, Unpack},
+};
+
+use crate::testing_tool::{
+    chain::TestChain,
+    eth_wallet::EthWallet,
+    polyjuice::{erc20::SudtErc20ArgsBuilder, PolyjuiceAccount, PolyjuiceSystemLog},
+    rpc_server::RPCServer,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_max_cycles_limit() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mem_pool_config = MemPoolConfig {
+        mem_block: MemBlockConfig {
+            max_cycles_limit: 200_0000,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let rollup_type_script = Script::default();
+    let mut chain = {
+        let chain = TestChain::setup(rollup_type_script).await;
+        chain.update_mem_pool_config(mem_pool_config.clone()).await
+    };
+    let rpc_server = {
+        let mut args = RPCServer::default_registry_args(
+            &chain.inner,
+            chain.rollup_type_script.to_owned(),
+            None,
+        );
+        args.mem_pool_config = mem_pool_config;
+        RPCServer::build_from_registry_args(args).await.unwrap()
+    };
+
+    // Check block producer is valid registry address
+    chain.produce_block(vec![], vec![]).await.unwrap();
+    let block_producer: Bytes = chain.last_valid_block().raw().block_producer().unpack();
+    assert!(RegistryAddress::from_slice(&block_producer).is_some());
+
+    let mem_pool_state = chain.mem_pool_state().await;
+    let snap = mem_pool_state.load();
+    let mut state = snap.state().unwrap();
+
+    let test_wallet = EthWallet::random(chain.rollup_type_hash());
+    let test_account_id = test_wallet
+        .create_account(&mut state, 1000000u128.into())
+        .unwrap();
+
+    let polyjuice_account = PolyjuiceAccount::create(chain.rollup_type_hash(), &mut state).unwrap();
+
+    state.submit_tree_to_mem_block();
+
+    // Deploy erc20 contract
+    let deploy_args = SudtErc20ArgsBuilder::deploy(CKB_SUDT_ACCOUNT_ID, 18).finish();
+    let raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(test_account_id.pack())
+        .to_id(polyjuice_account.id.pack())
+        .nonce(0u32.pack())
+        .args(deploy_args.pack())
+        .build();
+    let reg_addr_bytes = test_wallet.reg_address().to_bytes().into();
+
+    mem_pool_state.store(snap.into());
+    let run_result = rpc_server
+        .execute_raw_l2transaction(&raw_tx, None, Some(reg_addr_bytes))
+        .await
+        .unwrap();
+
+    let logs = run_result.logs.into_iter().map(Into::into);
+    let system_log = PolyjuiceSystemLog::parse_logs(logs).unwrap();
+    assert_eq!(system_log.status_code, 0);
+
+    // Test TransactionError::CyclesLimitReached
+    let mem_pool_config = MemPoolConfig {
+        mem_block: MemBlockConfig {
+            max_cycles_limit: 1000,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let rollup_type_script = Script::default();
+    let chain = {
+        let chain = TestChain::setup(rollup_type_script).await;
+        chain.update_mem_pool_config(mem_pool_config.clone()).await
+    };
+    let rpc_server = {
+        let mut args = RPCServer::default_registry_args(
+            &chain.inner,
+            chain.rollup_type_script.to_owned(),
+            None,
+        );
+        args.mem_pool_config = mem_pool_config;
+        RPCServer::build_from_registry_args(args).await.unwrap()
+    };
+
+    let mem_pool_state = chain.mem_pool_state().await;
+    let snap = mem_pool_state.load();
+    let mut state = snap.state().unwrap();
+
+    let test_wallet = EthWallet::random(chain.rollup_type_hash());
+    let test_account_id = test_wallet
+        .create_account(&mut state, 1000000u128.into())
+        .unwrap();
+
+    let polyjuice_account = PolyjuiceAccount::create(chain.rollup_type_hash(), &mut state).unwrap();
+    state.submit_tree_to_mem_block();
+
+    let raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(test_account_id.pack())
+        .to_id(polyjuice_account.id.pack())
+        .nonce(0u32.pack())
+        .args(deploy_args.pack())
+        .build();
+    let reg_addr_bytes = test_wallet.reg_address().to_bytes().into();
+
+    mem_pool_state.store(snap.into());
+    let err = rpc_server
+        .execute_raw_l2transaction(&raw_tx, None, Some(reg_addr_bytes))
+        .await
+        .unwrap_err();
+    eprintln!("err {}", err);
+
+    let expected_err = TransactionError::CyclesLimitReached { limit: 1000 };
+    assert!(err.to_string().contains(&expected_err.to_string()));
+}

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
@@ -1,7 +1,6 @@
 use ckb_types::prelude::{Builder, Entity};
 use gw_common::{builtins::CKB_SUDT_ACCOUNT_ID, registry_address::RegistryAddress};
 use gw_config::{MemBlockConfig, MemPoolConfig};
-use gw_generator::error::TransactionError;
 use gw_types::{
     bytes::Bytes,
     packed::{RawL2Transaction, Script},
@@ -133,6 +132,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = TransactionError::BlockCyclesLimitReached { limit: 1000 };
-    assert!(err.to_string().contains(&expected_err.to_string()));
+    let expected_err = "invalid exit code -1";
+    assert!(err.to_string().contains(expected_err));
 }

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
@@ -81,7 +81,7 @@ async fn test_block_max_cycles_limit() {
     let system_log = PolyjuiceSystemLog::parse_logs(logs).unwrap();
     assert_eq!(system_log.status_code, 0);
 
-    // Test TransactionError::CyclesLimitReached
+    // Test TransactionError::BlockCyclesLimitReached
     let mem_pool_config = MemPoolConfig {
         mem_block: MemBlockConfig {
             max_cycles_limit: 1000,
@@ -133,6 +133,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = TransactionError::CyclesLimitReached { limit: 1000 };
+    let expected_err = TransactionError::BlockCyclesLimitReached { limit: 1000 };
     assert!(err.to_string().contains(&expected_err.to_string()));
 }

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
@@ -80,7 +80,7 @@ async fn test_block_max_cycles_limit() {
     let system_log = PolyjuiceSystemLog::parse_logs(logs).unwrap();
     assert_eq!(system_log.status_code, 0);
 
-    // Test TransactionError::BlockCyclesLimitReached
+    // Test TransactionError::ExceededBlockMaxCycles
     let mem_pool_config = MemPoolConfig {
         mem_block: MemBlockConfig {
             max_cycles_limit: 1000,
@@ -132,6 +132,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = "invalid exit code -1";
+    let expected_err = "Exceeded block max cycles limit";
     assert!(err.to_string().contains(expected_err));
 }

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
@@ -132,6 +132,6 @@ async fn test_block_max_cycles_limit() {
         .unwrap_err();
     eprintln!("err {}", err);
 
-    let expected_err = "Exceeded block max cycles limit";
+    let expected_err = "Exceeded max block cycles";
     assert!(err.to_string().contains(expected_err));
 }

--- a/crates/tests/src/tests/rpc_server/submit_l2transaction.rs
+++ b/crates/tests/src/tests/rpc_server/submit_l2transaction.rs
@@ -22,6 +22,8 @@ use crate::testing_tool::{
     rpc_server::{wait_tx_committed, RPCServer},
 };
 
+pub mod block_max_cycles_limit;
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_polyjuice_erc20_tx() {
     let _ = env_logger::builder().is_test(true).try_init();

--- a/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
@@ -1,0 +1,212 @@
+use std::time::Duration;
+
+use ckb_types::prelude::{Builder, Entity};
+use gw_common::{
+    builtins::{CKB_SUDT_ACCOUNT_ID, ETH_REGISTRY_ACCOUNT_ID, RESERVED_ACCOUNT_ID},
+    state::State,
+    H256,
+};
+use gw_config::{MemBlockConfig, MemPoolConfig};
+use gw_generator::account_lock_manage::secp256k1::Secp256k1Eth;
+use gw_types::{
+    packed::{
+        CreateAccount, DepositRequest, Fee, L2Transaction, MetaContractArgs, RawL2Transaction,
+        Script,
+    },
+    prelude::Pack,
+};
+
+use crate::testing_tool::{
+    chain::TestChain,
+    eth_wallet::EthWallet,
+    polyjuice::{erc20::SudtErc20ArgsBuilder, PolyjuiceAccount, PolyjuiceSystemLog},
+    rpc_server::{wait_tx_committed, RPCServer},
+};
+
+const BLOCK_MAX_CYCLES_LIMIT: u64 = 200_0000;
+const META_CONTRACT_ACCOUNT_ID: u32 = RESERVED_ACCOUNT_ID;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_max_cycles_limit() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mem_pool_config = MemPoolConfig {
+        mem_block: MemBlockConfig {
+            max_cycles_limit: BLOCK_MAX_CYCLES_LIMIT,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let rollup_type_script = Script::default();
+    let mut chain = {
+        let chain = TestChain::setup(rollup_type_script).await;
+        chain.update_mem_pool_config(mem_pool_config).await
+    };
+    let rpc_server = RPCServer::build(&chain, None).await.unwrap();
+
+    // Deposit alice account and bob account
+    const DEPOSIT_CAPACITY: u64 = BLOCK_MAX_CYCLES_LIMIT * 10u64.pow(8);
+    let alice_wallet = EthWallet::random(chain.rollup_type_hash());
+    let bob_wallet = EthWallet::random(chain.rollup_type_hash());
+    let alice_deposit = DepositRequest::new_builder()
+        .capacity(DEPOSIT_CAPACITY.pack())
+        .sudt_script_hash(H256::zero().pack())
+        .amount(0.pack())
+        .script(alice_wallet.account_script().to_owned())
+        .registry_id(ETH_REGISTRY_ACCOUNT_ID.pack())
+        .build();
+    let bob_deposit = alice_deposit
+        .clone()
+        .as_builder()
+        .script(bob_wallet.account_script().to_owned())
+        .build();
+    chain
+        .produce_block(vec![alice_deposit, bob_deposit], vec![])
+        .await
+        .unwrap();
+
+    let mem_pool_state = chain.mem_pool_state().await;
+    let snap = mem_pool_state.load();
+    let state = snap.state().unwrap();
+
+    let alice_id = state
+        .get_account_id_by_script_hash(&alice_wallet.account_script_hash())
+        .unwrap()
+        .unwrap();
+    let bob_id = state
+        .get_account_id_by_script_hash(&bob_wallet.account_script_hash())
+        .unwrap()
+        .unwrap();
+
+    // Deploy polyjuice
+    let polyjuice_account = PolyjuiceAccount::build_script(chain.rollup_type_hash());
+    let meta_contract_script_hash = state.get_script_hash(META_CONTRACT_ACCOUNT_ID).unwrap();
+    let fee = Fee::new_builder()
+        .registry_id(ETH_REGISTRY_ACCOUNT_ID.pack())
+        .amount(0u128.pack())
+        .build();
+    let create_polyjuice = CreateAccount::new_builder()
+        .fee(fee)
+        .script(polyjuice_account.clone())
+        .build();
+    let args = MetaContractArgs::new_builder()
+        .set(create_polyjuice)
+        .build();
+    let raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(alice_id.pack())
+        .to_id(META_CONTRACT_ACCOUNT_ID.pack())
+        .nonce(0u32.pack())
+        .args(args.as_bytes().pack())
+        .build();
+
+    let signing_message = Secp256k1Eth::eip712_signing_message(
+        chain.chain_id(),
+        &raw_tx,
+        alice_wallet.reg_address().to_owned(),
+        meta_contract_script_hash,
+    )
+    .unwrap();
+    let sign = alice_wallet.sign_message(signing_message.into()).unwrap();
+
+    let deploy_tx = L2Transaction::new_builder()
+        .raw(raw_tx)
+        .signature(sign.pack())
+        .build();
+
+    {
+        let mut mem_pool = chain.mem_pool().await;
+        mem_pool.push_transaction(deploy_tx).await.unwrap();
+    }
+
+    // Refresh block cycles limit
+    chain.produce_block(vec![], vec![]).await.unwrap();
+
+    let snap = mem_pool_state.load();
+    let state = snap.state().unwrap();
+
+    // We will submit two txs, expect bob's tx to be packaged in next block due to
+    // block max cycles limit.
+    let polyjuice_account_id = state
+        .get_account_id_by_script_hash(&polyjuice_account.hash().into())
+        .unwrap()
+        .unwrap();
+
+    // Gas limit will be used as tx's cycles limit for polyjuice tx
+    // If cycles limit is bigger than block's remained cycles, then that tx will not be packaged.
+    let deploy_args = SudtErc20ArgsBuilder::deploy(CKB_SUDT_ACCOUNT_ID, 18)
+        .gas_limit(BLOCK_MAX_CYCLES_LIMIT - 1)
+        .gas_price(1)
+        .finish();
+
+    let alice_raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(alice_id.pack())
+        .to_id(polyjuice_account_id.pack())
+        .nonce(1u32.pack())
+        .args(deploy_args.pack())
+        .build();
+
+    let alice_deploy_tx = alice_wallet
+        .sign_polyjuice_tx(&state, alice_raw_tx.clone())
+        .unwrap();
+
+    let bob_deploy_gas_limit = BLOCK_MAX_CYCLES_LIMIT - 2;
+    let deploy_args = SudtErc20ArgsBuilder::deploy(CKB_SUDT_ACCOUNT_ID, 18)
+        .gas_limit(bob_deploy_gas_limit)
+        .gas_price(1)
+        .finish();
+
+    let bob_raw_tx = alice_raw_tx
+        .as_builder()
+        .from_id(bob_id.pack())
+        .nonce(0u32.pack())
+        .args(deploy_args.pack())
+        .build();
+
+    let bob_deploy_tx = bob_wallet.sign_polyjuice_tx(&state, bob_raw_tx).unwrap();
+
+    let alice_tx_hash = rpc_server
+        .submit_l2transaction(&alice_deploy_tx)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let bob_tx_hash = rpc_server
+        .submit_l2transaction(&bob_deploy_tx)
+        .await
+        .unwrap()
+        .unwrap();
+
+    wait_tx_committed(&chain, &alice_tx_hash, Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    let system_log = PolyjuiceSystemLog::parse_from_tx_hash(&chain, alice_tx_hash).unwrap();
+    assert_eq!(system_log.status_code, 0);
+
+    {
+        let mem_pool = chain.mem_pool().await;
+        let cycles = mem_pool.cycles_pool().cycles();
+        assert!(cycles < bob_deploy_gas_limit);
+    }
+
+    // Wait 5s, should timeout
+    wait_tx_committed(&chain, &bob_tx_hash, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+
+    let is_in_queue = rpc_server.is_request_in_queue(bob_tx_hash).await.unwrap();
+    assert!(is_in_queue);
+
+    // Produce a block to refresh mem block cycles
+    chain.produce_block(vec![], vec![]).await.unwrap();
+
+    wait_tx_committed(&chain, &bob_tx_hash, Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    let system_log = PolyjuiceSystemLog::parse_from_tx_hash(&chain, bob_tx_hash).unwrap();
+    assert_eq!(system_log.status_code, 0);
+}

--- a/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
@@ -196,7 +196,7 @@ async fn test_block_max_cycles_limit() {
         let err = mem_pool.push_transaction(bob_deploy_tx).await.unwrap_err();
         eprintln!("err {}", err);
 
-        let expected_err = "Block cycles limit reached";
+        let expected_err = "Insufficient pool cycles";
         assert!(err.to_string().contains(expected_err));
     }
 

--- a/crates/tests/src/tests/rpc_server/submit_withdrawal_request.rs
+++ b/crates/tests/src/tests/rpc_server/submit_withdrawal_request.rs
@@ -96,13 +96,15 @@ async fn test_submit_withdrawal_request() {
         .is_request_in_queue(withdrawal_hash)
         .await
         .unwrap();
-    assert!(is_in_queue);
 
-    chain.produce_block(vec![], vec![]).await.unwrap();
+    if !is_in_queue {
+        chain.produce_block(vec![], vec![withdrawal]).await.unwrap();
+    } else {
+        chain.produce_block(vec![], vec![]).await.unwrap();
+    }
 
     let snap = mem_pool_state.load();
     let state = snap.state().unwrap();
-
     let balance_after_withdrawal = state
         .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, test_wallet.reg_address())
         .unwrap();

--- a/crates/types/src/offchain/run_result.rs
+++ b/crates/types/src/offchain/run_result.rs
@@ -40,8 +40,6 @@ pub struct RunResult {
     pub get_scripts: HashMap<H256, Script>,
     // data hash -> data full size
     pub read_data: HashMap<H256, Bytes>,
-    // used cycles
-    pub used_cycles: u64,
     pub exit_code: i8,
     pub write: RunResultWriteState,
     pub cycles: RunResultCycles,

--- a/crates/types/src/offchain/run_result.rs
+++ b/crates/types/src/offchain/run_result.rs
@@ -20,6 +20,18 @@ pub struct RunResultWriteState {
     pub logs: Vec<LogItem>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunResultCycles {
+    pub execution: u64,
+    pub r#virtual: u64,
+}
+
+impl RunResultCycles {
+    pub fn total(&self) -> u64 {
+        self.execution.saturating_add(self.r#virtual)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RunResult {
     pub read_values: HashMap<H256, H256>,
@@ -32,6 +44,7 @@ pub struct RunResult {
     pub used_cycles: u64,
     pub exit_code: i8,
     pub write: RunResultWriteState,
+    pub cycles: RunResultCycles,
 }
 
 impl RunResult {


### PR DESCRIPTION
## Summary

This pr adds a new cycles limit `max_cycles_limit` to mem block. If mem pool's available cycles is not enough, transactions will be packaged in next block. If a transaction's cycles exceeded `max_cycles_limit`, it will be discarded.

## Motivation

A dynamic configurable way to manage number of block transaction.

## Specification

Split transaction's cycles into two parts: `execution cycles` and `virtual cycles`. Only syscalls listed in `SyscallCyclesConfig` contribute to transaction's `virtual cycles`.

### SyscallCyclesConfig

```rust
pub struct SyscallCyclesConfig {
    pub sys_store_cycles: u64,
    pub sys_load_cycles: u64,
    pub sys_create_cycles: u64,
    pub sys_load_account_script_cycles: u64,
    pub sys_store_data_cycles: u64,
    pub sys_load_data_cycles: u64,
    pub sys_get_block_hash_cycles: u64,
    pub sys_recover_account_cycles: u64,
    pub sys_log_cycles: u64,
}
```

## Different between `L2TX_MAX_CYCLES` and block `max_cycles_limit`

| L2TX_MAX_CYCLES  | Block max cycles limit |
| :---:    | :---:    |
| execution cycles  | execution cycles + virtual cycles  |
| failed transaction | discard | 


## Implementation

- new(config): add `max_cycles_limit` and `syscall_cycles: SyscallCyclesConfig` to `MemBlockConfig`
- feat(generator): `TransactionError::ExceededMaxBlockCycles` and `TransactionError::InsufficientPoolCycles`
- feat(rpc-server): stop package tx into mem block when mem pool reaches `max_cycles_limit`
- feat(rpc-server): discard tx if it's cycles limit exceed block `max_cycles_limit`
- feat(rpc-server): new `TransactionError::ExceededMaxBlockCycles` for `gw_execute_l2transacton` and `gw_execute_raw_l2transaction`