### PR TITLE
fix(mem-pool): fee queue use meta contract nonce for txs from id 0

### DIFF
--- a/crates/benches/benches/benchmarks/fee_queue.rs
+++ b/crates/benches/benches/benchmarks/fee_queue.rs
@@ -4,7 +4,7 @@ use gw_config::GenesisConfig;
 use gw_generator::genesis::init_genesis;
 use gw_mem_pool::fee::{
     queue::FeeQueue,
-    types::{FeeEntry, FeeItem},
+    types::{FeeEntry, FeeItem, FeeItemSender},
 };
 use gw_store::{
     mem_pool_state::MemStore, state::state_db::StateContext, traits::chain_store::ChainStore, Store,
@@ -47,7 +47,7 @@ fn bench_add_full(b: &mut Bencher) {
             ),
             fee: (100 * 1000u64).into(),
             cycles_limit: 1000,
-            sender: 2,
+            sender: FeeItemSender::AccountId(2),
             order: queue.len(),
         };
         queue.add(entry1, ());
@@ -68,7 +68,7 @@ fn bench_add_full(b: &mut Bencher) {
             ),
             fee: (100 * 1000u64).into(),
             cycles_limit: 1000,
-            sender: 2,
+            sender: FeeItemSender::AccountId(2),
             order: queue.len(),
         };
         queue.add(entry1, ());
@@ -104,7 +104,7 @@ fn bench_add_fetch_20(b: &mut Bencher) {
             ),
             fee: (100 * 1000u64).into(),
             cycles_limit: 1000,
-            sender: 2,
+            sender: FeeItemSender::AccountId(2),
             order: queue.len(),
         };
         queue.add(entry1, ());
@@ -127,7 +127,7 @@ fn bench_add_fetch_20(b: &mut Bencher) {
                 ),
                 fee: (100 * 1000u64).into(),
                 cycles_limit: 1000,
-                sender: 2,
+                sender: FeeItemSender::AccountId(2),
                 order: queue.len(),
             };
             queue.add(entry1, ());

--- a/crates/hash/src/blake2b.rs
+++ b/crates/hash/src/blake2b.rs
@@ -9,3 +9,12 @@ pub fn new_blake2b() -> Blake2b {
         .personal(CKB_PERSONALIZATION)
         .build()
 }
+
+pub fn hash(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = new_blake2b();
+    hasher.update(bytes);
+
+    let mut hash = [0u8; 32];
+    hasher.finalize(&mut hash);
+    hash
+}


### PR DESCRIPTION
Fee queue will increase nonce from same account id, but txs from id 0 always set nonce to 0. This cause multiple txs are incorrectly dropped during `fetch`.

In this pr, we separate txs from id 0 by their signature hash, and correctly increase their nonces.