### PR TITLE
fix(rpc): don't return bad blocks

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -801,7 +801,9 @@ impl Chain {
                         let block = db
                             .get_bad_block(&current_block_hash)
                             .expect("rewind block should exists");
-
+                        // XXX: maybe the following two functions should be
+                        // merged into one function `detach_bad_block`.
+                        db.delete_bad_block(&current_block_hash)?;
                         db.rewind_block_smt(&block)?;
                         current_block_hash = block.raw().parent_block_hash().unpack();
                     }

--- a/crates/challenge/src/context.rs
+++ b/crates/challenge/src/context.rs
@@ -38,7 +38,7 @@ pub fn build_challenge_context(
 ) -> Result<ChallengeContext> {
     let block_hash: H256 = target.block_hash().unpack();
     let block = {
-        let opt_ = db.get_block(&block_hash)?;
+        let opt_ = db.get_bad_block(&block_hash);
         opt_.ok_or_else(|| anyhow!("bad block {} not found", hex::encode(block_hash.as_slice())))?
     };
 

--- a/crates/db/src/schema.rs
+++ b/crates/db/src/schema.rs
@@ -7,9 +7,18 @@ pub const COLUMNS: u32 = 37;
 /// Column store meta data
 pub const COLUMN_META: Col = 0;
 /// Column store chain index
+///
+/// Block number (little endian) -> Block hash, and
+/// block hash -> block number (little endian).
+///
+/// Only for valid blocks. Bad blocks are not indexed.
 pub const COLUMN_INDEX: Col = 1;
 /// Column store block
 pub const COLUMN_BLOCK: Col = 2;
+/// Column store bad blocks.
+///
+/// Block hash -> L2Block.
+pub const COLUMN_BAD_BLOCK: Col = 3;
 /// Column store block's global state
 pub const COLUMN_BLOCK_GLOBAL_STATE: Col = 4;
 /// Column store transaction
@@ -73,7 +82,8 @@ pub const COLUMN_BLOCK_POST_FINALIZED_CUSTODIAN_CAPACITY: Col = 36;
 
 /// chain id
 pub const META_CHAIN_ID_KEY: &[u8] = b"CHAIN_ID";
-/// META_TIP_BLOCK_HASH_KEY tracks the latest known best block hash
+/// META_TIP_BLOCK_HASH_KEY tracks the latest known block. It may be a bad block
+/// or a valid block.
 pub const META_TIP_BLOCK_HASH_KEY: &[u8] = b"TIP_BLOCK_HASH";
 /// block SMT root
 pub const META_BLOCK_SMT_ROOT_KEY: &[u8] = b"BLOCK_SMT_ROOT_KEY";

--- a/crates/store/src/transaction/store_transaction.rs
+++ b/crates/store/src/transaction/store_transaction.rs
@@ -397,6 +397,13 @@ impl StoreTransaction {
         Ok(())
     }
 
+    /// Delete bad block and block global state.
+    pub fn delete_bad_block(&self, block_hash: &H256) -> Result<(), Error> {
+        self.delete(COLUMN_BAD_BLOCK, block_hash.as_slice())?;
+        self.delete(COLUMN_BLOCK_GLOBAL_STATE, block_hash.as_slice())?;
+        Ok(())
+    }
+
     pub fn revert_bad_blocks(&self, bad_blocks: &[packed::L2Block]) -> Result<(), Error> {
         if bad_blocks.is_empty() {
             return Ok(());


### PR DESCRIPTION
Refactored store schema. Now bad blocks are not indexed and stored in a separate column.