### PR TITLE
Perform basic verification on tx before submit in queue

### DIFF
--- a/crates/config/src/constants.rs
+++ b/crates/config/src/constants.rs
@@ -3,9 +3,9 @@ pub const MAX_TX_SIZE: usize = 50_000;
 /// MAX withdrawal size 50 KB
 pub const MAX_WITHDRAWAL_SIZE: usize = 50_000;
 // 25 KB
-pub const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25 * 1024;
+pub const MAX_WRITE_DATA_BYTES: usize = 25 * 1024;
 // 2MB
-pub const MAX_TOTAL_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
+pub const MAX_TOTAL_READ_DATA_BYTES: usize = 1024 * 1024 * 2;
 /// Max cycles of a layer2 transaction
 pub const L2TX_MAX_CYCLES_150M: u64 = 150_000_000;
 /// Max cycles of a layer2 transaction

--- a/crates/config/src/constants.rs
+++ b/crates/config/src/constants.rs
@@ -5,7 +5,7 @@ pub const MAX_WITHDRAWAL_SIZE: usize = 50_000;
 // 25 KB
 pub const MAX_WRITE_DATA_BYTES_LIMIT: usize = 25 * 1024;
 // 2MB
-pub const MAX_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
+pub const MAX_TOTAL_READ_DATA_BYTES_LIMIT: usize = 1024 * 1024 * 2;
 /// Max cycles of a layer2 transaction
 pub const L2TX_MAX_CYCLES_150M: u64 = 150_000_000;
 /// Max cycles of a layer2 transaction

--- a/crates/config/src/fork_config.rs
+++ b/crates/config/src/fork_config.rs
@@ -4,8 +4,8 @@ use ckb_fixed_hash::H256;
 use serde::{Deserialize, Serialize};
 
 use crate::constants::{
-    L2TX_MAX_CYCLES_150M, L2TX_MAX_CYCLES_500M, MAX_TOTAL_READ_DATA_BYTES_LIMIT, MAX_TX_SIZE,
-    MAX_WITHDRAWAL_SIZE, MAX_WRITE_DATA_BYTES_LIMIT,
+    L2TX_MAX_CYCLES_150M, L2TX_MAX_CYCLES_500M, MAX_TOTAL_READ_DATA_BYTES, MAX_TX_SIZE,
+    MAX_WITHDRAWAL_SIZE, MAX_WRITE_DATA_BYTES,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -64,11 +64,11 @@ impl ForkConfig {
     }
 
     pub fn max_write_data_bytes(&self, _block_number: u64) -> usize {
-        MAX_WRITE_DATA_BYTES_LIMIT
+        MAX_WRITE_DATA_BYTES
     }
 
     pub fn max_total_read_data_bytes(&self, _block_number: u64) -> usize {
-        MAX_TOTAL_READ_DATA_BYTES_LIMIT
+        MAX_TOTAL_READ_DATA_BYTES
     }
 }
 

--- a/crates/config/src/fork_config.rs
+++ b/crates/config/src/fork_config.rs
@@ -4,7 +4,7 @@ use ckb_fixed_hash::H256;
 use serde::{Deserialize, Serialize};
 
 use crate::constants::{
-    L2TX_MAX_CYCLES_150M, L2TX_MAX_CYCLES_500M, MAX_READ_DATA_BYTES_LIMIT, MAX_TX_SIZE,
+    L2TX_MAX_CYCLES_150M, L2TX_MAX_CYCLES_500M, MAX_TOTAL_READ_DATA_BYTES_LIMIT, MAX_TX_SIZE,
     MAX_WITHDRAWAL_SIZE, MAX_WRITE_DATA_BYTES_LIMIT,
 };
 
@@ -67,8 +67,8 @@ impl ForkConfig {
         MAX_WRITE_DATA_BYTES_LIMIT
     }
 
-    pub fn max_read_data_bytes(&self, _block_number: u64) -> usize {
-        MAX_READ_DATA_BYTES_LIMIT
+    pub fn max_total_read_data_bytes(&self, _block_number: u64) -> usize {
+        MAX_TOTAL_READ_DATA_BYTES_LIMIT
     }
 }
 

--- a/crates/generator/src/error.rs
+++ b/crates/generator/src/error.rs
@@ -134,8 +134,8 @@ pub enum TransactionError {
     State(StateError),
     #[error("can't find backend for script_hash {script_hash:?}")]
     BackendNotFound { script_hash: H256 },
-    #[error("Exceeded maximum read data: max bytes {max_bytes}, readed bytes {used_bytes}")]
-    ExceededMaxReadData { max_bytes: usize, used_bytes: usize },
+    #[error("Exceeded maximum total read data: max bytes {max_bytes}, readed bytes {used_bytes}")]
+    ExceededMaxTotalReadData { max_bytes: usize, used_bytes: usize },
     #[error("Exceeded maximum write data: max bytes {max_bytes}, writen bytes {used_bytes}")]
     ExceededMaxWriteData { max_bytes: usize, used_bytes: usize },
     #[error("Cannot create sUDT proxy contract from account id: {account_id}.")]

--- a/crates/generator/src/generator.rs
+++ b/crates/generator/src/generator.rs
@@ -801,10 +801,10 @@ impl Generator {
             .into());
         }
         // check read data bytes
-        let max_read_data_bytes = self
+        let max_total_read_data_bytes = self
             .rollup_context
             .fork_config
-            .max_read_data_bytes(block_number);
+            .max_total_read_data_bytes(block_number);
         let read_data_bytes: usize = state_tracker
             .read_data()
             .lock()
@@ -812,9 +812,9 @@ impl Generator {
             .values()
             .map(Bytes::len)
             .sum();
-        if read_data_bytes > max_read_data_bytes {
-            return Err(TransactionError::ExceededMaxReadData {
-                max_bytes: max_read_data_bytes,
+        if read_data_bytes > max_total_read_data_bytes {
+            return Err(TransactionError::ExceededMaxTotalReadData {
+                max_bytes: max_total_read_data_bytes,
                 used_bytes: read_data_bytes,
             }
             .into());

--- a/crates/rpc-server/src/registry.rs
+++ b/crates/rpc-server/src/registry.rs
@@ -138,6 +138,7 @@ pub struct ExecutionTransactionContext {
 
 pub struct SubmitTransactionContext {
     in_queue_request_map: Option<Arc<InQueueRequestMap>>,
+    generator: Arc<Generator>,
     submit_tx: mpsc::Sender<(InQueueRequestHandle, Request)>,
     mem_pool_state: Arc<MemPoolState>,
     rate_limiter: Option<SendTransactionRateLimiter>,
@@ -286,6 +287,7 @@ impl Registry {
             .with_data(Data::new(SubmitTransactionContext {
                 in_queue_request_map: self.in_queue_request_map.clone(),
                 submit_tx: self.submit_tx.clone(),
+                generator: self.generator.clone(),
                 mem_pool_state: self.mem_pool_state.clone(),
                 rate_limiter: send_transaction_rate_limiter,
                 rate_limit_config: self.send_tx_rate_limit,
@@ -1076,7 +1078,12 @@ async fn execute_l2transaction(
 
         Result::<_, anyhow::Error>::Ok(run_result)
     })
-    .await??;
+    .await?
+    .map_err(|err| RpcError::Full {
+        code: INVALID_REQUEST,
+        message: err.to_string(),
+        data: None,
+    })?;
 
     if run_result.exit_code != 0 {
         let receipt = gw_types::offchain::ErrorTxReceipt {
@@ -1309,6 +1316,33 @@ async fn submit_l2transaction(
             }
         }
         rate_limiter.put(sender_id, Instant::now());
+    }
+
+    // TODO use TransactionVerifier after remove sender auto creator
+    // verify tx size
+    {
+        // block info
+        let block_info = ctx
+            .mem_pool_state
+            .load_shared()
+            .mem_block
+            .expect("mem block info");
+        // check tx size
+        let max_tx_size = ctx
+            .generator
+            .fork_config()
+            .max_tx_size(block_info.number().unpack());
+        if tx.as_slice().len() > max_tx_size {
+            let err = TransactionError::ExceededMaxTxSize {
+                max_size: max_tx_size,
+                tx_size: tx.as_slice().len(),
+            };
+            return Err(RpcError::Full {
+                code: INVALID_REQUEST,
+                message: err.to_string(),
+                data: None,
+            });
+        }
     }
 
     // check sender's nonce

--- a/docs/known_caveats_of_polyjuice.md
+++ b/docs/known_caveats_of_polyjuice.md
@@ -28,3 +28,15 @@ Ethereum differs in the processing of ERC20 tokens, and native ETH tokens. This 
 
 Whether you use a native CKB or any sUDT token type, they will all be represented in Godwoken as a layer2 sUDT type. Polyjuice starts from this layer2 sUDT [contract](https://github.com/nervosnetwork/godwoken-polyjuice/blob/b9c3ad4/solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.sol) and ensures that all the tokens on Godwoken are in compliance with the ERC20 standard, no matter if they are backed by a native CKB or a sUDT. This means you don't need to distinguish between native token and ERC20 tokens. All you have to deal with is the same ERC20 interface for all different tokens.
 
+## Additional limitations
+
+To prevent the DOS and make it easy to perform a challenge on-chain, Godwoken runtime set some additional limitations when verifying a tx:
+
+1. Max transaction size - Max tx size is 50KB, the size is calculated in Godwoken tx format, so it is slightly different from the Ethereum RLP encoded format.
+2. Max withdrawal size - Max withdrawal size is 50KB.
+3. Max transaction cycles - Max tx cycles is 500M, and Godwoken runs EVM in the CKB-VM. Besides the gas limit, we also set a cycle limit on the CKB-VM.
+4. Max write data - Max write data limit the data size per write to 25 KB.
+5. Max total read data - 2M, total read data in a single transaction.
+6. Max return data - the return data of a transaction is limited to 128KB
+
+These restrictions aim to prevent DOS attacks, and normal transactions shouldn't be affected. If you are running a normal transaction call and get into trouble with these limitations, please open an issue to the project.


### PR DESCRIPTION
1. Verify the tx size in RPC.
2. Add a document of additional limitations of Godwoken runtime.
3. Rename `MAX_READ_DATA_BYTES_LIMIT `