### PR TITLE
feat: add rewind-to-last-valid-block subcommand

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -338,7 +338,11 @@ impl Chain {
                         db.rollback()?;
 
                         let block_number = l2block.raw().number().unpack();
-                        log::warn!("bad block #{} found, rollback db", block_number,);
+                        log::warn!(
+                            "bad block #{} found, rollback db. If this is accidental, \
+                            you can rewind bad blocks with the rewind-to-last-valid-block subcommand",
+                            block_number
+                        );
 
                         db.insert_bad_block(&l2block, &global_state)?;
                         log::info!("insert bad block 0x{}", hex::encode(l2block.hash()));
@@ -807,6 +811,8 @@ impl Chain {
                             .expect("rewind block should exists");
 
                         db.rewind_block_smt(&block)?;
+                        // XXX: delete the bad block?
+                        db.delete_bad_block_challenge_target(&current_block_hash)?;
                         current_block_hash = block.raw().parent_block_hash().unpack();
                     }
                     assert_eq!(current_block_hash, last_valid_tip_block_hash);

--- a/crates/godwoken-bin/src/subcommand/mod.rs
+++ b/crates/godwoken-bin/src/subcommand/mod.rs
@@ -2,3 +2,4 @@ pub mod db_block_validator;
 pub mod export_block;
 pub mod import_block;
 pub mod peer_id;
+pub mod rewind_to_last_valid_block;

--- a/crates/godwoken-bin/src/subcommand/rewind_to_last_valid_block.rs
+++ b/crates/godwoken-bin/src/subcommand/rewind_to_last_valid_block.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use gw_block_producer::runner::BaseInitComponents;
+use gw_chain::chain::{Chain, RevertL1ActionContext, RevertedL1Action, SyncParam};
+use gw_store::traits::chain_store::ChainStore;
+
+pub const COMMAND_REWIND_TO_LAST_VALID_BLOCK: &str = "rewind-to-last-valid-block";
+
+/// Rewind to last valid block
+#[derive(Parser)]
+#[clap(name = COMMAND_REWIND_TO_LAST_VALID_BLOCK)]
+pub struct RewindToLastValidBlockCommand {
+    /// The config file path
+    #[clap(short, long, default_value = "./config.toml")]
+    config_path: PathBuf,
+}
+
+impl RewindToLastValidBlockCommand {
+    pub async fn run(self) -> Result<()> {
+        let content = std::fs::read(&self.config_path).with_context(|| {
+            format!(
+                "read config file from {}",
+                self.config_path.to_string_lossy()
+            )
+        })?;
+        let config = toml::from_slice(&content).context("parse config file")?;
+        let base = BaseInitComponents::init(&config, true).await?;
+        let store = base.store.clone();
+        let mut chain = Chain::create(
+            &base.rollup_config,
+            &base.rollup_type_script,
+            &config.chain,
+            base.store,
+            base.generator,
+            None,
+        )?;
+        let last_valid_tip_block_hash = store.get_last_valid_tip_block_hash()?;
+        let last_valid_tip_post_global_state = store
+            .get_block_post_global_state(&last_valid_tip_block_hash)?
+            .context("last valid tip post global state not found")?;
+        let rewind_to_last_valid_tip = RevertedL1Action {
+            prev_global_state: last_valid_tip_post_global_state,
+            context: RevertL1ActionContext::RewindToLastValidTip,
+        };
+
+        let param = SyncParam {
+            reverts: vec![rewind_to_last_valid_tip],
+            updates: vec![],
+        };
+        chain.sync(param).await?;
+
+        Ok(())
+    }
+}

--- a/crates/store/src/transaction/store_transaction.rs
+++ b/crates/store/src/transaction/store_transaction.rs
@@ -102,6 +102,10 @@ impl StoreTransaction {
         )
     }
 
+    pub fn delete_bad_block_challenge_target(&self, block_hash: &H256) -> Result<(), Error> {
+        self.delete(COLUMN_BAD_BLOCK_CHALLENGE_TARGET, block_hash.as_slice())
+    }
+
     pub fn set_reverted_block_hashes(
         &self,
         reverted_block_smt_root: &H256,


### PR DESCRIPTION
Godwoken node operators can use this command to rewind the chain to the last valid block if the node has encountered some bad blocks accidentally due to e.g. version/configuration differences.

Challenge targets for these blocks are also removed, so these blocks can be validated again.

A reference for this command is added to the log message generated when inserting the first bad block.