### PR TITLE
feat: deprecate verifications for state_checkpoint_list and prev_state_checkpoint

### DIFF
--- a/crates/benches/benches/benchmarks/smt.rs
+++ b/crates/benches/benches/benchmarks/smt.rs
@@ -419,7 +419,6 @@ impl BenchExecutionEnvironment {
         db.insert_block(
             genesis.clone(),
             global_state,
-            Vec::new(),
             prev_txs_state,
             Vec::new(),
             Default::default(),

--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -116,11 +116,16 @@ pub fn produce_block(
             .build()
     };
     assert_eq!(parent_block.raw().post_account(), prev_merkle_state);
-    assert_eq!(
-        state_checkpoint_list.len(),
-        withdrawals.len() + txs.len(),
-        "state checkpoint len"
-    );
+    if rollup_context
+        .fork_config
+        .enforce_correctness_of_state_checkpoint_list(number)
+    {
+        assert_eq!(
+            state_checkpoint_list.len(),
+            withdrawals.len() + txs.len(),
+            "state checkpoint len"
+        );
+    }
     let raw_block = RawL2Block::new_builder()
         .number(number.pack())
         .block_producer(block_producer.pack())

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1035,7 +1035,7 @@ impl Chain {
         // process transactions
         // TODO: run offchain validator before send challenge, to make sure the block is bad
         let generator = &self.generator;
-        let (withdrawal_receipts, prev_txs_state, tx_receipts) = match generator
+        let (_withdrawal_receipts, prev_txs_state, tx_receipts) = match generator
             .verify_and_apply_block(db, &chain_view, args, &self.skipped_invalid_block_list)
         {
             ApplyBlockResult::Success {
@@ -1066,7 +1066,6 @@ impl Chain {
         db.insert_block(
             l2block.clone(),
             global_state.clone(),
-            withdrawal_receipts,
             prev_txs_state,
             tx_receipts,
             deposit_info_vec,

--- a/crates/config/src/fork_config.rs
+++ b/crates/config/src/fork_config.rs
@@ -71,6 +71,11 @@ impl ForkConfig {
         self.global_state_version(block_number) >= 2
     }
 
+    /// Returns if we should enforce the correctness of `RawL2Block.state_checkpoint_list`.
+    pub fn enforce_correctness_of_state_checkpoint_list(&self, block_number: u64) -> bool {
+        self.global_state_version(block_number) <= 1
+    }
+
     /// Return l2 tx cycles limit by block height
     pub fn max_l2_tx_cycles(&self, block_number: u64) -> u64 {
         match self.increase_max_l2_tx_cycles_to_500m {

--- a/crates/generator/src/genesis.rs
+++ b/crates/generator/src/genesis.rs
@@ -235,7 +235,6 @@ pub fn init_genesis(
     db.insert_block(
         genesis.clone(),
         global_state,
-        Vec::new(),
         prev_txs_state,
         Vec::new(),
         Default::default(),

--- a/crates/mem-pool/src/pool.rs
+++ b/crates/mem-pool/src/pool.rs
@@ -1358,7 +1358,15 @@ impl MemPool {
 
             // update mem block
             let post_merkle_state = tip_block.raw().post_account();
-            let mem_block = MemBlock::new(block_info, post_merkle_state);
+            let enforce_correctness_of_state_checkpoint_list = self
+                .generator
+                .fork_config()
+                .enforce_correctness_of_state_checkpoint_list(next_block_number);
+            let mem_block = MemBlock::new(
+                block_info,
+                post_merkle_state,
+                enforce_correctness_of_state_checkpoint_list,
+            );
             self.mem_block = mem_block;
 
             let mut state = StateDB::from_store(snapshot)?;
@@ -1475,7 +1483,7 @@ mod test {
 
         // Fill mem block
         let mem_block = {
-            let mut mem_block = MemBlock::new(block_info.clone(), prev_merkle_state.clone());
+            let mut mem_block = MemBlock::new(block_info.clone(), prev_merkle_state.clone(), true);
             for ((hash, touched_keys), state) in { withdrawals.clone().into_iter() }
                 .zip(withdrawals_touch_keys.clone())
                 .zip(withdrawals_state.clone())
@@ -1514,7 +1522,7 @@ mod test {
         );
 
         let repackage = |withdrawals_count, deposits_count, txs_count| -> _ {
-            let mut expected = MemBlock::new(block_info.clone(), prev_merkle_state.clone());
+            let mut expected = MemBlock::new(block_info.clone(), prev_merkle_state.clone(), true);
             let mut post_states = vec![prev_merkle_state.clone()];
             for ((hash, touched_keys), state) in { withdrawals.clone().into_iter() }
                 .zip(withdrawals_touch_keys.clone())

--- a/gwos/contracts/gw-utils/src/fork.rs
+++ b/gwos/contracts/gw-utils/src/fork.rs
@@ -9,6 +9,11 @@ impl Fork {
         global_state_version == 1
     }
 
+    // Fork feature: enforce the correctness of `RawL2Block.state_checkpoint_list`.
+    pub const fn enforce_correctness_of_state_checkpoint_list(global_state_version: u8) -> bool {
+        global_state_version <= 1
+    }
+
     // Fork feature: block.timestamp in the backbone range
     pub const fn enforce_block_timestamp_in_l1_backbone_range(global_state_version: u8) -> bool {
         global_state_version >= 2


### PR DESCRIPTION
Currently, Godwoken supports single-round interactive challenge mechanism, in which challengers replay disputed transactions on L1 to detect invalid assertions. We need state root lists for each L2 transaction in order to determine who wins. The state root lists are represented by [`RawL2Block.state_checkpoint_list`](https://github.com/nervosnetwork/godwoken-scripts/blob/b50b8fce5e1a1a2742f2edb6538da5df62b60029/c/godwoken.mol#L107) ~~, and [`RawL2Block.submit_transactions.prev_state_checkpoint`](https://github.com/nervosnetwork/godwoken-scripts/blob/b50b8fce5e1a1a2742f2edb6538da5df62b60029/c/godwoken.mol#L89)~~

Godwoken plans to switch to multiple-round interactive challenge mechanism. So that the state root lists are useless any more.

~~This PR deprecates verifications for `state_checkpoint_list` and `prev_state_checkpoint` but keeps the fields.~~
This PR adds a fork trigger `enforce_correctness_of_state_checkpoint_list(version: u8)`, represents whether check the `state_checkpoint_list` or not. This fork feature is enabled for versions less then v2.