### PR TITLE
chore: use the actions/stale to manage inactive issues

### DIFF
--- a/.github/workflows/close-inactive-issue.yml
+++ b/.github/workflows/close-inactive-issue.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v6
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Comment on and close issues that have been inactive for a certain period of time

1. comment if an issue has been inactive for 30 days to prompt participants to take action.
2. if no additional activity occurs after 14 days, close the issue.