### PR TITLE
feat: add built-in liveness probe (/livez)

### DIFF
--- a/crates/block-producer/src/sync_l1.rs
+++ b/crates/block-producer/src/sync_l1.rs
@@ -13,7 +13,7 @@ use gw_types::{
     packed::{NumberHash, Script},
     prelude::*,
 };
-use gw_utils::exponential_backoff::ExponentialBackoff;
+use gw_utils::{exponential_backoff::ExponentialBackoff, liveness::Liveness};
 use tokio::sync::Mutex;
 
 use crate::chain_updater::ChainUpdater;
@@ -24,6 +24,7 @@ pub trait SyncL1Context {
     fn chain(&self) -> &Mutex<Chain>;
     fn chain_updater(&self) -> &ChainUpdater;
     fn rollup_type_script(&self) -> &Script;
+    fn liveness(&self) -> &Liveness;
 }
 
 /// Sync with L1.
@@ -160,6 +161,7 @@ async fn sync_l1_unknown(
                 rt_handle.block_on(async move { chain_updater.update_single(&tx.tx_hash).await })
             })
             .await??;
+            ctx.liveness().tick();
         }
     }
     if !reverted {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -21,6 +21,7 @@ pub enum Trace {
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     pub node_mode: NodeMode,
+    pub liveness_duration_secs: Option<u64>,
     #[serde(default)]
     pub contract_log_config: ContractLogConfig,
     pub backend_switches: Vec<BackendSwitchConfig>,

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod exponential_backoff;
 pub mod export_block;
 pub mod fee;
 pub mod genesis_info;
+pub mod liveness;
 pub mod local_cells;
 pub mod polyjuice_parser;
 mod query_rollup_cell;

--- a/crates/utils/src/liveness.rs
+++ b/crates/utils/src/liveness.rs
@@ -1,0 +1,26 @@
+use std::{
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+pub struct Liveness {
+    last_tick: Mutex<Instant>,
+    duration: Duration,
+}
+
+impl Liveness {
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            last_tick: Mutex::new(Instant::now()),
+            duration,
+        }
+    }
+
+    pub fn is_live(&self) -> bool {
+        self.last_tick.lock().unwrap().elapsed() < self.duration
+    }
+
+    pub fn tick(&self) {
+        *self.last_tick.lock().unwrap() = Instant::now();
+    }
+}


### PR DESCRIPTION
A node become not live if it hasn't produced, received, submitted or
confirmed a block in a while.