### PR TITLE
feat: add syscalls using Barreto-Naehrig (BN) curve construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,6 +1809,7 @@ dependencies = [
  "rlp",
  "secp256k1 0.20.3",
  "sha3",
+ "substrate-bn",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2619,6 +2620,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -4043,6 +4047,18 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "git+https://github.com/paritytech/bn.git?rev=63f8c58#63f8c587356a67b33c7396af98e065b66fca5dda"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
+]
 
 [[package]]
 name = "subtle"

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -571,7 +571,8 @@ pub struct SyscallCyclesConfig {
     pub sys_log_cycles: u64,
     pub sys_bn_add_cycles: u64,
     pub sys_bn_mul_cycles: u64,
-    pub sys_bn_pairing_cycles: u64,
+    pub sys_bn_fixed_pairing_cycles: u64,
+    pub sys_bn_per_pairing_cycles: u64,
 }
 
 impl SyscallCyclesConfig {
@@ -592,7 +593,8 @@ impl SyscallCyclesConfig {
             // see: https://eips.ethereum.org/EIPS/eip-1108
             sys_bn_add_cycles: 450,
             sys_bn_mul_cycles: 18_000,
-            sys_bn_pairing_cycles: 135_000,
+            sys_bn_fixed_pairing_cycles: 135_000,
+            sys_bn_per_pairing_cycles: 102_000,
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -577,15 +577,16 @@ pub struct SyscallCyclesConfig {
 impl SyscallCyclesConfig {
     pub fn default() -> Self {
         SyscallCyclesConfig {
-            sys_store_cycles: 0,
-            sys_load_cycles: 0,
-            sys_create_cycles: 0,
-            sys_load_account_script_cycles: 0,
-            sys_store_data_cycles: 0,
-            sys_load_data_cycles: 0,
-            sys_get_block_hash_cycles: 0,
-            sys_recover_account_cycles: 0,
-            sys_log_cycles: 0,
+            sys_store_cycles: 50000,
+            sys_load_cycles: 5000,
+            sys_create_cycles: 50000,
+            sys_load_account_script_cycles: 5000,
+            sys_store_data_cycles: 50000,
+            sys_load_data_cycles: 5000,
+            sys_get_block_hash_cycles: 50000,
+            sys_recover_account_cycles: 50000,
+            sys_log_cycles: 50000,
+
             // default cycles of BN operations
             // estimated_cycles = 3 * (Gas Cost of EIP-1108)
             // see: https://eips.ethereum.org/EIPS/eip-1108

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -398,7 +398,7 @@ const fn default_max_block_cycles_limit() -> u64 {
 }
 
 fn default_syscall_cycles() -> SyscallCyclesConfig {
-    SyscallCyclesConfig::all_zero()
+    SyscallCyclesConfig::default()
 }
 
 // Workaround: https://github.com/alexcrichton/toml-rs/issues/256
@@ -444,7 +444,7 @@ impl Default for MemBlockConfig {
             max_txs: 1000,
             deposit_timeout_config: Default::default(),
             max_cycles_limit: default_max_block_cycles_limit(),
-            syscall_cycles: SyscallCyclesConfig::all_zero(),
+            syscall_cycles: SyscallCyclesConfig::default(),
         }
     }
 }
@@ -569,10 +569,13 @@ pub struct SyscallCyclesConfig {
     pub sys_get_block_hash_cycles: u64,
     pub sys_recover_account_cycles: u64,
     pub sys_log_cycles: u64,
+    pub sys_bn_add_cycles: u64,
+    pub sys_bn_mul_cycles: u64,
+    pub sys_bn_pairing_cycles: u64,
 }
 
 impl SyscallCyclesConfig {
-    pub fn all_zero() -> Self {
+    pub fn default() -> Self {
         SyscallCyclesConfig {
             sys_store_cycles: 0,
             sys_load_cycles: 0,
@@ -583,6 +586,12 @@ impl SyscallCyclesConfig {
             sys_get_block_hash_cycles: 0,
             sys_recover_account_cycles: 0,
             sys_log_cycles: 0,
+            // default cycles of BN operations
+            // estimated_cycles = 3 * (Gas Cost of EIP-1108)
+            // see: https://eips.ethereum.org/EIPS/eip-1108
+            sys_bn_add_cycles: 450,
+            sys_bn_mul_cycles: 18_000,
+            sys_bn_pairing_cycles: 135_000,
         }
     }
 }

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 lazy_static = "1.4"
 rlp = "0.5.0"
 secp256k1 = { version = "0.20", features = ["recovery"] }
+substrate-bn = { git = "https://github.com/paritytech/bn.git", rev = "63f8c58" }
 sha3 = "0.9.1"
 log = "0.4"
 hex = "0.4"

--- a/crates/generator/src/syscalls/bn.rs
+++ b/crates/generator/src/syscalls/bn.rs
@@ -1,0 +1,125 @@
+/// https://github.com/Flouse/bn/tree/0.6.0
+use substrate_bn::{
+    arith::U256, pairing_batch, AffineG1, AffineG2, Fq, Fq2, Fr, Group, Gt, G1, G2,
+};
+
+pub struct Error(pub &'static str);
+
+fn read_pt(buf: &[u8]) -> Result<G1, Error> {
+    let px = Fq::from_slice(&buf[0..32]).map_err(|_| Error("invalid pt"))?;
+    let py = Fq::from_slice(&buf[32..64]).map_err(|_| Error("invalid pt"))?;
+    Ok(if px == Fq::zero() && py == Fq::zero() {
+        G1::zero()
+    } else {
+        AffineG1::new(px, py)
+            .map_err(|_| Error("invalid pt"))?
+            .into()
+    })
+}
+
+fn read_fr(buf: &[u8]) -> Result<Fr, Error> {
+    Fr::from_slice(buf).map_err(|_| Error("invalid fr"))
+}
+
+pub fn add(input: &[u8]) -> Result<[u8; 64], Error> {
+    let mut buffer = [0u8; 128];
+    if input.len() < 128 {
+        buffer[0..input.len()].copy_from_slice(input);
+    } else {
+        buffer[0..128].copy_from_slice(&input[0..128]);
+    }
+    let p1 = read_pt(&buffer[0..64])?;
+    let p2 = read_pt(&buffer[64..128])?;
+
+    let mut buffer = [0u8; 64];
+    if let Some(sum) = AffineG1::from_jacobian(p1 + p2) {
+        sum.x().to_big_endian(&mut buffer[0..32]).unwrap();
+        sum.y().to_big_endian(&mut buffer[32..64]).unwrap();
+    }
+    Ok(buffer)
+}
+
+pub fn mul(input: &[u8]) -> Result<[u8; 64], Error> {
+    let mut buffer = [0u8; 96];
+    if input.len() < 96 {
+        buffer[0..input.len()].copy_from_slice(input);
+    } else {
+        buffer[0..96].copy_from_slice(&input[0..96]);
+    }
+    let pt = read_pt(&buffer[0..64])?;
+    let fr = read_fr(&buffer[64..96])?;
+
+    let mut buffer = [0u8; 64];
+    if let Some(sum) = AffineG1::from_jacobian(pt * fr) {
+        sum.x().to_big_endian(&mut buffer[0..32]).unwrap();
+        sum.y().to_big_endian(&mut buffer[32..64]).unwrap();
+    }
+    Ok(buffer)
+}
+
+pub fn pairing(input: &[u8]) -> Result<[u8; 32], Error> {
+    if input.len() % 192 != 0 {
+        return Err(Error(
+            "Invalid input length, must be multiple of 192 (3 * (32*2))",
+        ));
+    }
+    let elements = input.len() / 192; // (a, b_a, b_b - each 64-byte affine coordinates)
+
+    let ret = if input.is_empty() {
+        U256::one()
+    } else {
+        let mut vals = Vec::with_capacity(elements);
+        for idx in 0..elements {
+            let a_x = Fq::from_slice(&input[idx * 192..idx * 192 + 32])
+                .map_err(|_| Error("Invalid a argument x coordinate"))?;
+
+            let a_y = Fq::from_slice(&input[idx * 192 + 32..idx * 192 + 64])
+                .map_err(|_| Error("Invalid a argument y coordinate"))?;
+
+            let b_a_y = Fq::from_slice(&input[idx * 192 + 64..idx * 192 + 96])
+                .map_err(|_| Error("Invalid b argument imaginary coeff x coordinate"))?;
+
+            let b_a_x = Fq::from_slice(&input[idx * 192 + 96..idx * 192 + 128])
+                .map_err(|_| Error("Invalid b argument imaginary coeff y coordinate"))?;
+
+            let b_b_y = Fq::from_slice(&input[idx * 192 + 128..idx * 192 + 160])
+                .map_err(|_| Error("Invalid b argument real coeff x coordinate"))?;
+
+            let b_b_x = Fq::from_slice(&input[idx * 192 + 160..idx * 192 + 192])
+                .map_err(|_| Error("Invalid b argument real coeff y coordinate"))?;
+
+            let b_a = Fq2::new(b_a_x, b_a_y);
+            let b_b = Fq2::new(b_b_x, b_b_y);
+            let b = if b_a.is_zero() && b_b.is_zero() {
+                G2::zero()
+            } else {
+                G2::from(
+                    AffineG2::new(b_a, b_b)
+                        .map_err(|_| Error("Invalid b argument - not on curve"))?,
+                )
+            };
+            let a = if a_x.is_zero() && a_y.is_zero() {
+                G1::zero()
+            } else {
+                G1::from(
+                    AffineG1::new(a_x, a_y)
+                        .map_err(|_| Error("Invalid a argument - not on curve"))?,
+                )
+            };
+            vals.push((a, b));
+        }
+
+        let mul = pairing_batch(vals.as_ref());
+
+        if mul == Gt::one() {
+            U256::one()
+        } else {
+            U256::zero()
+        }
+    };
+
+    let mut output = [0u8; 32];
+    ret.to_big_endian(&mut output)
+        .expect("Cannot fail since 0..32 is 32-byte length");
+    Ok(output)
+}

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -569,8 +569,8 @@ impl<'a, 'b, S: State, C: ChainView, Mac: SupportMachine> Syscalls<Mac>
                     let k: u64 = input_size / 192;
                     if k > 0 {
                         // Subtract additional cycles per pairing
-                        // https://eips.ethereum.org/EIPS/eip-1108
-                        let additional_cycles = k * 34000 * 3;
+                        let additional_cycles =
+                            k * cycles_pool.syscall_config().sys_bn_per_pairing_cycles;
                         self.result.cycles.r#virtual = self
                             .result
                             .cycles
@@ -723,7 +723,7 @@ impl<'a, 'b, S: State, C: ChainView> L2Syscalls<'a, 'b, S, C> {
             SYS_LOG => cycles_config.sys_log_cycles,
             SYS_BN_ADD => cycles_config.sys_bn_add_cycles,
             SYS_BN_MUL => cycles_config.sys_bn_mul_cycles,
-            SYS_BN_PAIRING => cycles_config.sys_bn_pairing_cycles,
+            SYS_BN_PAIRING => cycles_config.sys_bn_fixed_pairing_cycles,
             _ => 0,
         }
     }

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -708,7 +708,7 @@ impl MemPool {
             }
 
             // To simplify logic, don't restrict reinjected txs
-            self.cycles_pool = CyclesPool::new(u64::MAX, SyscallCyclesConfig::all_zero());
+            self.cycles_pool = CyclesPool::new(u64::MAX, SyscallCyclesConfig::default());
 
             self.prepare_next_mem_block(
                 &db,
@@ -1247,7 +1247,7 @@ impl MemPool {
             self.remove_unexecutables(&mut mem_state, &db)?;
 
             // reset cycles pool available cycles.
-            self.cycles_pool = CyclesPool::new(u64::MAX, SyscallCyclesConfig::all_zero());
+            self.cycles_pool = CyclesPool::new(u64::MAX, SyscallCyclesConfig::default());
 
             // prepare next mem block
             self.try_package_more_withdrawals(&mem_state, &mut withdrawals);

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -472,8 +472,7 @@ impl RequestSubmitter {
 
             // Use unlimit to ensure all exists mem pool transactions are included
             let mut org_cycles_pool = mem_pool.cycles_pool().clone();
-            *mem_pool.cycles_pool_mut() =
-                CyclesPool::new(u64::MAX, SyscallCyclesConfig::all_zero());
+            *mem_pool.cycles_pool_mut() = CyclesPool::new(u64::MAX, SyscallCyclesConfig::default());
 
             while let Some(hash) = mem_pool.pending_restored_tx_hashes().pop_front() {
                 match db.get_mem_pool_transaction(&hash) {

--- a/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_l2transaction/block_max_cycles_limit.rs
@@ -20,7 +20,7 @@ async fn test_block_max_cycles_limit() {
 
     let mem_pool_config = MemPoolConfig {
         mem_block: MemBlockConfig {
-            max_cycles_limit: 200_0000,
+            max_cycles_limit: crate::tests::rpc_server::BLOCK_MAX_CYCLES_LIMIT,
             ..Default::default()
         },
         ..Default::default()

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction/block_max_cycles_limit.rs
@@ -20,7 +20,7 @@ async fn test_block_max_cycles_limit() {
 
     let mem_pool_config = MemPoolConfig {
         mem_block: MemBlockConfig {
-            max_cycles_limit: 200_0000,
+            max_cycles_limit: crate::tests::rpc_server::BLOCK_MAX_CYCLES_LIMIT,
             ..Default::default()
         },
         ..Default::default()

--- a/crates/tests/src/tests/rpc_server/mod.rs
+++ b/crates/tests/src/tests/rpc_server/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) const BLOCK_MAX_CYCLES_LIMIT: u64 = 300_0000;
+
 pub mod execute_l2transaction;
 pub mod execute_raw_l2transaction;
 pub mod submit_l2transaction;

--- a/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
@@ -369,7 +369,8 @@ async fn test_block_max_cycles_limit() {
                 sys_log_cycles: MAX_CYCLES_LIMIT,
                 sys_bn_add_cycles: MAX_CYCLES_LIMIT,
                 sys_bn_mul_cycles: MAX_CYCLES_LIMIT,
-                sys_bn_pairing_cycles: MAX_CYCLES_LIMIT,
+                sys_bn_fixed_pairing_cycles: MAX_CYCLES_LIMIT,
+                sys_bn_per_pairing_cycles: MAX_CYCLES_LIMIT,
             },
             ..Default::default()
         },

--- a/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
@@ -19,14 +19,16 @@ use gw_types::{
     prelude::Pack,
 };
 
-use crate::testing_tool::{
-    chain::{into_deposit_info_cell, TestChain},
-    eth_wallet::EthWallet,
-    polyjuice::{erc20::SudtErc20ArgsBuilder, PolyjuiceAccount, PolyjuiceSystemLog},
-    rpc_server::{wait_tx_committed, RPCServer},
+use crate::{
+    testing_tool::{
+        chain::{into_deposit_info_cell, TestChain},
+        eth_wallet::EthWallet,
+        polyjuice::{erc20::SudtErc20ArgsBuilder, PolyjuiceAccount, PolyjuiceSystemLog},
+        rpc_server::{wait_tx_committed, RPCServer},
+    },
+    tests::rpc_server::BLOCK_MAX_CYCLES_LIMIT,
 };
 
-const BLOCK_MAX_CYCLES_LIMIT: u64 = 200_0000;
 const META_CONTRACT_ACCOUNT_ID: u32 = RESERVED_ACCOUNT_ID;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
+++ b/crates/tests/src/tests/rpc_server/submit_l2transaction/block_max_cycles_limit.rs
@@ -367,6 +367,9 @@ async fn test_block_max_cycles_limit() {
                 sys_get_block_hash_cycles: MAX_CYCLES_LIMIT,
                 sys_recover_account_cycles: MAX_CYCLES_LIMIT,
                 sys_log_cycles: MAX_CYCLES_LIMIT,
+                sys_bn_add_cycles: MAX_CYCLES_LIMIT,
+                sys_bn_mul_cycles: MAX_CYCLES_LIMIT,
+                sys_bn_pairing_cycles: MAX_CYCLES_LIMIT,
             },
             ..Default::default()
         },


### PR DESCRIPTION
Introduce a [pairing cryptography](https://en.wikipedia.org/wiki/Pairing-based_cryptography) library to provide [the functions](https://github.com/nervosnetwork/godwoken/blob/1b9de5231b0efdac1e56fd82a2d734dd8bbccf60/crates/generator/src/syscalls/bn.rs) of Barreto-Naehrig (BN) curve such as:

```rust
bn::add
bn::mul
bn::pairing
```
