### PR TITLE
Fix workspace error when installing ckb-binary-patcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ members = [
 ]
 
 exclude = [
- "gwos-evm/polyjuice-tests",
- "gwos-evm/deps/ckb-binary-patcher"
+ "gwos-evm/polyjuice-tests"
 ]
 
 [profile.release]

--- a/gwos-evm/Makefile
+++ b/gwos-evm/Makefile
@@ -82,32 +82,25 @@ clean-via-docker:
 
 dist: clean-via-docker all-via-docker
 
-CKB_BIN_PATCHER := deps/ckb-binary-patcher/target/release/ckb-binary-patcher
-build/ckb-binary-patcher:
-	cd deps && [ -d "ckb-binary-patcher" ] \
-	  || ( \
-		echo "fetch ckb-binary-patcher with [Remove atomic instructions] feature" && \
-		git clone -b master https://github.com/nervosnetwork/ckb-binary-patcher.git)
-	[ -f ${CKB_BIN_PATCHER} ] \
-	  || ( \
-		echo "build ckb-binary-patcher" && \
-		cd deps/ckb-binary-patcher && \
-		git checkout b9489de4b3b9d59bc29bce945279bc6f28413113 && \
-		cargo build --release)
-patch-generator: build/ckb-binary-patcher
-	${CKB_BIN_PATCHER} --remove-a -i build/generator -o build/generator.aot
+install/ckb-binary-patcher:
+	echo "install ckb-binary-patcher from https://github.com/nervosnetwork/ckb-binary-patcher/commits/master"
+	cargo install --git https://github.com/nervosnetwork/ckb-binary-patcher.git \
+				  --rev b9489de4b3b9d59bc29bce945279bc6f28413113
+	ckb-binary-patcher --version
+patch-generator: install/ckb-binary-patcher
+	ckb-binary-patcher --remove-a -i build/generator -o build/generator.aot
 	mv build/generator build/generator.asm
 	cp build/generator.aot build/generator
-patch-generator_log: build/ckb-binary-patcher
-	${CKB_BIN_PATCHER} --remove-a -i build/generator_log -o build/generator_log.aot
+patch-generator_log: install/ckb-binary-patcher
+	ckb-binary-patcher --remove-a -i build/generator_log -o build/generator_log.aot
 	mv build/generator_log build/generator_log.asm
 	cp build/generator_log.aot build/generator_log
-# patch-validator: build/ckb-binary-patcher
-# 	${CKB_BIN_PATCHER} --remove-a -i build/validator -o build/validator.aot
-# patch-validator_log: build/ckb-binary-patcher
-# 	${CKB_BIN_PATCHER} --remove-a -i build/validator_log -o build/validator_log.aot
-# patch-test_contracts: build/ckb-binary-patcher
-# 	${CKB_BIN_PATCHER} --remove-a -i build/test_contracts -o build/test_contracts.aot
+# patch-validator: install/ckb-binary-patcher
+# 	ckb-binary-patcher --remove-a -i build/validator -o build/validator.aot
+# patch-validator_log: install/ckb-binary-patcher
+# 	ckb-binary-patcher --remove-a -i build/validator_log -o build/validator_log.aot
+# patch-test_contracts: install/ckb-binary-patcher
+# 	ckb-binary-patcher --remove-a -i build/test_contracts -o build/test_contracts.aot
 
 build/generator: c/generator.c $(GENERATOR_DEPS)
 	cd $(SECP_DIR) && (git apply workaround-fix-g++-linking.patch || true) && cd - # apply patch

--- a/gwos-evm/Makefile
+++ b/gwos-evm/Makefile
@@ -90,11 +90,11 @@ install/ckb-binary-patcher:
 patch-generator: install/ckb-binary-patcher
 	ckb-binary-patcher --remove-a -i build/generator -o build/generator.aot
 	mv build/generator build/generator.asm
-	cp build/generator.aot build/generator
+	mv build/generator.aot build/generator
 patch-generator_log: install/ckb-binary-patcher
 	ckb-binary-patcher --remove-a -i build/generator_log -o build/generator_log.aot
 	mv build/generator_log build/generator_log.asm
-	cp build/generator_log.aot build/generator_log
+	mv build/generator_log.aot build/generator_log
 # patch-validator: install/ckb-binary-patcher
 # 	ckb-binary-patcher --remove-a -i build/validator -o build/validator.aot
 # patch-validator_log: install/ckb-binary-patcher


### PR DESCRIPTION
```
error: current package believes it's in a workspace when it's not:
current:   /build/godwoken/gwos-evm/deps/ckb-binary-patcher/Cargo.toml
workspace: /build/godwoken/Cargo.toml

this may be fixable by adding `gwos-evm/deps/ckb-binary-patcher` to the `workspace.members` array of the manifest located at: /build/godwoken/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
Makefile:86: recipe for target 'build/ckb-binary-patcher' failed
make[2]: *** [build/ckb-binary-patcher] Error 101
make[2]: Leaving directory '/build/godwoken/gwos-evm'
Makefile:64: recipe for target 'all-via-docker' failed
make[1]: *** [all-via-docker] Error 2
make[1]: Leaving directory '/build/godwoken/gwos-evm'
Makefile:30: recipe for target 'build-components' failed
make: *** [build-components] Error 2
```