### PR TITLE
fix: emit EVM_INTERNAL_ERROR(-1) if polyjuice failed to generate a system log

### DIFF
--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -765,6 +765,11 @@ impl Generator {
         raw_tx: &RawL2Transaction,
         mut run_result: RunResult,
     ) -> Result<RunResult, TransactionError> {
+        /// Error code represents EVM internal error
+        /// we emit this error from Godwoken side if
+        /// Polyjuice failed to generate a system log
+        const ERROR_EVM_INTERNAL: i32 = -1;
+
         let sender_id: u32 = raw_tx.from_id().unpack();
         let nonce_raw_key = build_account_field_key(sender_id, GW_ACCOUNT_NONCE_TYPE);
         let nonce_before = state.get_nonce(sender_id)?;
@@ -848,7 +853,7 @@ impl Generator {
                             gas,
                             gas,
                             Default::default(),
-                            0,
+                            ERROR_EVM_INTERNAL,
                         ));
                     }
                     let parser = tx.parser().ok_or(TransactionError::NoCost)?;

--- a/crates/utils/src/script_log.rs
+++ b/crates/utils/src/script_log.rs
@@ -235,7 +235,7 @@ pub fn generate_polyjuice_system_log(
     gas_used: u64,
     cumulative_gas_used: u64,
     created_address: [u8; 20],
-    status_code: u32,
+    status_code: i32,
 ) -> LogItem {
     let service_flag: u8 = GW_LOG_POLYJUICE_SYSTEM;
     let mut data = [0u8; 40];


### PR DESCRIPTION
This PR fixes the status code of EVM, the status code is changed from `0`(success) to `-1`(internal error) when polyjuice failed to generate a system log.

EVMC status code: https://github.com/ethereum/evmc/blob/649c66176ef5aa886441447c4bfee11600d8a512/include/evmc/evmc.h#L211

The status code of a tx neither affect the state tree or the block, so the change should be compatible.