### PR TITLE
feat: (optionally) support gasless transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -252,28 +252,12 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
@@ -1165,11 +1149,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -1258,14 +1242,13 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "16.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
 dependencies = [
  "ethereum-types",
  "hex",
  "serde",
- "serde_json",
  "sha3",
  "thiserror",
  "uint",
@@ -1273,27 +1256,23 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-rlp",
- "impl-serde",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+checksum = "81224dc661606574f5a0f28c9947d0ee1d93ff11c5f1c4e7272f52e8c0b5483c"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-rlp",
- "impl-serde",
  "primitive-types",
  "uint",
 ]
@@ -1354,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -1425,9 +1404,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2216,6 +2195,7 @@ dependencies = [
  "anyhow",
  "ckb-crypto",
  "ckb-types",
+ "ethabi",
  "faster-hex 0.4.1",
  "gw-common",
  "gw-config",
@@ -2317,7 +2297,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2448,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2466,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -3185,9 +3165,9 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
 dependencies = [
  "arrayvec 0.7.2",
  "bitvec",
@@ -3199,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.3.1"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3419,9 +3399,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitive-types"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -3570,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4148,19 +4128,17 @@ checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "digest 0.10.6",
  "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -5151,9 +5129,12 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -148,7 +148,7 @@ impl BenchExecutionEnvironment {
         let rollup_context = RollupContext {
             rollup_config: genesis_config.rollup_config.clone().into(),
             rollup_script_hash: ROLLUP_TYPE_HASH.into(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
 
         let backend_manage = {

--- a/crates/benches/benches/benchmarks/sudt.rs
+++ b/crates/benches/benches/benchmarks/sudt.rs
@@ -106,7 +106,7 @@ fn run_contract_get_result<S: State + CodeStore + JournalDB>(
     let rollup_ctx = RollupContext {
         rollup_config: rollup_config.clone(),
         rollup_script_hash: [42u8; 32].into(),
-        fork_config: Default::default(),
+        ..Default::default()
     };
     let generator = Generator::new(
         backend_manage,

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -761,6 +761,7 @@ pub async fn run(config: Config, skip_config_check: bool) -> Result<()> {
         dynamic_config_manager,
         polyjuice_sender_recover,
         debug_backend_forks: config.debug_backend_forks.clone(),
+        gasless_tx_support_config: config.gasless_tx_support.clone(),
     };
 
     let rpc_registry = Registry::create(args).await;

--- a/crates/block-producer/src/withdrawal.rs
+++ b/crates/block-producer/src/withdrawal.rs
@@ -334,7 +334,7 @@ mod test {
                 .withdrawal_script_type_hash(H256::from_u32(100).pack())
                 .finality_blocks(1u64.pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
 
         let sudt_script = Script::new_builder()
@@ -464,7 +464,7 @@ mod test {
                 .l1_sudt_script_type_hash(sudt_script.code_hash())
                 .finality_blocks(1u64.pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
 
         let contracts_dep = {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -54,6 +54,9 @@ pub struct Config {
     pub p2p_network_config: Option<P2PNetworkConfig>,
     #[serde(default)]
     pub sync_server: SyncServerConfig,
+    /// Gasless tx support is enabled when this config presents.
+    #[serde(default)]
+    pub gasless_tx_support: Option<GaslessTxSupportConfig>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -275,6 +278,12 @@ impl Default for DebugConfig {
             enable_debug_rpc: false,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct GaslessTxSupportConfig {
+    /// Gasless tx entrypoint address.
+    pub entrypoint_address: H160,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,4 +1,5 @@
 use ckb_fixed_hash::{H160, H256};
+pub use gw_jsonrpc_types::godwoken::GaslessTxSupportConfig;
 use gw_jsonrpc_types::{
     blockchain::{CellDep, Script},
     ckb_jsonrpc_types::JsonBytes,
@@ -278,12 +279,6 @@ impl Default for DebugConfig {
             enable_debug_rpc: false,
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct GaslessTxSupportConfig {
-    /// Gasless tx entrypoint address.
-    pub entrypoint_address: H160,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -27,12 +27,12 @@ lazy_static = "1.4"
 rlp = "0.5.0"
 secp256k1 = { version = "0.20", features = ["recovery"] }
 substrate-bn = { git = "https://github.com/paritytech/bn.git", rev = "63f8c58" }
-sha3 = "0.9.1"
+sha3 = "0.10.6"
 log = "0.4"
 hex = "0.4"
 tokio = "1"
 arc-swap = "1.5"
-ethabi = "16.0.0"
+ethabi = { version = "18.0.0", default-features = false, features = ["thiserror", "std"] }
 tracing = { version = "0.1", features = ["attributes"] }
 
 [dev-dependencies]

--- a/crates/generator/src/account_lock_manage/secp256k1.rs
+++ b/crates/generator/src/account_lock_manage/secp256k1.rs
@@ -342,11 +342,10 @@ mod tests {
             .args(Bytes::from(receiver_args).pack())
             .build();
         let ctx = RollupContext {
-            rollup_script_hash: Default::default(),
             rollup_config: RollupConfig::new_builder()
                 .chain_id(chain_id.pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
         eth.verify_tx(&ctx, sender_address, sender_script, receiver_script, tx)
             .expect("verify signature");
@@ -406,11 +405,10 @@ mod tests {
             .args(args.pack())
             .build();
         let ctx = RollupContext {
-            rollup_script_hash: Default::default(),
             rollup_config: RollupConfig::new_builder()
                 .chain_id(chain_id.pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
         let eth = Secp256k1Eth::default();
         eth.verify_tx(&ctx, sender_reg_addr, sender_script, receive_script, tx)
@@ -474,11 +472,10 @@ mod tests {
             .args(Bytes::from(receiver_args).pack())
             .build();
         let ctx = RollupContext {
-            rollup_script_hash: Default::default(),
             rollup_config: RollupConfig::new_builder()
                 .chain_id(chain_id.pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
 
         eth.verify_tx(&ctx, sender_address, sender_script, receiver_script, tx)
@@ -535,11 +532,10 @@ mod tests {
             .args(Bytes::from(receiver_args).pack())
             .build();
         let ctx = RollupContext {
-            rollup_script_hash: Default::default(),
             rollup_config: RollupConfig::new_builder()
                 .chain_id(chain_id.pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
         eth.verify_tx(&ctx, sender_address, sender_script, receiver_script, tx)
             .expect("verify signature");
@@ -581,11 +577,10 @@ mod tests {
             .args(Bytes::from(receiver_args).pack())
             .build();
         let ctx = RollupContext {
-            rollup_script_hash: Default::default(),
             rollup_config: RollupConfig::new_builder()
                 .chain_id(chain_id.pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
         eth.verify_tx(&ctx, sender_address, sender_script, receiver_script, tx)
             .expect("verify signature");
@@ -646,9 +641,8 @@ mod tests {
             .args(Bytes::from(receiver_args).pack())
             .build();
         let ctx = RollupContext {
-            rollup_script_hash: Default::default(),
             rollup_config: RollupConfig::new_builder().chain_id(0.pack()).build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
         let eth = Secp256k1Eth::default();
         eth.verify_tx(&ctx, sender_address, sender_script, receiver_script, tx)

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -1,6 +1,6 @@
 use crate::blockchain::Script;
 use anyhow::{anyhow, Error as JsonError};
-use ckb_fixed_hash::H256;
+use ckb_fixed_hash::{H160, H256};
 use ckb_jsonrpc_types::{JsonBytes, Uint128, Uint32, Uint64};
 use gw_types::{bytes::Bytes, offchain, packed, prelude::*};
 use serde::{Deserialize, Serialize};
@@ -1172,6 +1172,7 @@ pub struct NodeInfo {
     pub gw_scripts: Vec<GwScript>,
     pub rollup_cell: RollupCell,
     pub rollup_config: NodeRollupConfig,
+    pub gasless_tx_support: Option<GaslessTxSupportConfig>,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
@@ -1279,6 +1280,13 @@ impl Default for EoaScriptType {
         EoaScriptType::Unknown
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
+pub struct GaslessTxSupportConfig {
+    /// Gasless tx entrypoint address.
+    pub entrypoint_address: H160,
+}
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct ErrorTxReceipt {

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -1172,6 +1172,9 @@ pub struct NodeInfo {
     pub gw_scripts: Vec<GwScript>,
     pub rollup_cell: RollupCell,
     pub rollup_config: NodeRollupConfig,
+    // Web3 as of 1.9.0 cannot handle null values in node info. So we omit this
+    // field instead of saying it's null.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gasless_tx_support: Option<GaslessTxSupportConfig>,
 }
 

--- a/crates/mem-pool/src/withdrawal.rs
+++ b/crates/mem-pool/src/withdrawal.rs
@@ -345,7 +345,7 @@ mod test {
             rollup_config: RollupConfig::new_builder()
                 .withdrawal_script_type_hash(H256::from_u32(100).pack())
                 .build(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
 
         let sudt_script = Script::new_builder()

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0"
 lazy_static = "1.4"
 secp256k1 = { version = "0.21", features = ["recovery", "rand-std"] }
 async-jsonrpc-client = { version = "0.3.0", default-features = false, features = ["http-tokio"] }
-sha3 = "0.9.1"
+sha3 = "0.10.6"
 hex = "0.4.2"
 ckb-script = "0.105.1"
 ckb-types = "0.105.1"

--- a/crates/tests/src/script_tests/l2_scripts/examples.rs
+++ b/crates/tests/src/script_tests/l2_scripts/examples.rs
@@ -96,7 +96,7 @@ fn test_example_sum() {
         let rollup_context = RollupContext {
             rollup_config: Default::default(),
             rollup_script_hash: [42u8; 32].into(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
         let generator = Generator::new(
             backend_manage,
@@ -241,7 +241,7 @@ fn test_example_account_operation() {
             )
             .build(),
         rollup_script_hash: [42u8; 32].into(),
-        fork_config: Default::default(),
+        ..Default::default()
     };
     let generator = Generator::new(
         backend_manage,
@@ -481,7 +481,7 @@ fn test_example_recover_account() {
             )
             .build(),
         rollup_script_hash,
-        fork_config: Default::default(),
+        ..Default::default()
     };
     let generator = Generator::new(
         backend_manage,
@@ -653,7 +653,7 @@ fn test_sudt_total_supply() {
         let rollup_context = RollupContext {
             rollup_config,
             rollup_script_hash: [42u8; 32].into(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
         let generator = Generator::new(
             backend_manage,

--- a/crates/tests/src/script_tests/l2_scripts/mod.rs
+++ b/crates/tests/src/script_tests/l2_scripts/mod.rs
@@ -246,7 +246,7 @@ pub fn run_contract_get_result<S: State + CodeStore + JournalDB>(
     let rollup_ctx = RollupContext {
         rollup_config: rollup_config.clone(),
         rollup_script_hash: [42u8; 32].into(),
-        fork_config: Default::default(),
+        ..Default::default()
     };
     let generator = Generator::new(
         backend_manage,

--- a/crates/tests/src/script_tests/utils/context.rs
+++ b/crates/tests/src/script_tests/utils/context.rs
@@ -76,7 +76,7 @@ impl TestingContext {
         let rollup_context = RollupContext {
             rollup_config: rollup_config.clone(),
             rollup_script_hash: [42u8; 32].into(),
-            fork_config: Default::default(),
+            ..Default::default()
         };
 
         // deploy registry contract

--- a/crates/tests/src/testing_tool/chain.rs
+++ b/crates/tests/src/testing_tool/chain.rs
@@ -466,7 +466,7 @@ pub fn chain_generator(chain: &Chain, rollup_type_script: Script) -> Arc<Generat
     let rollup_context = RollupContext {
         rollup_script_hash: rollup_type_script.hash().into(),
         rollup_config,
-        fork_config: Default::default(),
+        ..Default::default()
     };
     Arc::new(Generator::new(
         backend_manage,
@@ -503,7 +503,7 @@ pub async fn setup_chain_with_account_lock_manage(
     let rollup_context = RollupContext {
         rollup_script_hash: rollup_script_hash.into(),
         rollup_config: rollup_config.clone(),
-        fork_config: Default::default(),
+        ..Default::default()
     };
     let generator = Arc::new(Generator::new(
         backend_manage,

--- a/crates/tests/src/testing_tool/rpc_server.rs
+++ b/crates/tests/src/testing_tool/rpc_server.rs
@@ -81,6 +81,7 @@ impl RPCServer {
             chain_config: Default::default(),
             consensus_config: Default::default(),
             dynamic_config_manager: Default::default(),
+            gasless_tx_support_config: None,
             polyjuice_sender_recover,
             debug_backend_forks: None,
         }

--- a/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
+++ b/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
@@ -179,7 +179,7 @@ async fn test_build_unlock_to_owner_tx() {
     let rollup_context = RollupContext {
         rollup_script_hash,
         rollup_config: rollup_config.clone(),
-        fork_config: Default::default(),
+        ..Default::default()
     };
 
     let contracts_dep = ContractsCellDep {

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -17,7 +17,7 @@ toml = "0.5"
 tempfile = "3.1"
 lazy_static = "1.3"
 secp256k1 = "0.24"
-sha3 = "0.9.1"
+sha3 = "0.10.6"
 reqwest = { version = "0.11", features = ["json"] }
 ckb-jsonrpc-types = "0.105.1"
 ckb-types = "0.105.1"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -18,4 +18,4 @@ gw-hash = { path = "../hash", default-features = false }
 ckb-fixed-hash = { version = "0.105.1", optional = true }
 sparse-merkle-tree = { version = "0.6.1", default-features = false }
 ckb-types = { version = "0.105.1", default-features = false, optional = true }
-primitive-types = { version = "0.10", default-features = false, features = [ "impl-serde", "impl-rlp" ] }
+primitive-types = { version = "0.12", default-features = false, features = [ "impl-serde", "impl-rlp" ] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,10 +15,11 @@ gw-store = { path = "../store" }
 anyhow = "1.0"
 faster-hex = "0.4"
 ckb-crypto = "0.105.1"
-sha3 = "0.9.1"
+sha3 = "0.10.6"
 secp256k1 = "0.21"
 log = "0.4"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 ckb-types = "0.105.1"
 tokio = "1"
 zstd = "0.11.2"
+ethabi = { version = "18.0.0", default-features = false, features = ["thiserror", "std"] }

--- a/crates/utils/src/gasless.rs
+++ b/crates/utils/src/gasless.rs
@@ -1,0 +1,98 @@
+use std::convert::TryInto;
+
+use anyhow::{Context as _, Result};
+use ethabi::decode;
+use gw_config::GaslessTxSupportConfig;
+
+use crate::polyjuice_parser::PolyjuiceParser;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Fee {
+    pub gas_limit: u64,
+    pub gas_price: u128,
+}
+
+pub fn is_gasless_tx(config: Option<&GaslessTxSupportConfig>, tx: &PolyjuiceParser) -> bool {
+    tx.gas_price() == 0
+        && tx.to_address().is_some()
+        && tx.to_address() == config.map(|c| c.entrypoint_address.as_bytes())
+}
+
+pub fn gasless_tx_fee(data: &[u8]) -> Result<Fee> {
+    use ethabi::ParamType::*;
+
+    // struct UserOperation {
+    //     address callContract;
+    //     bytes callData;
+    //     uint256 callGasLimit;
+    //     uint256 verificationGasLimit;
+    //     uint256 maxFeePerGas;
+    //     uint256 maxPriorityFeePerGas;
+    //     bytes paymasterAndData;
+    // }
+    let mut tokens = decode(
+        &[Tuple(vec![
+            Address,
+            Bytes,
+            Uint(256),
+            Uint(256),
+            Uint(256),
+            Uint(256),
+            Bytes,
+        ])],
+        data,
+    )
+    .context("decode data")?;
+
+    // Why unwrapping: if ethabi successfully decoded the data, we trust it to
+    // give us tokens in the right shape.
+
+    let mut tokens = tokens.remove(0).into_tuple().unwrap();
+    assert_eq!(tokens.len(), 7);
+    let mut tokens = tokens.drain(2..);
+
+    let call_gas_limit = tokens.next().unwrap().into_uint().unwrap();
+    let verification_gas_limit = tokens.next().unwrap().into_uint().unwrap();
+    let max_fee_per_gas = tokens.next().unwrap().into_uint().unwrap();
+
+    // when using a Paymaster, the verificationGasLimit is used also to as a
+    // limit for the postOp call. our security model might call postOp
+    // eventually twice so the verificationGasLimit shoud x3 times.
+    let gas_limit = (move || {
+        verification_gas_limit
+            .checked_mul(3.into())?
+            .checked_add(call_gas_limit)?
+            .try_into()
+            .ok()
+    })()
+    .context("gas limit overflow")?;
+    let gas_price = max_fee_per_gas
+        .try_into()
+        .ok()
+        .context("gas price overflow")?;
+
+    Ok(Fee {
+        gas_limit,
+        gas_price,
+    })
+}
+
+#[test]
+fn test_gasless_tx_fee() {
+    // https://web3playground.io/QmVUNCDSFoPQ9d1npLyEP7oJUJr3tymvX9FU9ikjhJeJSo
+    //
+    // "callGasLimit": 2563223,
+    // "verificationGasLimit": 23747,
+    // "maxFeePerGas": 25000,
+    const HEX_DATA: &str = "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000001df923e4f009663b0fddc1775dac783b85f432fb00000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000271c970000000000000000000000000000000000000000000000000000000000005cc300000000000000000000000000000000000000000000000000000000000061a800000000000000000000000000000000000000000000000000000000000061a800000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000002ffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000141df923e4f009663b0fddc1775dac783b85f432fb000000000000000000000000";
+    let mut data = [0u8; HEX_DATA.len() / 2];
+    faster_hex::hex_decode(HEX_DATA.as_bytes(), &mut data).unwrap();
+
+    assert_eq!(
+        gasless_tx_fee(&data).unwrap(),
+        Fee {
+            gas_limit: 23747 * 3 + 2563223,
+            gas_price: 25000,
+        }
+    );
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod compression;
 pub mod exponential_backoff;
 pub mod export_block;
 pub mod fee;
+pub mod gasless;
 pub mod genesis_info;
 pub mod liveness;
 pub mod local_cells;

--- a/crates/utils/src/rollup_context.rs
+++ b/crates/utils/src/rollup_context.rs
@@ -3,7 +3,7 @@ use gw_types::core::H256;
 use gw_types::packed::RollupConfig;
 
 /// A wildly used context, contains several common-used configurations.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RollupContext {
     /// rollup_state_cell's type hash
     pub rollup_script_hash: H256,

--- a/gwos/c-uint256-tests/Cargo.toml
+++ b/gwos/c-uint256-tests/Cargo.toml
@@ -10,7 +10,7 @@ cty = "0.2"
 
 [dev-dependencies]
 proptest = "1.0"
-primitive-types = { version = "0.10", default-features = false, features = [ "impl-serde", "impl-rlp" ] }
+primitive-types = { version = "0.12", default-features = false, features = [ "impl-serde", "impl-rlp" ] }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Support gasless transactions when the `gasless_tx_support` config is present:

```toml
[gasless_tx_support]
entrypoint_address = "entrypoint address in 0x-prefixed hex format"
```

* Sort gasless transactions according to actual transaction gas limit/gas price defined in transaction payload (`UserOperation`).

  (This only affects a full node. Read-only nodes will allow any received gasless transactions, without verifying the entrypoint address.)

Also updated some ethereum related deps.