### PR TITLE
Cherry pick inc ret data to 1.6-rc

### DIFF
--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -37,7 +37,7 @@ pub mod error_codes;
 
 /* Constants */
 // 25KB is max ethereum contract code size
-const MAX_SET_RETURN_DATA_SIZE: u64 = 1024 * 25;
+const MAX_SET_RETURN_DATA_SIZE: u64 = 1024 * 128;
 
 /* Syscall account store / load / create */
 const SYS_CREATE: u64 = 3100;

--- a/crates/generator/src/syscalls/mod.rs
+++ b/crates/generator/src/syscalls/mod.rs
@@ -36,7 +36,7 @@ use self::error_codes::{
 pub mod error_codes;
 
 /* Constants */
-// 25KB is max ethereum contract code size
+// Increasing from 25k(ethereum contract code size) to 128k.
 const MAX_SET_RETURN_DATA_SIZE: u64 = 1024 * 128;
 
 /* Syscall account store / load / create */


### PR DESCRIPTION
The size of the return data is increased. And this patch should be applied on v1.6.

## Ref
- https://github.com/godwokenrises/godwoken/pull/811