### PR TITLE
hotfix(rpc server): submit withdrawal missing data for `submit_tx`

### DIFF
--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -1283,6 +1283,7 @@ async fn submit_withdrawal_request(
 }
 
 // TODO: remove code after remove withdrawal cell
+#[allow(clippy::type_complexity)]
 #[instrument(skip_all)]
 async fn inner_submit_withdrawal_request(
     Params((withdrawal_request,)): Params<(JsonBytes,)>,
@@ -1941,6 +1942,7 @@ async fn get_mem_pool_state_ready(
 }
 
 // TODO: remove code after remove withdrawal cell
+#[allow(clippy::type_complexity)]
 #[instrument(skip_all)]
 async fn test_submit_withdrawal_request_finalized_custodian_unchecked(
     Params((withdrawal_request,)): Params<(JsonBytes,)>,

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -294,7 +294,7 @@ impl Registry {
             }))
             .with_data(Data::new(SubmitTransactionContext {
                 in_queue_request_map: self.in_queue_request_map.clone(),
-                submit_tx: self.submit_tx,
+                submit_tx: self.submit_tx.clone(),
                 mem_pool_state: self.mem_pool_state.clone(),
                 rate_limiter: send_transaction_rate_limiter,
                 rate_limit_config: self.send_tx_rate_limit,
@@ -313,6 +313,7 @@ impl Registry {
             .with_data(Data::new(self.consensus_config))
             .with_data(Data::new(self.node_mode))
             .with_data(Data::new(self.in_queue_request_map))
+            .with_data(Data::new(self.submit_tx))
             .with_method("gw_ping", ping)
             .with_method("gw_get_tip_block_hash", get_tip_block_hash)
             .with_method("gw_get_block_hash", get_block_hash)
@@ -1252,6 +1253,7 @@ async fn submit_l2transaction(
 }
 
 // TODO: refactor complex type.
+// Either `RPCContext` or derive?
 #[allow(clippy::type_complexity)]
 #[instrument(skip_all)]
 async fn submit_withdrawal_request(

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -385,7 +385,11 @@ impl Registry {
                     server = server
                         // .with_method("gw_dump_mem_block", dump_mem_block)
                         .with_method("gw_get_rocksdb_mem_stats", get_rocksdb_memory_stats)
-                        .with_method("gw_dump_jemalloc_profiling", dump_jemalloc_profiling);
+                        .with_method("gw_dump_jemalloc_profiling", dump_jemalloc_profiling)
+                        .with_method(
+                            "gw_submit_withdrawal_request_finalized_custodian_unchecked",
+                            test_submit_withdrawal_request_finalized_custodian_unchecked,
+                        );
                 }
             }
         }
@@ -1266,12 +1270,35 @@ async fn submit_withdrawal_request(
     ),
     rpc_client: Data<RPCClient>,
 ) -> Result<JsonH256, RpcError> {
+    inner_submit_withdrawal_request(
+        Params((withdrawal_request,)),
+        generator,
+        store,
+        in_queue_request_map,
+        submit_tx,
+        rpc_client,
+        true,
+    )
+    .await
+}
+
+// TODO: remove code after remove withdrawal cell
+#[instrument(skip_all)]
+async fn inner_submit_withdrawal_request(
+    Params((withdrawal_request,)): Params<(JsonBytes,)>,
+    generator: Data<Generator>,
+    store: Data<Store>,
+    in_queue_request_map: Data<Option<Arc<InQueueRequestMap>>>,
+    submit_tx: Data<mpsc::Sender<(InQueueRequestHandle, Request)>>,
+    rpc_client: Data<RPCClient>,
+    check_finalized_custodian: bool,
+) -> Result<JsonH256, RpcError> {
     let withdrawal_bytes = withdrawal_request.into_bytes();
     let withdrawal = packed::WithdrawalRequestExtra::from_slice(&withdrawal_bytes)?;
     let withdrawal_hash = withdrawal.hash();
 
     // verify finalized custodian
-    {
+    if check_finalized_custodian {
         let t = Instant::now();
         let finalized_custodians = {
             let db = store.get_snapshot();
@@ -1911,6 +1938,30 @@ async fn get_mem_pool_state_ready(
     mem_pool_state: Data<Arc<MemPoolState>>,
 ) -> Result<bool, RpcError> {
     Ok(mem_pool_state.completed_initial_syncing())
+}
+
+// TODO: remove code after remove withdrawal cell
+#[instrument(skip_all)]
+async fn test_submit_withdrawal_request_finalized_custodian_unchecked(
+    Params((withdrawal_request,)): Params<(JsonBytes,)>,
+    generator: Data<Generator>,
+    store: Data<Store>,
+    (in_queue_request_map, submit_tx): (
+        Data<Option<Arc<InQueueRequestMap>>>,
+        Data<mpsc::Sender<(InQueueRequestHandle, Request)>>,
+    ),
+    rpc_client: Data<RPCClient>,
+) -> Result<JsonH256, RpcError> {
+    inner_submit_withdrawal_request(
+        Params((withdrawal_request,)),
+        generator,
+        store,
+        in_queue_request_map,
+        submit_tx,
+        rpc_client,
+        false,
+    )
+    .await
 }
 
 async fn tests_produce_block(

--- a/crates/tests/src/tests/rpc_server/mod.rs
+++ b/crates/tests/src/tests/rpc_server/mod.rs
@@ -1,3 +1,4 @@
 pub mod execute_l2transaction;
 pub mod execute_raw_l2transaction;
 pub mod submit_l2transaction;
+pub mod submit_withdrawal_request;

--- a/crates/tests/src/tests/rpc_server/submit_withdrawal_request.rs
+++ b/crates/tests/src/tests/rpc_server/submit_withdrawal_request.rs
@@ -1,0 +1,114 @@
+use gw_common::{
+    builtins::{CKB_SUDT_ACCOUNT_ID, ETH_REGISTRY_ACCOUNT_ID},
+    ckb_decimal::CKBCapacity,
+    state::State,
+    H256,
+};
+use gw_generator::account_lock_manage::eip712::{self, traits::EIP712Encode};
+use gw_types::{
+    packed::{
+        DepositRequest, RawWithdrawalRequest, Script, WithdrawalRequest, WithdrawalRequestExtra,
+    },
+    prelude::{Builder, Entity, Pack},
+};
+
+use crate::testing_tool::{chain::TestChain, eth_wallet::EthWallet, rpc_server::RPCServer};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_withdrawal_request() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let rollup_type_script = Script::default();
+    let mut chain = TestChain::setup(rollup_type_script).await;
+    let rpc_server = RPCServer::build(&chain, None).await.unwrap();
+
+    // Deposit test account
+    const DEPOSIT_CAPACITY: u64 = 12345768 * 10u64.pow(8);
+    let test_wallet = EthWallet::random(chain.rollup_type_hash());
+    let deposit = DepositRequest::new_builder()
+        .capacity(DEPOSIT_CAPACITY.pack())
+        .sudt_script_hash(H256::zero().pack())
+        .amount(0.pack())
+        .script(test_wallet.account_script().to_owned())
+        .registry_id(ETH_REGISTRY_ACCOUNT_ID.pack())
+        .build();
+    chain.produce_block(vec![deposit], vec![]).await.unwrap();
+
+    let mem_pool_state = chain.mem_pool_state().await;
+    let snap = mem_pool_state.load();
+    let state = snap.state().unwrap();
+
+    let balance_before_withdrawal = state
+        .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, test_wallet.reg_address())
+        .unwrap();
+
+    const WITHDRAWAL_CAPACITY: u64 = 1000u64 * 10u64.pow(8);
+    let withdrawal = {
+        let raw = RawWithdrawalRequest::new_builder()
+            .chain_id(chain.chain_id().pack())
+            .capacity(WITHDRAWAL_CAPACITY.pack())
+            .amount(0.pack())
+            .account_script_hash(test_wallet.account_script_hash().pack())
+            .owner_lock_hash(test_wallet.account_script_hash().pack())
+            .registry_id(gw_common::builtins::ETH_REGISTRY_ACCOUNT_ID.pack())
+            .build();
+        let typed_withdrawal = eip712::types::Withdrawal::from_raw(
+            raw.clone(),
+            test_wallet.account_script().to_owned(),
+            test_wallet.registry_address.clone(),
+        )
+        .unwrap();
+        let domain_seperator = eip712::types::EIP712Domain {
+            name: "Godwoken".to_string(),
+            version: "1".to_string(),
+            chain_id: chain.chain_id(),
+            verifying_contract: None,
+            salt: None,
+        };
+        let message = typed_withdrawal.eip712_message(domain_seperator.hash_struct());
+        let sig = test_wallet.sign_message(message).unwrap();
+        let req = WithdrawalRequest::new_builder()
+            .raw(raw)
+            .signature(sig.pack())
+            .build();
+        WithdrawalRequestExtra::new_builder()
+            .request(req)
+            .owner_lock(test_wallet.account_script().to_owned())
+            .build()
+    };
+
+    // Expect `gw_submit_withdrawal_request` call finalized custodian check logic code
+    let err = rpc_server
+        .submit_withdrawal_request(&withdrawal)
+        .await
+        .unwrap_err();
+    eprintln!("submit withdrawal request {}", err);
+
+    // Expect rpc error since we don't configure valid rpc url
+    assert!(err.to_string().contains("get_cells error"));
+
+    let withdrawal_hash = rpc_server
+        .submit_withdrawal_request_finalized_custodian_unchecked(&withdrawal)
+        .await
+        .unwrap();
+
+    let is_in_queue = rpc_server
+        .is_request_in_queue(withdrawal_hash)
+        .await
+        .unwrap();
+    assert!(is_in_queue);
+
+    chain.produce_block(vec![], vec![]).await.unwrap();
+
+    let snap = mem_pool_state.load();
+    let state = snap.state().unwrap();
+
+    let balance_after_withdrawal = state
+        .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, test_wallet.reg_address())
+        .unwrap();
+
+    assert_eq!(
+        balance_before_withdrawal,
+        balance_after_withdrawal + CKBCapacity::from_layer1(WITHDRAWAL_CAPACITY).to_layer2()
+    );
+}


### PR DESCRIPTION
## **Change**
- fix(rpc-server): missing data for `Data<mpsc::Sender<(InQueueRequestHandle, Request)>>`
- feat(rpc-server): `gw_submit_withdrawal_request_finalized_custodian_unchecked` rpc method for test, enable by `RPCMethods::Test`
- refactor(rpc-server): `submit_withdrawal_request`, skip check finalized custodian for `gw_submit_withdrawal_request_finalized_custodian_unchecked`

## **Describe the bug**
`gw_submit_withdrawal_request` reuturn `Internal Error`

## **To Reproduce**
Steps to reproduce the behavior:
**cURL CMD:**
```bash
curl 'https://godwoken-testnet-v1.ckbapp.dev/' \
  -H 'content-type: application/json' \
  --data-raw '{"jsonrpc":"2.0","id":6745565,"method":"gw_submit_withdrawal_request","params":["0x400100000c000000f5000000e90000000c000000a400000011000000e91601000000000000e8764817000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000aea8e18bfd509331b6a6414c9335adfac35f0da8d474d3f8fa422cb6e54a7f0f02000000b585adc922e4861180d4afe1f919c0a21fa9fb810d9b892174a5f2a6a0b64d630000000000000000000000000000000041000000725987129d936f1d14716121fbd850514ece326b4e5950a96bea26873f88b1b212c96eae75569259fdf7226fe1413c269ba52d24affe136394c5ff7d406b77a61c4b00000010000000300000003100000079f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e011600000001d1667cbf1cc60da94c1cf6c9cfb261e71b6047f700"]}' \
  --compressed

# Result
{"jsonrpc":"2.0","id":6745565,"error":{"code":-32603,"message":"Internal Error"}}
```