### PR TITLE
fix(CI): polyjuice integration test

### DIFF
--- a/.github/workflows/gwos-evm-ci.yml
+++ b/.github/workflows/gwos-evm-ci.yml
@@ -60,9 +60,6 @@ jobs:
         sha256sum build/generator build/generator_log build/validator build/validator_log
 
   integration-test:
-    defaults:
-      run:
-        working-directory: gwos-evm
     uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
     with:
       extra_github_env: |


### PR DESCRIPTION
Looks like `defaults` cannot be used with `uses` at the same time.
Since the integration test doesn't need a working directory, we can simply delete the default entry. I have tested this in my repo. See more here: https://github.com/magicalne/godwoken/actions/runs/3561861834/jobs/5983131222