### PR TITLE
refactor(generator): unchecked_execution_transaction and move it behind a feature gate

### DIFF
--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 default = ["detect-asm"]
 detect-asm = ["ckb-vm/detect-asm", "ckb-vm/aot"]
 enable-always-success-lock = []
+unhandled-execution = []
 
 [dependencies]
 gw-types = { path = "../types" }

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -1118,7 +1118,7 @@ impl MemPool {
 
         // execute tx
         let raw_tx = tx.raw();
-        let run_result = generator.unchecked_execute_transaction(
+        let run_result = generator.execute_transaction(
             &chain_view,
             state,
             block_info,

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -1054,7 +1054,7 @@ async fn execute_l2transaction(
         ctx.generator.check_transaction_signature(&state, &tx)?;
         // execute tx
         let raw_tx = tx.raw();
-        let run_result = ctx.generator.unchecked_execute_transaction(
+        let run_result = ctx.generator.execute_transaction(
             &chain_view,
             &state,
             &block_info,
@@ -1201,7 +1201,7 @@ async fn execute_raw_l2transaction(
                         .map_err(|err| anyhow!("check balance err {}", err))?;
                 }
 
-                ctx.generator.unchecked_execute_transaction(
+                ctx.generator.execute_transaction(
                     &chain_view,
                     &state,
                     &block_info,
@@ -1223,7 +1223,7 @@ async fn execute_raw_l2transaction(
                         .map_err(|err| anyhow!("check balance err {}", err))?;
                 }
 
-                ctx.generator.unchecked_execute_transaction(
+                ctx.generator.execute_transaction(
                     &chain_view,
                     &state,
                     &block_info,


### PR DESCRIPTION
For easily godwoken-scripts custom contracts test.  For example:
  - https://github.com/nervosnetwork/godwoken-scripts/blob/master/tests/src/script_tests/l2_scripts/examples.rs#L205

`unchecked_execute_transaction` and `execute_transaction` are identical. It also pays fee for failed tx. But for custom contract, which uses BackendType::Unknown, it always result in `Transaction::NoCost`.

Refactor `unchecked_execute_transaction` to `unhandled_execute_transaction`. It won't call `handle_run_result` and return origin `RunResult`.

Make this api behind `unhandled-execution` feature gate. 
