### PR TITLE
feat(mem-pool): auto-create accounts for native pCKB transfer recipients

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -6,11 +6,14 @@ pub mod error;
 pub mod h256_ext;
 pub mod merkle_utils;
 pub mod registry;
-pub mod registry_address;
 pub mod smt;
 pub mod state;
 #[cfg(test)]
 pub mod test_traits;
+
+pub mod registry_address {
+    pub use gw_types::registry_address::RegistryAddress;
+}
 
 // re-exports
 

--- a/crates/mem-pool/src/account_creator.rs
+++ b/crates/mem-pool/src/account_creator.rs
@@ -1,0 +1,218 @@
+use anyhow::{anyhow, bail, Result};
+
+use gw_common::{
+    builtins::{CKB_SUDT_ACCOUNT_ID, ETH_REGISTRY_ACCOUNT_ID, RESERVED_ACCOUNT_ID},
+    ckb_decimal::CKBCapacity,
+    registry_address::RegistryAddress,
+    state::State,
+    H256,
+};
+use gw_generator::account_lock_manage::secp256k1::Secp256k1Eth;
+use gw_types::{
+    core::{AllowedEoaType, ScriptHashType},
+    packed::{
+        BatchCreateEthAccounts, Fee, L2Transaction, LogItemReader, MetaContractArgs,
+        RawL2Transaction, Script, ScriptVec,
+    },
+    prelude::{Builder, Entity, Pack, Reader, Unpack},
+    U256,
+};
+use gw_utils::{
+    script_log::{parse_log, GwLog, GW_LOG_SUDT_TRANSFER},
+    wallet::Wallet,
+    RollupContext,
+};
+use tracing::instrument;
+
+const META_CONTRACT_ACCOUNT_ID: u32 = RESERVED_ACCOUNT_ID;
+const ONE_CKB: u64 = 10u64.pow(8);
+pub const MIN_BALANCE: u64 = ONE_CKB;
+
+pub struct CkbTransfer;
+
+impl CkbTransfer {
+    pub fn filter_new_address<'a>(
+        logs: impl IntoIterator<Item = LogItemReader<'a>>,
+        state: &impl State,
+    ) -> Option<Vec<RegistryAddress>> {
+        let do_filter = |log: LogItemReader<'_>| -> Result<Option<RegistryAddress>> {
+            if !matches!(log.service_flag().into(), GW_LOG_SUDT_TRANSFER)
+                || !matches!(log.account_id().unpack(), CKB_SUDT_ACCOUNT_ID)
+            {
+                return Ok(None);
+            }
+
+            let to = match parse_log(&log.to_entity())? {
+                GwLog::SudtTransfer { to_address, .. } => to_address,
+                _ => return Ok(None),
+            };
+
+            if state.get_script_hash_by_registry_address(&to)?.is_some() {
+                return Ok(None);
+            }
+
+            let min_balance: U256 = CKBCapacity::from_layer1(MIN_BALANCE).to_layer2();
+            let to_balance = state.get_sudt_balance(CKB_SUDT_ACCOUNT_ID, &to)?;
+            if to_balance < min_balance {
+                tracing::info!("new address {:?} balance less than {}", to, min_balance);
+                return Ok(None);
+            }
+
+            Ok(Some(to))
+        };
+
+        let filtered = logs.into_iter().filter_map(|log| match do_filter(log) {
+            Err(err) => {
+                tracing::error!("parse log {}", err);
+                None
+            }
+            Ok(new) => new,
+        });
+
+        let new: Vec<_> = filtered.collect();
+        if new.is_empty() {
+            None
+        } else {
+            Some(new)
+        }
+    }
+}
+
+pub struct AccountCreator {
+    pub chain_id: u64,
+    pub rollup_script_hash: H256,
+    pub eth_lock_code_hash: H256,
+    pub creator_script_hash: H256,
+    pub creator_wallet: Wallet,
+}
+
+impl AccountCreator {
+    pub const MAX_CREATE_ACCOUNTS_PER_BATCH: usize = 50;
+
+    pub fn create(rollup_context: &RollupContext, creator_wallet: Wallet) -> Result<Self> {
+        let chain_id = rollup_context.rollup_config.chain_id().unpack();
+        let rollup_script_hash = rollup_context.rollup_script_hash;
+        let eth_lock_code_hash = {
+            let allowed_eoa_type_hashes = rollup_context.rollup_config.allowed_eoa_type_hashes();
+            { allowed_eoa_type_hashes.as_reader().iter() }
+                .find_map(|type_hash| {
+                    if type_hash.type_().to_entity() == AllowedEoaType::Eth.into() {
+                        Some(type_hash.hash().unpack())
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_else(|| anyhow!("eth lock code hash not found"))?
+        };
+
+        let creator_script_hash = {
+            let s = creator_wallet.eth_lock_script(&rollup_script_hash, &eth_lock_code_hash)?;
+            s.hash().into()
+        };
+
+        let creator = Self {
+            chain_id,
+            rollup_script_hash,
+            eth_lock_code_hash,
+            creator_script_hash,
+            creator_wallet,
+        };
+
+        Ok(creator)
+    }
+
+    #[instrument(skip_all)]
+    pub fn build_batch_create_tx<'a>(
+        &'a self,
+        state: &'a impl State,
+        addresses: impl IntoIterator<Item = RegistryAddress>,
+    ) -> Result<Option<(L2Transaction, Vec<RegistryAddress>)>> {
+        let creator_account_id = state
+            .get_account_id_by_script_hash(&self.creator_script_hash)?
+            .ok_or_else(|| anyhow!("creator account id not found"))?;
+
+        let creator_registry_address = match state.get_registry_address_by_script_hash(
+            ETH_REGISTRY_ACCOUNT_ID,
+            &self.creator_script_hash,
+        )? {
+            Some(addr) => addr,
+            None => bail!("creator eth registry address not found"),
+        };
+
+        let nonce = state.get_nonce(creator_account_id)?;
+        let meta_contract_script_hash = state.get_script_hash(META_CONTRACT_ACCOUNT_ID)?;
+
+        let new_addrs: Vec<_> = {
+            addresses.into_iter().filter_map(|addr| {
+                match state.get_script_hash_by_registry_address(&addr) {
+                    Ok(None) => Some(addr),
+                    Ok(Some(_)) => None,
+                    Err(err) => {
+                        tracing::error!("query address {:?} script hash error {}", addr, err);
+                        None
+                    }
+                }
+            })
+        }
+        .collect();
+
+        let create_accounts = { new_addrs.iter() }
+            .take(Self::MAX_CREATE_ACCOUNTS_PER_BATCH)
+            .collect::<Vec<_>>();
+        if create_accounts.is_empty() {
+            return Ok(None);
+        }
+        tracing::info!("create account {:?}", create_accounts);
+
+        let create_accounts = { create_accounts.into_iter() }
+            .map(|a| self.to_account_script(&a))
+            .collect::<Vec<_>>();
+        let next_batch = { new_addrs.into_iter() }
+            .skip(Self::MAX_CREATE_ACCOUNTS_PER_BATCH)
+            .collect::<Vec<_>>();
+
+        let fee = Fee::new_builder()
+            .registry_id(ETH_REGISTRY_ACCOUNT_ID.pack())
+            .amount(0u128.pack())
+            .build();
+        let batch_create = BatchCreateEthAccounts::new_builder()
+            .fee(fee)
+            .scripts(ScriptVec::new_builder().set(create_accounts).build())
+            .build();
+        let args = MetaContractArgs::new_builder().set(batch_create).build();
+
+        let raw_l2tx = RawL2Transaction::new_builder()
+            .chain_id(self.chain_id.pack())
+            .from_id(creator_account_id.pack())
+            .to_id(META_CONTRACT_ACCOUNT_ID.pack())
+            .nonce(nonce.pack())
+            .args(args.as_bytes().pack())
+            .build();
+
+        let signing_message = Secp256k1Eth::eip712_signing_message(
+            self.chain_id,
+            &raw_l2tx,
+            creator_registry_address,
+            meta_contract_script_hash,
+        )?;
+        let sign = self.creator_wallet.sign_message(signing_message.into())?;
+
+        let tx = L2Transaction::new_builder()
+            .raw(raw_l2tx)
+            .signature(sign.pack())
+            .build();
+
+        Ok(Some((tx, next_batch)))
+    }
+
+    fn to_account_script(&self, registry_address: &RegistryAddress) -> Script {
+        let mut args = self.rollup_script_hash.as_slice().to_vec();
+        args.extend_from_slice(&registry_address.address);
+
+        Script::new_builder()
+            .code_hash(self.eth_lock_code_hash.pack())
+            .hash_type(ScriptHashType::Type.into())
+            .args(args.pack())
+            .build()
+    }
+}

--- a/crates/mem-pool/src/account_creator.rs
+++ b/crates/mem-pool/src/account_creator.rs
@@ -165,7 +165,7 @@ impl AccountCreator {
         tracing::info!("create account {:?}", create_accounts);
 
         let create_accounts = { create_accounts.into_iter() }
-            .map(|a| self.to_account_script(&a))
+            .map(|a| self.to_account_script(a))
             .collect::<Vec<_>>();
         let next_batch = { new_addrs.into_iter() }
             .skip(Self::MAX_CREATE_ACCOUNTS_PER_BATCH)

--- a/crates/mem-pool/src/lib.rs
+++ b/crates/mem-pool/src/lib.rs
@@ -3,6 +3,7 @@
 //! MemPool only do basic verification on l2transactions & withdrawal requests,
 //! the block producer need to verify the fully verification itself.
 
+pub mod account_creator;
 pub mod block_sync_server;
 mod constants;
 pub mod custodian;

--- a/crates/mem-pool/src/mem_block.rs
+++ b/crates/mem-pool/src/mem_block.rs
@@ -94,9 +94,9 @@ impl MemBlock {
         self.prev_merkle_state = tip.raw().post_account();
         // mem block content
         let content = MemBlockContent {
-            txs: self.txs.clone(),
-            withdrawals: self.withdrawals.clone(),
-            new_addresses: self.new_addresses.drain().collect(),
+            txs: std::mem::take(&mut self.txs),
+            withdrawals: std::mem::take(&mut self.withdrawals),
+            new_addresses: std::mem::take(&mut self.new_addresses),
         };
         // reset status
         self.clear();

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -52,7 +52,7 @@ use tokio::task::block_in_place;
 use tracing::instrument;
 
 use crate::{
-    account_creator::{AccountCreator, CkbTransfer},
+    account_creator::{filter_new_address, AccountCreator},
     block_sync_server::BlockSyncServerState,
     mem_block::MemBlock,
     restore_manager::RestoreManager,
@@ -344,7 +344,7 @@ impl MemPool {
         // save new addresses
         if self.account_creator.is_some() {
             let logs = tx_receipt.as_reader().logs();
-            if let Some(new_addresses) = CkbTransfer::filter_new_address(logs.iter(), state) {
+            if let Some(new_addresses) = filter_new_address(logs.iter(), state) {
                 self.mem_block.append_new_addresses(new_addresses);
             }
         }

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -521,6 +521,7 @@ pub async fn setup_chain_with_account_lock_manage(
         node_mode: gw_config::NodeMode::FullNode,
         dynamic_config_manager: Default::default(),
         sync_server: None,
+        account_creator: None,
     };
     let mem_pool = MemPool::create(args).await.unwrap();
     Chain::create(

--- a/crates/tests/src/tests/mem_pool_ckb_transfer_create_new_recipient_account.rs
+++ b/crates/tests/src/tests/mem_pool_ckb_transfer_create_new_recipient_account.rs
@@ -1,0 +1,190 @@
+use ckb_types::prelude::{Builder, Entity};
+use gw_common::{
+    builtins::{CKB_SUDT_ACCOUNT_ID, ETH_REGISTRY_ACCOUNT_ID, RESERVED_ACCOUNT_ID},
+    ckb_decimal::CKBCapacity,
+    registry_address::RegistryAddress,
+    state::State,
+    H256,
+};
+use gw_generator::account_lock_manage::secp256k1::Secp256k1Eth;
+use gw_mem_pool::account_creator::{AccountCreator, MIN_BALANCE};
+use gw_types::{
+    bytes::Bytes,
+    packed::{
+        CreateAccount, DepositInfoVec, DepositRequest, Fee, L2Transaction, MetaContractArgs,
+        RawL2Transaction, Script,
+    },
+    prelude::{Pack, Unpack},
+    U256,
+};
+
+use crate::testing_tool::{
+    chain::{into_deposit_info_cell, TestChain},
+    eth_wallet::EthWallet,
+    polyjuice::{erc20::SudtErc20ArgsBuilder, PolyjuiceAccount, PolyjuiceSystemLog},
+};
+
+const META_CONTRACT_ACCOUNT_ID: u32 = RESERVED_ACCOUNT_ID;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_create_account_for_ckb_transfer_new_address_recipient() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let rollup_type_script = Script::default();
+    let mut chain = TestChain::setup(rollup_type_script).await;
+
+    // Deposit test account
+    let test_wallet = EthWallet::random(chain.rollup_type_hash());
+    let deposit = DepositRequest::new_builder()
+        .capacity((MIN_BALANCE * 1000).pack())
+        .sudt_script_hash(H256::zero().pack())
+        .amount(0.pack())
+        .script(test_wallet.account_script().to_owned())
+        .registry_id(ETH_REGISTRY_ACCOUNT_ID.pack())
+        .build();
+    let deposit_info_vec = DepositInfoVec::new_builder()
+        .push(into_deposit_info_cell(chain.inner.generator().rollup_context(), deposit).pack())
+        .build();
+    chain.produce_block(deposit_info_vec, vec![]).await.unwrap();
+
+    let block_producer: Bytes = chain.last_valid_block().raw().block_producer().unpack();
+    assert!(RegistryAddress::from_slice(&block_producer).is_some());
+
+    let mem_pool_state = chain.mem_pool_state().await;
+    let state = mem_pool_state.load_state_db();
+
+    let test_account_id = state
+        .get_account_id_by_script_hash(&test_wallet.account_script_hash())
+        .unwrap()
+        .unwrap();
+
+    // Deploy polyjuice
+    let polyjuice_account = PolyjuiceAccount::build_script(chain.rollup_type_hash());
+    let meta_contract_script_hash = state.get_script_hash(META_CONTRACT_ACCOUNT_ID).unwrap();
+    let fee = Fee::new_builder()
+        .registry_id(ETH_REGISTRY_ACCOUNT_ID.pack())
+        .amount(0u128.pack())
+        .build();
+    let create_polyjuice = CreateAccount::new_builder()
+        .fee(fee)
+        .script(polyjuice_account.clone())
+        .build();
+    let args = MetaContractArgs::new_builder()
+        .set(create_polyjuice)
+        .build();
+
+    let raw_l2tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(test_account_id.pack())
+        .to_id(META_CONTRACT_ACCOUNT_ID.pack())
+        .nonce(0u32.pack())
+        .args(args.as_bytes().pack())
+        .build();
+
+    let signing_message = Secp256k1Eth::eip712_signing_message(
+        chain.chain_id(),
+        &raw_l2tx,
+        test_wallet.reg_address().to_owned(),
+        meta_contract_script_hash,
+    )
+    .unwrap();
+    let sign = test_wallet.sign_message(signing_message.into()).unwrap();
+
+    let deploy_tx = L2Transaction::new_builder()
+        .raw(raw_l2tx)
+        .signature(sign.pack())
+        .build();
+    {
+        let mut mem_pool = chain.mem_pool().await;
+        mem_pool.push_transaction(deploy_tx).unwrap();
+    }
+
+    let state = mem_pool_state.load_state_db();
+
+    // Depoly erc20 contract
+    let polyjuice_account_id = state
+        .get_account_id_by_script_hash(&polyjuice_account.hash().into())
+        .unwrap()
+        .unwrap();
+    let deploy_args = SudtErc20ArgsBuilder::deploy(CKB_SUDT_ACCOUNT_ID, 18).finish();
+    let raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(test_account_id.pack())
+        .to_id(polyjuice_account_id.pack())
+        .nonce(1u32.pack())
+        .args(deploy_args.pack())
+        .build();
+
+    let deploy_tx = test_wallet.sign_polyjuice_tx(&state, raw_tx).unwrap();
+    let deploy_tx_hash: H256 = deploy_tx.hash().into();
+
+    {
+        let mut mem_pool = chain.mem_pool().await;
+        mem_pool.push_transaction(deploy_tx).unwrap();
+    }
+
+    let system_log = PolyjuiceSystemLog::parse_from_tx_hash(&chain, deploy_tx_hash).unwrap();
+    assert_eq!(system_log.status_code, 0);
+
+    let state = mem_pool_state.load_state_db();
+
+    let erc20_contract_account_id = system_log.contract_account_id(&state).unwrap();
+    let erc20_contract_script_hash = state.get_script_hash(erc20_contract_account_id).unwrap();
+    assert!(!erc20_contract_script_hash.is_zero());
+
+    let to_wallet = EthWallet::random(chain.rollup_type_hash());
+    let amount: U256 = CKBCapacity::from_layer1(MIN_BALANCE).to_layer2();
+
+    let transfer_args = SudtErc20ArgsBuilder::transfer(to_wallet.reg_address(), amount).finish();
+    let raw_tx = RawL2Transaction::new_builder()
+        .chain_id(chain.chain_id().pack())
+        .from_id(test_account_id.pack())
+        .to_id(erc20_contract_account_id.pack())
+        .nonce(2u32.pack())
+        .args(transfer_args.pack())
+        .build();
+
+    let transfer_tx = test_wallet.sign_polyjuice_tx(&state, raw_tx).unwrap();
+    let account_creator =
+        AccountCreator::create(chain.inner.generator().rollup_context(), test_wallet.inner)
+            .unwrap();
+    {
+        let mut mem_pool = chain.mem_pool().await;
+        mem_pool.set_account_creator(account_creator);
+        mem_pool.push_transaction(transfer_tx).unwrap();
+    }
+
+    let system_log = PolyjuiceSystemLog::parse_from_tx_hash(&chain, deploy_tx_hash).unwrap();
+    assert_eq!(system_log.status_code, 0);
+
+    let state = mem_pool_state.load_state_db();
+
+    let balance = state
+        .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_wallet.reg_address())
+        .unwrap();
+    assert_eq!(balance, amount);
+
+    let account_non_exists = state
+        .get_script_hash_by_registry_address(to_wallet.reg_address())
+        .unwrap()
+        .is_none();
+    assert!(account_non_exists);
+
+    chain
+        .produce_block(Default::default(), vec![])
+        .await
+        .unwrap();
+
+    let state = mem_pool_state.load_state_db();
+
+    let balance = state
+        .get_sudt_balance(CKB_SUDT_ACCOUNT_ID, to_wallet.reg_address())
+        .unwrap();
+    assert_eq!(balance, amount);
+
+    let account_exists = state
+        .get_script_hash_by_registry_address(to_wallet.reg_address())
+        .unwrap()
+        .is_some();
+    assert!(account_exists);
+}

--- a/crates/tests/src/tests/mod.rs
+++ b/crates/tests/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod chain;
 mod deposit_withdrawal;
 mod export_import_block;
 mod mem_block_repackage;
+mod mem_pool_ckb_transfer_create_new_recipient_account;
 mod meta_contract_args;
 mod polyjuice_sender_recover;
 mod restore_mem_block;

--- a/crates/types/schemas/mem_block.mol
+++ b/crates/types/schemas/mem_block.mol
@@ -34,7 +34,21 @@ table FinalizedCustodianCapacity {
 
 vector AccountMerkleStateVec <AccountMerkleState>;
 
+table RegistryAddress {
+    registry_id: Uint32,
+    address: Bytes,
+}
+
+vector RegistryAddressVec <RegistryAddress>;
+
 table CompactMemBlock {
+    txs: Byte32Vec,
+    withdrawals: Byte32Vec,
+    deposits: DepositInfoVec,
+    new_addresses: RegistryAddressVec,
+}
+
+table DeprecatedCompactMemBlock {
     txs: Byte32Vec,
     withdrawals: Byte32Vec,
     deposits: DepositInfoVec,

--- a/crates/types/src/conversion/mem_block.rs
+++ b/crates/types/src/conversion/mem_block.rs
@@ -1,6 +1,7 @@
 use sparse_merkle_tree::H256;
 
 use crate::offchain::{CellInfo, DepositInfo, FinalizedCustodianCapacity, SudtCustodian};
+use crate::registry_address::RegistryAddress;
 use crate::{packed, prelude::*, vec::Vec};
 
 impl Pack<packed::CellInfo> for CellInfo {
@@ -98,9 +99,32 @@ impl<'r> Unpack<FinalizedCustodianCapacity> for packed::FinalizedCustodianCapaci
     }
 }
 
+impl Pack<packed::RegistryAddress> for RegistryAddress {
+    fn pack(&self) -> packed::RegistryAddress {
+        packed::RegistryAddress::new_builder()
+            .registry_id(self.registry_id.pack())
+            .address(self.address.pack())
+            .build()
+    }
+}
+
+impl<'r> Unpack<RegistryAddress> for packed::RegistryAddressReader<'r> {
+    fn unpack(&self) -> RegistryAddress {
+        RegistryAddress {
+            registry_id: self.registry_id().unpack(),
+            address: self.address().unpack(),
+        }
+    }
+}
+
 impl_conversion_for_packed_iterator_pack!(AccountMerkleState, AccountMerkleStateVec);
 impl_conversion_for_vector!(DepositInfo, DepositInfoVec, DepositInfoVecReader);
 impl_conversion_for_vector!(SudtCustodian, SudtCustodianVec, SudtCustodianVecReader);
 impl_conversion_for_packed_iterator_pack!(WithdrawalRequestExtra, WithdrawalRequestExtraVec);
 impl_conversion_for_packed_iterator_pack!(DepositInfo, DepositInfoVec);
 impl_conversion_for_option!(H256, Byte32Opt, Byte32OptReader);
+impl_conversion_for_vector!(
+    RegistryAddress,
+    RegistryAddressVec,
+    RegistryAddressVecReader
+);

--- a/crates/types/src/generated/mem_block.rs
+++ b/crates/types/src/generated/mem_block.rs
@@ -2732,6 +2732,607 @@ impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for AccountMerkleStateVecReader
     }
 }
 #[derive(Clone)]
+pub struct RegistryAddress(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for RegistryAddress {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for RegistryAddress {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for RegistryAddress {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "registry_id", self.registry_id())?;
+        write!(f, ", {}: {}", "address", self.address())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for RegistryAddress {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            20, 0, 0, 0, 12, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        RegistryAddress::new_unchecked(v.into())
+    }
+}
+impl RegistryAddress {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn registry_id(&self) -> Uint32 {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint32::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn address(&self) -> Bytes {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            Bytes::new_unchecked(self.0.slice(start..end))
+        } else {
+            Bytes::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> RegistryAddressReader<'r> {
+        RegistryAddressReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for RegistryAddress {
+    type Builder = RegistryAddressBuilder;
+    const NAME: &'static str = "RegistryAddress";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        RegistryAddress(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        RegistryAddressReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        RegistryAddressReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .registry_id(self.registry_id())
+            .address(self.address())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct RegistryAddressReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for RegistryAddressReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for RegistryAddressReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for RegistryAddressReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "registry_id", self.registry_id())?;
+        write!(f, ", {}: {}", "address", self.address())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> RegistryAddressReader<'r> {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn registry_id(&self) -> Uint32Reader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Uint32Reader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn address(&self) -> BytesReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[12..]) as usize;
+            BytesReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            BytesReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for RegistryAddressReader<'r> {
+    type Entity = RegistryAddress;
+    const NAME: &'static str = "RegistryAddressReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        RegistryAddressReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Uint32Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        BytesReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct RegistryAddressBuilder {
+    pub(crate) registry_id: Uint32,
+    pub(crate) address: Bytes,
+}
+impl RegistryAddressBuilder {
+    pub const FIELD_COUNT: usize = 2;
+    pub fn registry_id(mut self, v: Uint32) -> Self {
+        self.registry_id = v;
+        self
+    }
+    pub fn address(mut self, v: Bytes) -> Self {
+        self.address = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for RegistryAddressBuilder {
+    type Entity = RegistryAddress;
+    const NAME: &'static str = "RegistryAddressBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.registry_id.as_slice().len()
+            + self.address.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.registry_id.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.address.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.registry_id.as_slice())?;
+        writer.write_all(self.address.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        RegistryAddress::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct RegistryAddressVec(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for RegistryAddressVec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for RegistryAddressVec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for RegistryAddressVec {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} [", Self::NAME)?;
+        for i in 0..self.len() {
+            if i == 0 {
+                write!(f, "{}", self.get_unchecked(i))?;
+            } else {
+                write!(f, ", {}", self.get_unchecked(i))?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+impl ::core::default::Default for RegistryAddressVec {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![4, 0, 0, 0];
+        RegistryAddressVec::new_unchecked(v.into())
+    }
+}
+impl RegistryAddressVec {
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn item_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.item_count()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn get(&self, idx: usize) -> Option<RegistryAddress> {
+        if idx >= self.len() {
+            None
+        } else {
+            Some(self.get_unchecked(idx))
+        }
+    }
+    pub fn get_unchecked(&self, idx: usize) -> RegistryAddress {
+        let slice = self.as_slice();
+        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
+        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
+        if idx == self.len() - 1 {
+            RegistryAddress::new_unchecked(self.0.slice(start..))
+        } else {
+            let end_idx = start_idx + molecule::NUMBER_SIZE;
+            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
+            RegistryAddress::new_unchecked(self.0.slice(start..end))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> RegistryAddressVecReader<'r> {
+        RegistryAddressVecReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for RegistryAddressVec {
+    type Builder = RegistryAddressVecBuilder;
+    const NAME: &'static str = "RegistryAddressVec";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        RegistryAddressVec(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        RegistryAddressVecReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        RegistryAddressVecReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().extend(self.into_iter())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct RegistryAddressVecReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for RegistryAddressVecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for RegistryAddressVecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for RegistryAddressVecReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} [", Self::NAME)?;
+        for i in 0..self.len() {
+            if i == 0 {
+                write!(f, "{}", self.get_unchecked(i))?;
+            } else {
+                write!(f, ", {}", self.get_unchecked(i))?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+impl<'r> RegistryAddressVecReader<'r> {
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn item_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.item_count()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn get(&self, idx: usize) -> Option<RegistryAddressReader<'r>> {
+        if idx >= self.len() {
+            None
+        } else {
+            Some(self.get_unchecked(idx))
+        }
+    }
+    pub fn get_unchecked(&self, idx: usize) -> RegistryAddressReader<'r> {
+        let slice = self.as_slice();
+        let start_idx = molecule::NUMBER_SIZE * (1 + idx);
+        let start = molecule::unpack_number(&slice[start_idx..]) as usize;
+        if idx == self.len() - 1 {
+            RegistryAddressReader::new_unchecked(&self.as_slice()[start..])
+        } else {
+            let end_idx = start_idx + molecule::NUMBER_SIZE;
+            let end = molecule::unpack_number(&slice[end_idx..]) as usize;
+            RegistryAddressReader::new_unchecked(&self.as_slice()[start..end])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for RegistryAddressVecReader<'r> {
+    type Entity = RegistryAddressVec;
+    const NAME: &'static str = "RegistryAddressVecReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        RegistryAddressVecReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(
+                Self,
+                TotalSizeNotMatch,
+                molecule::NUMBER_SIZE * 2,
+                slice_len
+            );
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        for pair in offsets.windows(2) {
+            let start = pair[0];
+            let end = pair[1];
+            RegistryAddressReader::verify(&slice[start..end], compatible)?;
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct RegistryAddressVecBuilder(pub(crate) Vec<RegistryAddress>);
+impl RegistryAddressVecBuilder {
+    pub fn set(mut self, v: Vec<RegistryAddress>) -> Self {
+        self.0 = v;
+        self
+    }
+    pub fn push(mut self, v: RegistryAddress) -> Self {
+        self.0.push(v);
+        self
+    }
+    pub fn extend<T: ::core::iter::IntoIterator<Item = RegistryAddress>>(
+        mut self,
+        iter: T,
+    ) -> Self {
+        for elem in iter {
+            self.0.push(elem);
+        }
+        self
+    }
+}
+impl molecule::prelude::Builder for RegistryAddressVecBuilder {
+    type Entity = RegistryAddressVec;
+    const NAME: &'static str = "RegistryAddressVecBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (self.0.len() + 1)
+            + self
+                .0
+                .iter()
+                .map(|inner| inner.as_slice().len())
+                .sum::<usize>()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let item_count = self.0.len();
+        if item_count == 0 {
+            writer.write_all(&molecule::pack_number(
+                molecule::NUMBER_SIZE as molecule::Number,
+            ))?;
+        } else {
+            let (total_size, offsets) = self.0.iter().fold(
+                (
+                    molecule::NUMBER_SIZE * (item_count + 1),
+                    Vec::with_capacity(item_count),
+                ),
+                |(start, mut offsets), inner| {
+                    offsets.push(start);
+                    (start + inner.as_slice().len(), offsets)
+                },
+            );
+            writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+            for offset in offsets.into_iter() {
+                writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+            }
+            for inner in self.0.iter() {
+                writer.write_all(inner.as_slice())?;
+            }
+        }
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        RegistryAddressVec::new_unchecked(inner.into())
+    }
+}
+pub struct RegistryAddressVecIterator(RegistryAddressVec, usize, usize);
+impl ::core::iter::Iterator for RegistryAddressVecIterator {
+    type Item = RegistryAddress;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 >= self.2 {
+            None
+        } else {
+            let ret = self.0.get_unchecked(self.1);
+            self.1 += 1;
+            Some(ret)
+        }
+    }
+}
+impl ::core::iter::ExactSizeIterator for RegistryAddressVecIterator {
+    fn len(&self) -> usize {
+        self.2 - self.1
+    }
+}
+impl ::core::iter::IntoIterator for RegistryAddressVec {
+    type Item = RegistryAddress;
+    type IntoIter = RegistryAddressVecIterator;
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.len();
+        RegistryAddressVecIterator(self, 0, len)
+    }
+}
+impl<'r> RegistryAddressVecReader<'r> {
+    pub fn iter<'t>(&'t self) -> RegistryAddressVecReaderIterator<'t, 'r> {
+        RegistryAddressVecReaderIterator(&self, 0, self.len())
+    }
+}
+pub struct RegistryAddressVecReaderIterator<'t, 'r>(&'t RegistryAddressVecReader<'r>, usize, usize);
+impl<'t: 'r, 'r> ::core::iter::Iterator for RegistryAddressVecReaderIterator<'t, 'r> {
+    type Item = RegistryAddressReader<'t>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 >= self.2 {
+            None
+        } else {
+            let ret = self.0.get_unchecked(self.1);
+            self.1 += 1;
+            Some(ret)
+        }
+    }
+}
+impl<'t: 'r, 'r> ::core::iter::ExactSizeIterator for RegistryAddressVecReaderIterator<'t, 'r> {
+    fn len(&self) -> usize {
+        self.2 - self.1
+    }
+}
+#[derive(Clone)]
 pub struct CompactMemBlock(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for CompactMemBlock {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -2753,6 +3354,7 @@ impl ::core::fmt::Display for CompactMemBlock {
         write!(f, "{}: {}", "txs", self.txs())?;
         write!(f, ", {}: {}", "withdrawals", self.withdrawals())?;
         write!(f, ", {}: {}", "deposits", self.deposits())?;
+        write!(f, ", {}: {}", "new_addresses", self.new_addresses())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -2763,13 +3365,14 @@ impl ::core::fmt::Display for CompactMemBlock {
 impl ::core::default::Default for CompactMemBlock {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            28, 0, 0, 0, 16, 0, 0, 0, 20, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
+            36, 0, 0, 0, 20, 0, 0, 0, 24, 0, 0, 0, 28, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 4, 0, 0, 0, 4, 0, 0, 0,
         ];
         CompactMemBlock::new_unchecked(v.into())
     }
 }
 impl CompactMemBlock {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -2801,11 +3404,17 @@ impl CompactMemBlock {
     pub fn deposits(&self) -> DepositInfoVec {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        DepositInfoVec::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn new_addresses(&self) -> RegistryAddressVec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
-            DepositInfoVec::new_unchecked(self.0.slice(start..end))
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            RegistryAddressVec::new_unchecked(self.0.slice(start..end))
         } else {
-            DepositInfoVec::new_unchecked(self.0.slice(start..))
+            RegistryAddressVec::new_unchecked(self.0.slice(start..))
         }
     }
     pub fn as_reader<'r>(&'r self) -> CompactMemBlockReader<'r> {
@@ -2838,6 +3447,7 @@ impl molecule::prelude::Entity for CompactMemBlock {
             .txs(self.txs())
             .withdrawals(self.withdrawals())
             .deposits(self.deposits())
+            .new_addresses(self.new_addresses())
     }
 }
 #[derive(Clone, Copy)]
@@ -2862,6 +3472,7 @@ impl<'r> ::core::fmt::Display for CompactMemBlockReader<'r> {
         write!(f, "{}: {}", "txs", self.txs())?;
         write!(f, ", {}: {}", "withdrawals", self.withdrawals())?;
         write!(f, ", {}: {}", "deposits", self.deposits())?;
+        write!(f, ", {}: {}", "new_addresses", self.new_addresses())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -2870,7 +3481,7 @@ impl<'r> ::core::fmt::Display for CompactMemBlockReader<'r> {
     }
 }
 impl<'r> CompactMemBlockReader<'r> {
-    pub const FIELD_COUNT: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -2902,11 +3513,17 @@ impl<'r> CompactMemBlockReader<'r> {
     pub fn deposits(&self) -> DepositInfoVecReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
+        let end = molecule::unpack_number(&slice[16..]) as usize;
+        DepositInfoVecReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn new_addresses(&self) -> RegistryAddressVecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[16..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[16..]) as usize;
-            DepositInfoVecReader::new_unchecked(&self.as_slice()[start..end])
+            let end = molecule::unpack_number(&slice[20..]) as usize;
+            RegistryAddressVecReader::new_unchecked(&self.as_slice()[start..end])
         } else {
-            DepositInfoVecReader::new_unchecked(&self.as_slice()[start..])
+            RegistryAddressVecReader::new_unchecked(&self.as_slice()[start..])
         }
     }
 }
@@ -2962,6 +3579,7 @@ impl<'r> molecule::prelude::Reader<'r> for CompactMemBlockReader<'r> {
         Byte32VecReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         Byte32VecReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
         DepositInfoVecReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        RegistryAddressVecReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
         Ok(())
     }
 }
@@ -2970,8 +3588,307 @@ pub struct CompactMemBlockBuilder {
     pub(crate) txs: Byte32Vec,
     pub(crate) withdrawals: Byte32Vec,
     pub(crate) deposits: DepositInfoVec,
+    pub(crate) new_addresses: RegistryAddressVec,
 }
 impl CompactMemBlockBuilder {
+    pub const FIELD_COUNT: usize = 4;
+    pub fn txs(mut self, v: Byte32Vec) -> Self {
+        self.txs = v;
+        self
+    }
+    pub fn withdrawals(mut self, v: Byte32Vec) -> Self {
+        self.withdrawals = v;
+        self
+    }
+    pub fn deposits(mut self, v: DepositInfoVec) -> Self {
+        self.deposits = v;
+        self
+    }
+    pub fn new_addresses(mut self, v: RegistryAddressVec) -> Self {
+        self.new_addresses = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for CompactMemBlockBuilder {
+    type Entity = CompactMemBlock;
+    const NAME: &'static str = "CompactMemBlockBuilder";
+    fn expected_length(&self) -> usize {
+        molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
+            + self.txs.as_slice().len()
+            + self.withdrawals.as_slice().len()
+            + self.deposits.as_slice().len()
+            + self.new_addresses.as_slice().len()
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
+        let mut offsets = Vec::with_capacity(Self::FIELD_COUNT);
+        offsets.push(total_size);
+        total_size += self.txs.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.withdrawals.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.deposits.as_slice().len();
+        offsets.push(total_size);
+        total_size += self.new_addresses.as_slice().len();
+        writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
+        for offset in offsets.into_iter() {
+            writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
+        }
+        writer.write_all(self.txs.as_slice())?;
+        writer.write_all(self.withdrawals.as_slice())?;
+        writer.write_all(self.deposits.as_slice())?;
+        writer.write_all(self.new_addresses.as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        CompactMemBlock::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
+pub struct DeprecatedCompactMemBlock(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for DeprecatedCompactMemBlock {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for DeprecatedCompactMemBlock {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for DeprecatedCompactMemBlock {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "txs", self.txs())?;
+        write!(f, ", {}: {}", "withdrawals", self.withdrawals())?;
+        write!(f, ", {}: {}", "deposits", self.deposits())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl ::core::default::Default for DeprecatedCompactMemBlock {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            28, 0, 0, 0, 16, 0, 0, 0, 20, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
+        ];
+        DeprecatedCompactMemBlock::new_unchecked(v.into())
+    }
+}
+impl DeprecatedCompactMemBlock {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn txs(&self) -> Byte32Vec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Byte32Vec::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn withdrawals(&self) -> Byte32Vec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Byte32Vec::new_unchecked(self.0.slice(start..end))
+    }
+    pub fn deposits(&self) -> DepositInfoVec {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            DepositInfoVec::new_unchecked(self.0.slice(start..end))
+        } else {
+            DepositInfoVec::new_unchecked(self.0.slice(start..))
+        }
+    }
+    pub fn as_reader<'r>(&'r self) -> DeprecatedCompactMemBlockReader<'r> {
+        DeprecatedCompactMemBlockReader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for DeprecatedCompactMemBlock {
+    type Builder = DeprecatedCompactMemBlockBuilder;
+    const NAME: &'static str = "DeprecatedCompactMemBlock";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        DeprecatedCompactMemBlock(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        DeprecatedCompactMemBlockReader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        DeprecatedCompactMemBlockReader::from_compatible_slice(slice)
+            .map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder()
+            .txs(self.txs())
+            .withdrawals(self.withdrawals())
+            .deposits(self.deposits())
+    }
+}
+#[derive(Clone, Copy)]
+pub struct DeprecatedCompactMemBlockReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for DeprecatedCompactMemBlockReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for DeprecatedCompactMemBlockReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for DeprecatedCompactMemBlockReader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{} {{ ", Self::NAME)?;
+        write!(f, "{}: {}", "txs", self.txs())?;
+        write!(f, ", {}: {}", "withdrawals", self.withdrawals())?;
+        write!(f, ", {}: {}", "deposits", self.deposits())?;
+        let extra_count = self.count_extra_fields();
+        if extra_count != 0 {
+            write!(f, ", .. ({} fields)", extra_count)?;
+        }
+        write!(f, " }}")
+    }
+}
+impl<'r> DeprecatedCompactMemBlockReader<'r> {
+    pub const FIELD_COUNT: usize = 3;
+    pub fn total_size(&self) -> usize {
+        molecule::unpack_number(self.as_slice()) as usize
+    }
+    pub fn field_count(&self) -> usize {
+        if self.total_size() == molecule::NUMBER_SIZE {
+            0
+        } else {
+            (molecule::unpack_number(&self.as_slice()[molecule::NUMBER_SIZE..]) as usize / 4) - 1
+        }
+    }
+    pub fn count_extra_fields(&self) -> usize {
+        self.field_count() - Self::FIELD_COUNT
+    }
+    pub fn has_extra_fields(&self) -> bool {
+        Self::FIELD_COUNT != self.field_count()
+    }
+    pub fn txs(&self) -> Byte32VecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[4..]) as usize;
+        let end = molecule::unpack_number(&slice[8..]) as usize;
+        Byte32VecReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn withdrawals(&self) -> Byte32VecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[8..]) as usize;
+        let end = molecule::unpack_number(&slice[12..]) as usize;
+        Byte32VecReader::new_unchecked(&self.as_slice()[start..end])
+    }
+    pub fn deposits(&self) -> DepositInfoVecReader<'r> {
+        let slice = self.as_slice();
+        let start = molecule::unpack_number(&slice[12..]) as usize;
+        if self.has_extra_fields() {
+            let end = molecule::unpack_number(&slice[16..]) as usize;
+            DepositInfoVecReader::new_unchecked(&self.as_slice()[start..end])
+        } else {
+            DepositInfoVecReader::new_unchecked(&self.as_slice()[start..])
+        }
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for DeprecatedCompactMemBlockReader<'r> {
+    type Entity = DeprecatedCompactMemBlock;
+    const NAME: &'static str = "DeprecatedCompactMemBlockReader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        DeprecatedCompactMemBlockReader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len < molecule::NUMBER_SIZE {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE, slice_len);
+        }
+        let total_size = molecule::unpack_number(slice) as usize;
+        if slice_len != total_size {
+            return ve!(Self, TotalSizeNotMatch, total_size, slice_len);
+        }
+        if slice_len == molecule::NUMBER_SIZE && Self::FIELD_COUNT == 0 {
+            return Ok(());
+        }
+        if slice_len < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, HeaderIsBroken, molecule::NUMBER_SIZE * 2, slice_len);
+        }
+        let offset_first = molecule::unpack_number(&slice[molecule::NUMBER_SIZE..]) as usize;
+        if offset_first % molecule::NUMBER_SIZE != 0 || offset_first < molecule::NUMBER_SIZE * 2 {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        if slice_len < offset_first {
+            return ve!(Self, HeaderIsBroken, offset_first, slice_len);
+        }
+        let field_count = offset_first / molecule::NUMBER_SIZE - 1;
+        if field_count < Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        } else if !compatible && field_count > Self::FIELD_COUNT {
+            return ve!(Self, FieldCountNotMatch, Self::FIELD_COUNT, field_count);
+        };
+        let mut offsets: Vec<usize> = slice[molecule::NUMBER_SIZE..offset_first]
+            .chunks_exact(molecule::NUMBER_SIZE)
+            .map(|x| molecule::unpack_number(x) as usize)
+            .collect();
+        offsets.push(total_size);
+        if offsets.windows(2).any(|i| i[0] > i[1]) {
+            return ve!(Self, OffsetsNotMatch);
+        }
+        Byte32VecReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
+        Byte32VecReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        DepositInfoVecReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
+        Ok(())
+    }
+}
+#[derive(Debug, Default)]
+pub struct DeprecatedCompactMemBlockBuilder {
+    pub(crate) txs: Byte32Vec,
+    pub(crate) withdrawals: Byte32Vec,
+    pub(crate) deposits: DepositInfoVec,
+}
+impl DeprecatedCompactMemBlockBuilder {
     pub const FIELD_COUNT: usize = 3;
     pub fn txs(mut self, v: Byte32Vec) -> Self {
         self.txs = v;
@@ -2986,9 +3903,9 @@ impl CompactMemBlockBuilder {
         self
     }
 }
-impl molecule::prelude::Builder for CompactMemBlockBuilder {
-    type Entity = CompactMemBlock;
-    const NAME: &'static str = "CompactMemBlockBuilder";
+impl molecule::prelude::Builder for DeprecatedCompactMemBlockBuilder {
+    type Entity = DeprecatedCompactMemBlock;
+    const NAME: &'static str = "DeprecatedCompactMemBlockBuilder";
     fn expected_length(&self) -> usize {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.txs.as_slice().len()
@@ -3017,7 +3934,7 @@ impl molecule::prelude::Builder for CompactMemBlockBuilder {
         let mut inner = Vec::with_capacity(self.expected_length());
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        CompactMemBlock::new_unchecked(inner.into())
+        DeprecatedCompactMemBlock::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -8,8 +8,8 @@ pub mod core;
 mod extension;
 mod generated;
 pub mod prelude;
-mod std_traits;
 pub mod registry_address;
+mod std_traits;
 
 pub use generated::packed;
 pub use molecule::bytes;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -9,6 +9,7 @@ mod extension;
 mod generated;
 pub mod prelude;
 mod std_traits;
+pub mod registry_address;
 
 pub use generated::packed;
 pub use molecule::bytes;

--- a/crates/types/src/registry_address.rs
+++ b/crates/types/src/registry_address.rs
@@ -1,7 +1,7 @@
 use crate::vec::Vec;
 use core::convert::TryInto;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct RegistryAddress {
     pub registry_id: u32,
     pub address: Vec<u8>,


### PR DESCRIPTION
Filter ckb transfer log and save new recipient addresses to mem block. Create accounts after mem pool reset.

require minimal balance: 1 ckb