### PR TITLE
[Draft] Bump ckb-vm to v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
  "ckb-logger",
  "ckb-traits",
  "ckb-types",
- "ckb-vm",
+ "ckb-vm 0.21.3",
  "faster-hex 0.6.1",
  "serde",
 ]
@@ -787,7 +787,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cc",
- "ckb-vm-definitions",
+ "ckb-vm-definitions 0.21.7",
  "derive_more",
  "goblin 0.2.3",
  "goblin 0.4.0",
@@ -799,10 +799,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-vm-definitions"
-version = "0.21.3"
+name = "ckb-vm"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7968c559498b68833791364e87182fdd1a3aba803e8a16c34b1aa45fc08add1c"
+checksum = "0f1126bf0240d100234bc06efa7020f0d50ca35fe90e5ac7cac1b7721e1bacb7"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "cc",
+ "ckb-vm-definitions 0.22.0",
+ "derive_more",
+ "goblin 0.2.3",
+ "goblin 0.4.0",
+ "rand 0.7.3",
+ "scroll",
+ "serde",
+]
+
+[[package]]
+name = "ckb-vm-aot"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d90662540a6a3b0d71e58d789016efe817d2cd0c4ec6b26bcaf7f9b18fe7cf"
+dependencies = [
+ "cc",
+ "ckb-vm 0.22.0",
+ "ckb-vm-definitions 0.22.0",
+ "derive_more",
+ "goblin 0.2.3",
+ "goblin 0.4.0",
+ "libc",
+ "memmap2",
+ "scroll",
+]
+
+[[package]]
+name = "ckb-vm-definitions"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7a838aab5ce5999add288511f719fa7af13e6790a5746f74d2538bbc47bb59"
+
+[[package]]
+name = "ckb-vm-definitions"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14739bf59648c169de9257ec7dd6aba1aeb6a41725d636005f1c91853df58fcc"
 
 [[package]]
 name = "clang-sys"
@@ -1794,7 +1835,8 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "blake2b-rs",
- "ckb-vm",
+ "ckb-vm 0.22.0",
+ "ckb-vm-aot",
  "ethabi",
  "gw-ckb-hardfork",
  "gw-common",
@@ -2037,8 +2079,9 @@ dependencies = [
  "ckb-script",
  "ckb-traits",
  "ckb-types",
- "ckb-vm",
- "ckb-vm-definitions",
+ "ckb-vm 0.22.0",
+ "ckb-vm-aot",
+ "ckb-vm-definitions 0.22.0",
  "env_logger",
  "godwoken-bin",
  "gw-block-producer",

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["detect-asm"]
-detect-asm = ["ckb-vm/detect-asm", "ckb-vm/aot"]
+default = []
 enable-always-success-lock = []
 
 [dependencies]
@@ -21,7 +20,8 @@ gw-ckb-hardfork = { path = "../ckb-hardfork" }
 gw-utils = { path = "../utils"}
 anyhow = "1.0"
 blake2b-rs = "0.2"
-ckb-vm = { version = "=0.21.3", features = ["detect-asm"] }
+ckb-vm = "0.22.0"
+ckb-vm-aot = "0.22.0"
 thiserror = "1.0"
 lazy_static = "1.4"
 rlp = "0.5.0"

--- a/crates/generator/build.rs
+++ b/crates/generator/build.rs
@@ -3,16 +3,7 @@ use std::env;
 fn main() {
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-    let is_windows = target_family == "windows";
-    let is_unix = target_family == "unix";
-    let is_x86_64 = target_arch == "x86_64";
-    let can_enable_asm = is_x86_64 && (is_windows || is_unix);
-
-    if cfg!(feature = "asm") && (!can_enable_asm) {
-        panic!("asm feature can only be enabled on x86_64 Linux, macOS and Windows platforms!");
-    }
-
-    if cfg!(any(feature = "asm", feature = "detect-asm")) && can_enable_asm {
-        println!("cargo:rustc-cfg=has_asm");
+    if target_arch == "x86_64" && (target_family == "windows" || target_family == "unix") {
+        println!("cargo:rustc-cfg=has_aot");
     }
 }

--- a/crates/generator/src/backend_manage.rs
+++ b/crates/generator/src/backend_manage.rs
@@ -4,7 +4,7 @@ use gw_config::{BackendConfig, BackendSwitchConfig, BackendType};
 use gw_types::bytes::Bytes;
 use std::{collections::HashMap, fs};
 
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 use crate::types::vm::AotCode;
 
 #[derive(Default, Clone)]
@@ -75,7 +75,7 @@ pub struct BackendManage {
     backend_switches: Vec<(u64, HashMap<H256, Backend>)>,
     /// define here not in backends,
     /// so we don't need to implement the trait `Clone` of AotCode
-    #[cfg(has_asm)]
+    #[cfg(has_aot)]
     aot_codes: (HashMap<H256, AotCode>, HashMap<H256, AotCode>),
 }
 
@@ -137,7 +137,7 @@ impl BackendManage {
                 validator,
                 generator,
             );
-            #[cfg(has_asm)]
+            #[cfg(has_aot)]
             if compile {
                 self.compile_backend(&backend);
             }
@@ -156,7 +156,7 @@ impl BackendManage {
         Ok(())
     }
 
-    #[cfg(has_asm)]
+    #[cfg(has_aot)]
     fn compile_backend(&mut self, backend: &Backend) {
         self.aot_codes.0.insert(
             backend.checksum.generator,
@@ -194,7 +194,7 @@ impl BackendManage {
             })
     }
 
-    #[cfg(has_asm)]
+    #[cfg(has_aot)]
     fn aot_compile(&self, code_bytes: &Bytes, vm_version: u32) -> Result<AotCode, ckb_vm::Error> {
         log::info!("Compile AotCode with VMVersion::V{}", vm_version);
         let vm_version = match vm_version {
@@ -202,7 +202,7 @@ impl BackendManage {
             1 => crate::types::vm::VMVersion::V1,
             ver => panic!("Unsupport VMVersion: {}", ver),
         };
-        let mut aot_machine = ckb_vm::machine::aot::AotCompilingMachine::load(
+        let mut aot_machine = ckb_vm_aot::AotCompilingMachine::load(
             code_bytes,
             Some(Box::new(crate::vm_cost_model::instruction_cycles)),
             vm_version.vm_isa(),
@@ -212,7 +212,7 @@ impl BackendManage {
     }
 
     /// get aot_code according to special VM version
-    #[cfg(has_asm)]
+    #[cfg(has_aot)]
     pub(crate) fn get_aot_code(&self, code_hash: &H256, vm_version: u32) -> Option<&AotCode> {
         log::debug!(
             "get_aot_code hash: {} version: {}",

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -51,7 +51,7 @@ use gw_types::{
 
 use ckb_vm::{DefaultMachineBuilder, SupportMachine};
 
-#[cfg(not(has_asm))]
+#[cfg(not(has_aot))]
 use ckb_vm::TraceMachine;
 use gw_utils::script_log::{generate_polyjuice_system_log, GW_LOG_POLYJUICE_SYSTEM};
 use tracing::instrument;
@@ -223,22 +223,22 @@ impl Generator {
                     cycles_pool: &mut cycles_pool,
                     log_buf: &mut sys_log_buf,
                 }))
-                .instruction_cycle_func(Box::new(instruction_cycles));
+                .instruction_cycle_func(&instruction_cycles);
             let default_machine = machine_builder.build();
 
-            #[cfg(has_asm)]
+            #[cfg(has_aot)]
             let aot_code_opt = self
                 .backend_manage
                 .get_aot_code(&backend.checksum.generator, global_vm_version);
-            #[cfg(has_asm)]
+            #[cfg(has_aot)]
             if aot_code_opt.is_none() {
                 log::warn!("[machine_run] Not AOT mode!");
             }
 
-            #[cfg(has_asm)]
-            let mut machine = ckb_vm::machine::asm::AsmMachine::new(default_machine, aot_code_opt);
+            #[cfg(has_aot)]
+            let mut machine = ckb_vm_aot::AotMachine::new(default_machine, aot_code_opt);
 
-            #[cfg(not(has_asm))]
+            #[cfg(not(has_aot))]
             let mut machine = TraceMachine::new(default_machine);
 
             machine.load_program(&backend.generator, &[])?;

--- a/crates/generator/src/types/vm.rs
+++ b/crates/generator/src/types/vm.rs
@@ -5,10 +5,10 @@ use ckb_vm::{
 use gw_types::packed::{ChallengeTarget, ChallengeWitness};
 use std::fmt::{self, Display};
 
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 use ckb_vm::machine::asm::AsmCoreMachine;
 
-#[cfg(not(has_asm))]
+#[cfg(not(has_aot))]
 use ckb_vm::{DefaultCoreMachine, SparseMemory, WXorXMemory};
 
 /// The type of CKB-VM ISA.
@@ -16,16 +16,16 @@ pub type VmIsa = u8;
 /// /// The type of CKB-VM version.
 pub type VmVersion = u32;
 
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub(crate) type CoreMachineType = AsmCoreMachine;
-#[cfg(not(has_asm))]
+#[cfg(not(has_aot))]
 pub(crate) type CoreMachineType = DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>;
 
 /// The type of core VM machine when uses ASM.
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub type CoreMachine = Box<AsmCoreMachine>;
 /// The type of core VM machine when doesn't use ASM.
-#[cfg(not(has_asm))]
+#[cfg(not(has_aot))]
 pub type CoreMachine = DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>;
 
 /// The version of CKB VM.
@@ -74,8 +74,8 @@ impl VMVersion {
     }
 }
 
-#[cfg(has_asm)]
-pub(crate) use ckb_vm::machine::asm::AotCode;
+#[cfg(has_aot)]
+pub(crate) use ckb_vm_aot::AotCode;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ChallengeContext {

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -27,8 +27,9 @@ gw-polyjuice-sender-recover = { path = "../polyjuice-sender-recover" }
 godwoken-bin = { path = "../godwoken-bin" }
 anyhow = "1.0"
 blake2b-rs = "0.2"
-ckb-vm = { version = "=0.21.3", features = ["detect-asm", "aot"] }
-ckb-vm-definitions = "=0.21.3"
+ckb-vm = "0.22.0"
+ckb-vm-aot = "0.22.0"
+ckb-vm-definitions = "0.22.0"
 thiserror = "1.0"
 lazy_static = "1.4"
 secp256k1 = { version = "0.21", features = ["recovery"] }


### PR DESCRIPTION
In ckb-vm v0.22.0, we removed the AOT mode code. Instead, we created a new repository: [nervosnetwork/ckb-vm-aot](https://github.com/nervosnetwork/ckb-vm-aot)

Since godwoken depends on ckb, it need to wait for [ckb](https://github.com/nervosnetwork/ckb/pull/3650) to update ckb-vm to v0.22.0 first.


