### PR TITLE
fix `cargo test -p gw-tests`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,7 +4144,6 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab7883017d5b21f011ef8040ea9c6c7ac90834c0df26a69e4c0b06276151f125"
 dependencies = [
- "rand 0.6.5",
  "secp256k1-sys 0.4.2",
 ]
 

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -32,7 +32,7 @@ ckb-vm = { version = "=0.20.0-rc5", features = ["detect-asm"] }
 ckb-vm-definitions = "=0.20.0-rc5"
 thiserror = "1.0"
 lazy_static = "1.4"
-secp256k1 = { version = "0.21", features = ["recovery", "rand"] }
+secp256k1 = { version = "0.21", features = ["recovery"] }
 async-jsonrpc-client = { version = "0.3.0", default-features = false, features = ["http-tokio"] }
 sha3 = "0.9.1"
 hex = "0.4.2"

--- a/crates/tests/src/testing_tool/eth_wallet.rs
+++ b/crates/tests/src/testing_tool/eth_wallet.rs
@@ -17,7 +17,8 @@ use gw_types::{
     U256,
 };
 use gw_utils::wallet::{privkey_to_eth_account_script, Wallet};
-use secp256k1::{rand::rngs::OsRng, Secp256k1};
+use rand::{rngs::OsRng, Rng};
+use secp256k1::SecretKey;
 
 use crate::testing_tool::chain::ETH_ACCOUNT_LOCK_CODE_HASH;
 
@@ -28,11 +29,8 @@ pub struct EthWallet {
 
 impl EthWallet {
     pub fn random(rollup_script_hash: H256) -> Self {
-        let secp = Secp256k1::new();
-        let mut rng = OsRng::new().expect("OsRng");
-
         let privkey = {
-            let (sk, _public_key) = secp.generate_keypair(&mut rng);
+            let sk = SecretKey::from_slice(&OsRng.gen::<[u8; 32]>()).expect("generating SecretKey");
             Privkey::from_slice(&sk.serialize_secret())
         };
 


### PR DESCRIPTION
Currently `cargo test -p gw-tests` fails to compile because the `rand_os` feature of rand 0.6 is not enabled when compiling gw-tests alone. The fix is to use rand 0.8 directly instead of using rand 0.6 through secp256k1.