### PR TITLE
chore(CI): add docker-prebuilds into monorepo 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,7 +132,7 @@ jobs:
           path: |
             target/release/godwoken
             target/release/gw-tools
-          key: component.godwoken-${{ steps.prepare.outputs.godwoken-sha1 }}
+          key: component.godwoken-crates-${{ hashFiles('crates/**') }}
       - name: Cache Godwoken target directory
         if: steps.godwoken-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,227 @@
+name: Docker
+
+on:
+  push:
+    branches: [ 'main', 'dev*', 'v1*', '1.*' ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*', '1.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ${{ github.ref_type != 'tag' && 'ghcr.io/' || '' }}
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: godwoken-prebuilds
+
+
+jobs:
+  docker-build-push:
+    runs-on: ubuntu-20.04
+    # Map the meta step outputs to this job outputs
+    outputs:
+      image_name: ${{ steps.result.outputs.image_name }}
+      image_tag: ${{ steps.result.outputs.image_tag }}
+    # If you specify the access for any of these scopes, all of those that are not specified are set to none.
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install Rust components
+        run: rustup component add rustfmt && rustup component add clippy
+      - name: Install moleculec
+        run: |
+          test "$(moleculec --version)" = "Moleculec 0.7.2" \
+          || cargo install moleculec --version 0.7.2 --force
+      - name: Install capsule
+        env:
+          CAPSULE_VERSION: v0.7.0
+        run: |
+          (which capsule && test "$(capsule --version)" = "Capsule 0.7.0") \
+          || curl -OL https://github.com/nervosnetwork/capsule/releases/download/${CAPSULE_VERSION}/capsule_${CAPSULE_VERSION}_x86_64-linux.tar.gz \
+          && tar xf capsule_${CAPSULE_VERSION}_x86_64-linux.tar.gz \
+          && mv capsule_${CAPSULE_VERSION}_x86_64-linux/capsule ~/.cargo/bin/
+          capsule --version
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      # GitHub automatically creates a unique GITHUB_TOKEN secret to use in this workflow.
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.ref_type != 'tag' && github.repository_owner || secrets.DOCKERHUB_USERNAME }}
+          password: ${{ github.ref_type != 'tag' && secrets.GITHUB_TOKEN || secrets.DOCKERHUB_TOKEN }}
+
+      - name: Prepare components
+        id: prepare
+        working-directory: docker
+        run: |
+          make prepare-repos
+          echo "Record the component's reference to the outputs of this step"
+          cat build/versions >> $GITHUB_OUTPUT
+
+      - name: Print the references of components
+        run: |
+          echo ref.component.godwoken=${{ steps.prepare.outputs.GODWOKEN_REF }}
+          echo ref.component.gwos=${{ steps.prepare.outputs.GODWOKEN_REF }}
+          echo ref.component.gwos-evm=${{ steps.prepare.outputs.GODWOKEN_REF }}
+          echo ref.component.ckb-production-scripts=${{ steps.prepare.outputs.OMNI_LOCK_REF }}
+
+      - name: Cache of component.ckb-production-scripts
+        id: ckb-production-scripts-cache
+        uses: actions/cache@v3
+        with:
+          path: docker/build/ckb-production-scripts/build/omni_lock
+          key: component.ckb-production-scripts-${{ steps.prepare.outputs.ckb-production-scripts-sha1 }}
+      - name: Build omni_lock
+        if: steps.ckb-production-scripts-cache.outputs.cache-hit != 'true'
+        working-directory: docker/build/ckb-production-scripts
+        run: make all-via-docker
+
+      - name: Cache of component.gwos
+        id: gwos-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            gwos/build/release/*
+            gwos/c/build/*-generator
+            gwos/c/build/*-validator
+            gwos/c/build/account_locks/*
+          key: component.gwos-${{ hashFiles('gwos/**') }}
+      - name: Build gwos binaries
+        if: steps.gwos-cache.outputs.cache-hit != 'true'
+        working-directory: gwos
+        run: cd c && make && cd .. && capsule build --release --debug-output
+
+      - name: Cache of component.gwos-evm
+        id: godwoken-polyjuice-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            gwos-evm/build/*generator*
+            gwos-evm/build/*validator*
+          key: component.gwos-evm-${{ hashFiles('gwos-evm/**') }}
+      - name: Build godwoken-polyjuice
+        if: steps.godwoken-polyjuice-cache.outputs.cache-hit != 'true'
+        working-directory: gwos-evm
+        run: |
+          git submodule update --init --recursive --depth=1
+          make all-via-docker
+
+      - name: Cache of component.godwoken
+        id: godwoken-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/release/godwoken
+            target/release/gw-tools
+          key: component.godwoken-${{ steps.prepare.outputs.godwoken-sha1 }}
+      - name: Cache Godwoken target directory
+        if: steps.godwoken-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-focal-cargo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-focal-cargo-
+      - name: Build godwoken
+        if: steps.godwoken-cache.outputs.cache-hit != 'true'
+        # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2, that means "mostly portable".
+        # see also: https://github.com/nervosnetwork/rust-rocksdb/blob/2de3ae5e5e23a315a477bd24e700eb4f5ef7a378/librocksdb-sys/build_detect_platform#L696-L699
+        run: |
+          rustup component add rustfmt
+          PORTABLE=1 USE_SSE=1 RUSTFLAGS="-C target-cpu=skylake" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}${{ startsWith(github.ref, 'refs/tags') && github.repository_owner == 'godwokenrises' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
+          # dynamically set date as a suffix
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch,suffix=-{{date 'YYYYMMDDHHmm'}}
+            type=ref,event=branch
+          labels: |
+            maintainer=Godwoken Core Dev
+            org.opencontainers.image.authors=Godwoken Core Dev
+            source.component.godwoken=https://github.com/godwokenrises/godwoken/tree/${{steps.prepare.outputs.GODWOKEN_REF }}
+            source.component.gwos=https://github.com/godwokenrises/godwoken/tree/${{steps.prepare.outputs.GODWOKEN_REF }}/gwos
+            source.component.gwos-evm=https://github.com/godwokenrises/godwoken/tree/${{steps.prepare.outputs.GODWOKEN_REF }}/gwos-evm
+            source.component.ckb-production-scripts=https://github.com/nervosnetwork/ckb-production-scripts/tree/${{steps.prepare.outputs.OMNI_LOCK_REF }}
+            ref.component.godwoken=${{ steps.prepare.outputs.GODWOKEN_REF }}
+            ref.component.godwoken-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
+            ref.component.gwos=${{ steps.prepare.outputs.GODWOKEN_REF }}
+            ref.component.gwos-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
+            ref.component.gwos-evm=${{ steps.prepare.outputs.GODWOKEN_REF }}
+            ref.component.gwos-evm-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
+            ref.component.ckb-production-scripts=${{ steps.prepare.outputs.OMNI_LOCK_REF }}
+            ref.component.ckb-production-scripts-sha1=${{ steps.prepare.outputs.ckb-production-scripts-sha1 }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+        if: ${{ github.ref_type != 'tag' }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # only for new tag
+      - name: Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-prebuilds
+        if: ${{ github.repository_owner == 'godwokenrises' && startsWith(github.ref, 'refs/tags') }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Check versions of the binaries in ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: |
+          docker run --rm ${{ env.IMAGE }} godwoken --version
+          docker run --rm ${{ env.IMAGE }} gw-tools --version
+          docker run --rm ${{ env.IMAGE }} ckb --version
+          docker run --rm ${{ env.IMAGE }} ckb-cli --version
+          docker run --rm ${{ env.IMAGE }} find /scripts -type f -exec sha1sum {} \;
+
+      - name: Record image info to the outputs of this jobs
+        id: result
+        run: |
+          echo "image_name=`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $1}'`" >> $GITHUB_OUTPUT
+          echo "image_tag=`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $NF}'`" >> $GITHUB_OUTPUT
+
+  integration-test:
+    needs: docker-build-push
+    uses: godwokenrises/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
+    with:
+      extra_github_env: |
+        GODWOKEN_PREBUILD_IMAGE_NAME="${{ needs.docker-build-push.outputs.image_name }}:${{ needs.docker-build-push.outputs.image_tag }}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,80 @@
+# Historical versions refer to checksum.txt
+# https://github.com/godwokenrises/godwoken-docker-prebuilds/pkgs/container/godwoken-prebuilds/49615211?tag=dev-poly1.5.0-202211091419
+FROM ghcr.io/godwokenrises/godwoken-prebuilds:dev-poly1.5.0 as historical-versions
+
+################################################################################
+
+# https://hub.docker.com/_/ubuntu/
+FROM ubuntu:focal
+LABEL description="Docker image containing all binaries used by Godwoken, saving you the hassles of building them yourself."
+LABEL maintainer="Godwoken Core Dev"
+
+RUN mkdir -p /scripts/godwoken-scripts \
+ && mkdir -p /scripts/godwoken-polyjuice \
+ && mkdir /ckb 
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y curl jq \
+ && apt-get clean \
+ && echo 'Finished installing OS updates'
+
+# ckb
+RUN cd /ckb \
+ && curl -LO https://github.com/nervosnetwork/ckb/releases/download/v0.103.0/ckb_v0.103.0_x86_64-unknown-linux-gnu.tar.gz \
+ && tar xzf ckb_v0.103.0_x86_64-unknown-linux-gnu.tar.gz \
+ && cp ckb_v0.103.0_x86_64-unknown-linux-gnu/ckb /bin/ckb \
+ && cp ckb_v0.103.0_x86_64-unknown-linux-gnu/ckb-cli /bin/ckb-cli \
+ && rm -rf /ckb
+
+# Copy historical versions (refer to checksum.txt)
+#
+# If <dest> doesn’t exist, it is created along with all missing directories in its path.
+# refer to https://docs.docker.com/engine/reference/builder/#copy
+COPY docker/checksum.txt /scripts/
+COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.1.5-beta/ \
+                                /scripts/godwoken-polyjuice-v1.1.5-beta/
+COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.2.0/ \
+                                /scripts/godwoken-polyjuice-v1.2.0/
+COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.4.0/ \
+                                /scripts/godwoken-polyjuice-v1.4.0/
+COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.4.1/ \
+                                /scripts/godwoken-polyjuice-v1.4.1/
+COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.4.2/ \
+                                /scripts/godwoken-polyjuice-v1.4.2/
+COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.4.4/ \
+                                /scripts/godwoken-polyjuice-v1.4.4/
+COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.4.5/ \
+                                /scripts/godwoken-polyjuice-v1.4.5/
+COPY --from=historical-versions /scripts/godwoken-polyjuice/* \
+                                /scripts/godwoken-polyjuice-v1.5.0/
+
+#################################### latest ####################################
+# COPY [--chown=<user>:<group>] ["<src>",... "<dest>"]
+
+# /scripts/godwoken-polyjuice
+COPY gwos-evm/build/*generator* \
+     gwos-evm/build/*validator* \
+     /scripts/godwoken-polyjuice/
+# TODO: remove *.aot in Polyjuice Makefile
+# RUN find /scripts -type f -name '*.aot' -exec rm {} \;
+
+# /scripts/omni-lock and /scripts/godwoken-scripts
+COPY docker/build/ckb-production-scripts/build/omni_lock \
+     gwos/build/release/* \
+     gwos/c/build/*-generator \ 
+     gwos/c/build/*-validator \
+     gwos/c/build/account_locks/* \
+     /scripts/godwoken-scripts/
+
+# godwoken
+COPY target/release/godwoken \
+     target/release/gw-tools \
+     docker/gw-healthcheck.sh \
+     /bin/
+################################################################################
+
+
+WORKDIR /deploy
+
+CMD [ "godwoken", "--version" ]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,64 @@
+SHELL := /bin/bash
+
+# components repos
+OMNI_LOCK_REPO := https://github.com/nervosnetwork/ckb-production-scripts.git
+
+# components tags
+OMNI_LOCK_REF := rc_lock
+
+define prepare_repo
+	if [ ! -d "build/$(3)" ]; then\
+		git clone --depth=1 $(1) build/$(3);\
+	fi
+	cd build/$(3);\
+	git fetch origin $(2);\
+	git checkout FETCH_HEAD;\
+	git submodule update --init --recursive --depth=1;\
+	echo "$(3)-sha1=$$(git rev-parse HEAD)" >> ../versions
+endef
+
+prepare-repos:
+	mkdir -p build
+	echo "godwoken-sha1=$$(git rev-parse HEAD)" >> build/versions
+	echo "GODWOKEN_REF=$$(git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD) $$(git rev-parse --short HEAD)" >> build/versions
+	$(call prepare_repo,$(OMNI_LOCK_REPO),$(OMNI_LOCK_REF),ckb-production-scripts)
+	echo "OMNI_LOCK_REF=$(OMNI_LOCK_REF) $$(cd build/ckb-production-scripts && git rev-parse --short HEAD)" >> build/versions
+
+build-components: prepare-repos
+	cd build/ckb-production-scripts && make all-via-docker
+	cd ../gwos-evm && git submodule update --init --recursive --depth=1 && make dist && cd -
+	cd ../gwos && cd c && make && cd .. && capsule build --release --debug-output && cd ../..
+	cd ../ && rustup component add rustfmt && RUSTFLAGS="-C target-cpu=native" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
+
+build-push:
+	make build-components
+	@read -p "Please Enter New Image Tag: " VERSION ; \
+	docker build . -t nervos/godwoken-prebuilds:$$VERSION ; \
+	docker push nervos/godwoken-prebuilds:$$VERSION
+
+test:
+	make build-components
+	docker build . -t godwokenrises/godwoken-prebuilds:latest-test
+	mkdir -p `pwd`/test-result/scripts
+	mkdir -p `pwd`/test-result/bin
+	docker run -it -d --name dummy godwokenrises/godwoken-prebuilds:latest-test
+	docker cp dummy:/scripts/. `pwd`/test-result/scripts
+	docker cp dummy:/bin/godwoken `pwd`/test-result/bin
+	docker cp dummy:/bin/gw-tools `pwd`/test-result/bin
+	docker rm -f dummy
+	make test-files
+
+test-files:
+	echo "start checking build result..."
+# compare scripts files
+	make test-scripts-files
+	make test-polyjuice-files
+# compare bin files
+	cd `pwd`/test-result/bin && ./godwoken --version && ./gw-tools --version
+	[ -e "test-result" ] && rm -rf test-result
+
+test-scripts-files:
+	source tool.sh && check_scripts_files_exists
+
+test-polyjuice-files:
+	source tool.sh && check_polyjuice_files_exists 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,66 @@
+godwoken-docker-prebuilds
+=========================
+
+Docker image containing all binaries used by Godwoken, saving you the hassles of building them yourself.
+
+How to build:
+
+```bash
+$ make build-components
+$ docker build . -t godwoken-prebuilds
+```
+
+How to upgrade:
+
+```bash
+$ # make sure it pass test..
+$ make test
+$ # build and push to docker-hub, will ask you to enter image tag
+$ make build-push
+```
+
+## Usage
+
+`Godwoken` binary resides in `/bin/godwoken`, this is already in PATH so you can do this:
+
+```bash
+$ docker run --rm godwoken-prebuilds godwoken --version
+```
+
+`gw-tools` can be used in the same way:
+
+```bash
+$ docker run --rm godwoken-prebuilds gw-tools --version
+```
+
+CKB and ckb-cli are also available this way:
+
+```bash
+$ docker run --rm godwoken-prebuilds ckb --version
+$ docker run --rm godwoken-prebuilds ckb-cli --version
+```
+
+## CPU Feature Requirement
+
+Starting from version 1.3.0-rc3, the published images require [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). Most recent x86-64 CPUs support AVX2. On linux, you can check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`.
+
+If your CPU/environment does not support AVX2, you can build Godwoken targeting your specific CPU/environment:
+```sh
+cd build/godwoken && rustup component add rustfmt && RUSTFLAGS="-C target-cpu=native" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
+```
+
+## Check the reference of every component
+```bash
+docker inspect godwoken-prebuilds:[TAG] | egrep ref.component
+```
+
+## Scripts
+
+All the scripts used by Godwoken can be found at `/scripts` folder:
+
+```bash
+$ docker run --rm godwoken-prebuilds find /scripts -type f -exec sha1sum {} \;
+```
+
+### Result
+refer to [checksum.txt](./checksum.txt)

--- a/docker/checksum.txt
+++ b/docker/checksum.txt
@@ -1,0 +1,178 @@
+# Run command in ghcr.io/godwokenrises/godwoken-prebuilds:dev-poly1.5.0
+# ```bash
+# find /scripts -type f -exec sha1sum {} \;
+# ```
+
+############################## Godwoken scripts ################################
+# https://github.com/godwokenrises/godwoken-scripts/releases/tag/v1.3.0-rc1
+56d24b532b9d790d24ca236782e8ed034b375399  /scripts/godwoken-scripts/sudt-validator
+65556f1157bfa7819befe8cb1cf6af73924fdefa  /scripts/godwoken-scripts/eth-addr-reg-validator
+678e163a475dd82c14f71fec189982643916c5ca  /scripts/godwoken-scripts/meta-contract-validator
+df27b2036e747e07a8b9703262d17dc386736173  /scripts/godwoken-scripts/sudt-generator
+7716f9c629d1780129531929c21717050a8b20df  /scripts/godwoken-scripts/meta-contract-generator
+e72547948d6028328bfc06a8caf5ccdbe2c4be19  /scripts/godwoken-scripts/eth-addr-reg-generator
+677be9b2545c8d1b15aaeb039ac501b6a0f6244e  /scripts/godwoken-scripts/eth-account-lock
+e1a2acd8764648a795fd8f513d39820baf0a00d0  /scripts/godwoken-scripts/state-validator
+248c7d2d85749d163423f3477b12231de1a9b3cd  /scripts/godwoken-scripts/always-success
+87586b3bf1117389cc0cc0785b0b3dfb74b9632b  /scripts/godwoken-scripts/custodian-lock
+dfb6ad1ceda1dd19eb70bc0b3c01528134a7fe9b  /scripts/godwoken-scripts/stake-lock
+502391a6bde1b5d6261fdd4f96204a69796adb38  /scripts/godwoken-scripts/deposit-lock
+cb92414b9d489115880bb09c8d0a2df60839d471  /scripts/godwoken-scripts/tron-account-lock
+0f2d54a4b0c016404f8f6e80b5d538ee0f4411e8  /scripts/godwoken-scripts/withdrawal-lock
+0f22b0f4249504a01d9eb615ae03176f5a1d5ac3  /scripts/godwoken-scripts/challenge-lock
+dab522b3b5a7c6fd179915f9059dac92891756eb  /scripts/godwoken-scripts/omni_lock
+
+############################## polyjuice-v1.5.0 ################################
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.5.0
+f82b92b2c8189d87e1baccd9e491b1ba06b64896  /scripts/godwoken-polyjuice-v1.5.0/validator
+4a405cead970d93b54d3682d1b988815d7566e5b  /scripts/godwoken-polyjuice-v1.5.0/validator.debug
+bc962eec16855eb2b854d3036b0ac4fc47386a9c  /scripts/godwoken-polyjuice-v1.5.0/validator_log
+07921053dd22b8f8af8a9f58699435e22c328822  /scripts/godwoken-polyjuice-v1.5.0/validator_log.debug
+c415d5789453ecaea8b349c7158a5ad1d65eeec5  /scripts/godwoken-polyjuice-v1.5.0/generator_log.debug
+9695481ef6c7f844b183b35d6b9da9ef351d2278  /scripts/godwoken-polyjuice-v1.5.0/generator.debug
+d6bc9842d0ffb0f9b43ef081d5b1559cf6865b55  /scripts/godwoken-polyjuice-v1.5.0/generator
+d6bc9842d0ffb0f9b43ef081d5b1559cf6865b55  /scripts/godwoken-polyjuice-v1.5.0/generator.aot
+9e2d276a59455aaf42cbb35f991749a537a3372e  /scripts/godwoken-polyjuice-v1.5.0/generator_log.asm
+a4874e3de7dec54f8a7f590a57de9e4a85600368  /scripts/godwoken-polyjuice-v1.5.0/generator_log.aot
+a4874e3de7dec54f8a7f590a57de9e4a85600368  /scripts/godwoken-polyjuice-v1.5.0/generator_log
+d26f4a19fa098b1023dfc26b9bc32578103f4e0d  /scripts/godwoken-polyjuice-v1.5.0/generator.asm
+
+############################## polyjuice-v1.4.6 ################################
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.6
+ab74da9f111f980af23782ace59e344d92d46c47  /scripts/godwoken-polyjuice-v1.4.6/validator
+0684a9216b6734ba99a8dee1620c9d17f5d8e314  /scripts/godwoken-polyjuice-v1.4.6/validator.debug
+dc91baddc5e35eb533f74bf55e6d826aa9cfbc73  /scripts/godwoken-polyjuice-v1.4.6/validator_log
+e9a8be7f52c91a5f7aaab2b7ffd06d76a624ec93  /scripts/godwoken-polyjuice-v1.4.6/validator_log.debug
+bd77600fc95d1478da76975f75618afa82fea499  /scripts/godwoken-polyjuice-v1.4.6/generator_log.debug
+2ae44ba49d92fc677478096f17e1feb4fa36cdff  /scripts/godwoken-polyjuice-v1.4.6/generator.debug
+674d89bbde9b1505767bfda7ef4b7e9c6e1fde69  /scripts/godwoken-polyjuice-v1.4.6/generator
+674d89bbde9b1505767bfda7ef4b7e9c6e1fde69  /scripts/godwoken-polyjuice-v1.4.6/generator.aot
+89161b4c90ee580d549fa2cef6ddbd5bd569601b  /scripts/godwoken-polyjuice-v1.4.6/generator_log.asm
+84ea59bd860e178433014f9b92d86d4caaf8f9b8  /scripts/godwoken-polyjuice-v1.4.6/generator_log.aot
+84ea59bd860e178433014f9b92d86d4caaf8f9b8  /scripts/godwoken-polyjuice-v1.4.6/generator_log
+6591a8dca95a0f68b3322acc754b02ab10b2831c  /scripts/godwoken-polyjuice-v1.4.6/generator.asm
+
+############################## polyjuice-v1.4.5 ################################
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.5
+2f749b73a63d022fdcb94e42fb6f924efdcfb8c5  /scripts/godwoken-polyjuice-v1.4.5/validator
+c19540b8821783d05af6bc1e3960cdc00dbaff87  /scripts/godwoken-polyjuice-v1.4.5/validator.debug
+962ddcfa894ed27f08cfcf5e59951f388ce456f8  /scripts/godwoken-polyjuice-v1.4.5/validator_log
+6d6aaa6080c3f2d0f6c8345d2b1746204e883643  /scripts/godwoken-polyjuice-v1.4.5/validator_log.debug
+c4049acd646dbe3df0e57d0f8a29ca9efce567a2  /scripts/godwoken-polyjuice-v1.4.5/generator_log.debug
+65d6e3df32473038a4e8dbdd85f19a81b64d53eb  /scripts/godwoken-polyjuice-v1.4.5/generator.debug
+85f6ec98a6494ee795ba3357bd827401592de610  /scripts/godwoken-polyjuice-v1.4.5/generator
+85f6ec98a6494ee795ba3357bd827401592de610  /scripts/godwoken-polyjuice-v1.4.5/generator.aot
+f7efcba16d1119a34303581eed6d765130185a89  /scripts/godwoken-polyjuice-v1.4.5/generator_log.asm
+ab8fc52528862063ac41712ca2abb59e1165aa70  /scripts/godwoken-polyjuice-v1.4.5/generator_log.aot
+ab8fc52528862063ac41712ca2abb59e1165aa70  /scripts/godwoken-polyjuice-v1.4.5/generator_log
+5febfd0fd5adeb15cc225d61304c2e107c82ee37  /scripts/godwoken-polyjuice-v1.4.5/generator.asm
+
+############################## polyjuice-v1.4.4 ################################
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.4
+# polyjuice commit: f8385446ce5be78d55bee583a21e15205725b7af or 5f146f764067afb103f2ee9c7705e4a77e63beed
+7e71da732e2e66cac21feac7fe182346ca40ac29  /scripts/godwoken-polyjuice-v1.4.4/validator
+af2783ed65ac1f48cb23020d975a1a36e6f79006  /scripts/godwoken-polyjuice-v1.4.4/validator.debug
+5886c688558da022bcaaffe251be4d457802a067  /scripts/godwoken-polyjuice-v1.4.4/validator_log
+67e839c64ac90c630801c0b14bc58c6f5ba464ba  /scripts/godwoken-polyjuice-v1.4.4/validator_log.debug
+fceed518ed4e55bc025210072f9cd98ae36226d9  /scripts/godwoken-polyjuice-v1.4.4/generator_log.debug
+379f85d2fee595f090716d9dd30baef427081ed3  /scripts/godwoken-polyjuice-v1.4.4/generator.debug
+c46b5a6218bd4c27b75ce2784969043e2b85d548  /scripts/godwoken-polyjuice-v1.4.4/generator
+c46b5a6218bd4c27b75ce2784969043e2b85d548  /scripts/godwoken-polyjuice-v1.4.4/generator.aot
+c452a9d1dcc03152ddc39eb3f223c2ebbc3d5b69  /scripts/godwoken-polyjuice-v1.4.4/generator_log.asm
+473894521a20a79461d774f9e27e4f651c07d221  /scripts/godwoken-polyjuice-v1.4.4/generator_log.aot
+473894521a20a79461d774f9e27e4f651c07d221  /scripts/godwoken-polyjuice-v1.4.4/generator_log
+804679fdc2d78d386de95cae712d1714f146b12f  /scripts/godwoken-polyjuice-v1.4.4/generator.asm
+
+############################## polyjuice-v1.4.2 ################################
+# TODO: deprecated this useless version
+# polyjuice commit: e16ce9be7859ba93e2da5ca565c4f518fed160d9
+11cf4d6d51448e74314943b52691142b747ffa04  /scripts/godwoken-polyjuice-v1.4.2/generator_log.debug
+5a373dbc96add6408604140652834be5b3a20288  /scripts/godwoken-polyjuice-v1.4.2/generator.debug
+dfe6a33d298a9532a9b49da2ceacdadd575f4e4d  /scripts/godwoken-polyjuice-v1.4.2/validator
+2248a67dc2c487b1a70af8dfec50570f20f6d3c7  /scripts/godwoken-polyjuice-v1.4.2/generator
+2248a67dc2c487b1a70af8dfec50570f20f6d3c7  /scripts/godwoken-polyjuice-v1.4.2/generator.aot
+5cac4d9331f5be6f1f056722f5342c08b2925b11  /scripts/godwoken-polyjuice-v1.4.2/generator_log.asm
+a82cba554dcd829e838e8f63572ca4e61a6f6f53  /scripts/godwoken-polyjuice-v1.4.2/validator.debug
+e49b4f29b65b27d60b6abdafaf070cdcc4b35f7f  /scripts/godwoken-polyjuice-v1.4.2/validator_log
+c95f24d2cf66ef952e8d389bd8c1e5d86e47906c  /scripts/godwoken-polyjuice-v1.4.2/validator_log.debug
+e05ab6544cae382bc9b1cdb9e79a1ae66f419757  /scripts/godwoken-polyjuice-v1.4.2/generator_log.aot
+e05ab6544cae382bc9b1cdb9e79a1ae66f419757  /scripts/godwoken-polyjuice-v1.4.2/generator_log
+d4277ae8f939d35c4402c6943a81fc5710993497  /scripts/godwoken-polyjuice-v1.4.2/generator.asm
+
+############################## polyjuice-v1.4.1 ################################
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.1
+f788606a0c9fc88cbff8aa06e3e3536a4f7f46f6  /scripts/godwoken-polyjuice-v1.4.1/generator_log.debug
+a3e4ab6616ad1df2fe390f8e69f089f7342789e9  /scripts/godwoken-polyjuice-v1.4.1/generator.debug
+0a9c0ca1cb2f30ddc20411eb0a0d2fe9fb7b030a  /scripts/godwoken-polyjuice-v1.4.1/validator
+1aaab8204d65f490047450c7d6b06e30be46c786  /scripts/godwoken-polyjuice-v1.4.1/generator
+1aaab8204d65f490047450c7d6b06e30be46c786  /scripts/godwoken-polyjuice-v1.4.1/generator.aot
+e0091db46761bfe31f29f2a8ad8087dd07908e1e  /scripts/godwoken-polyjuice-v1.4.1/generator_log.asm
+5bf1cad9c533d78c9789fda676b7d26ccc9a207d  /scripts/godwoken-polyjuice-v1.4.1/validator.debug
+4063af3289308f5b97fb342d2b995a31bcb60a14  /scripts/godwoken-polyjuice-v1.4.1/validator_log
+9c27c25f807ae365dbcc5fe4b08e8f93789e6cc1  /scripts/godwoken-polyjuice-v1.4.1/validator_log.debug
+91a0f9b98274e1c72c9355723c44691df275b9d8  /scripts/godwoken-polyjuice-v1.4.1/generator_log.aot
+91a0f9b98274e1c72c9355723c44691df275b9d8  /scripts/godwoken-polyjuice-v1.4.1/generator_log
+663280beff09594b4172576d6b90733b7d1ec3a3  /scripts/godwoken-polyjuice-v1.4.1/generator.asm
+
+############################## polyjuice-v1.4.0 ################################
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.4.0
+f788606a0c9fc88cbff8aa06e3e3536a4f7f46f6  /scripts/godwoken-polyjuice-v1.4.0/generator_log.debug
+a3e4ab6616ad1df2fe390f8e69f089f7342789e9  /scripts/godwoken-polyjuice-v1.4.0/generator.debug
+19c1d90af029d1985d38fcef00026e8af9b9bfc0  /scripts/godwoken-polyjuice-v1.4.0/validator
+83f5ac4c187425f99a4fcd155d3662e3b6702e42  /scripts/godwoken-polyjuice-v1.4.0/generator
+83f5ac4c187425f99a4fcd155d3662e3b6702e42  /scripts/godwoken-polyjuice-v1.4.0/generator.aot
+c1b534ab2a44b82c70525eb574ccac94dfe1ee6d  /scripts/godwoken-polyjuice-v1.4.0/generator_log.asm
+5bf1cad9c533d78c9789fda676b7d26ccc9a207d  /scripts/godwoken-polyjuice-v1.4.0/validator.debug
+c99c6480c4778f17ac6bd40b2d983d13fb4ab3b6  /scripts/godwoken-polyjuice-v1.4.0/validator_log
+9c27c25f807ae365dbcc5fe4b08e8f93789e6cc1  /scripts/godwoken-polyjuice-v1.4.0/validator_log.debug
+18f528d3acc9f8c52c9685f1620b2f87133bb44c  /scripts/godwoken-polyjuice-v1.4.0/generator_log.aot
+18f528d3acc9f8c52c9685f1620b2f87133bb44c  /scripts/godwoken-polyjuice-v1.4.0/generator_log
+98d2229564422e06e69dc548111a3d097fd91a73  /scripts/godwoken-polyjuice-v1.4.0/generator.asm
+
+############################## polyjuice-v1.3.0 ################################
+# Godwoken testnet_v1 blocks[180000..] use godwoken-polyjuice-v1.3.0
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.3.0
+58dd869500d3a7ff21e973664fbe0647aad4afd2  /scripts/godwoken-polyjuice-v1.3.0/generator_log.debug
+1ab4b82f61e10912789699a4281a9e70365a2ee6  /scripts/godwoken-polyjuice-v1.3.0/generator.debug
+cbd218999c11179ed5d6d3193abe7f9178d8d58f  /scripts/godwoken-polyjuice-v1.3.0/validator
+e4a47d037cc6bd433b370e822ee6132b16dd9b0f  /scripts/godwoken-polyjuice-v1.3.0/generator
+e4a47d037cc6bd433b370e822ee6132b16dd9b0f  /scripts/godwoken-polyjuice-v1.3.0/generator.aot
+3fcc5519ec1834934f9471002c346e499c242c3c  /scripts/godwoken-polyjuice-v1.3.0/generator_log.asm
+5d4a374e797b8da741766a53bd2504528122d90b  /scripts/godwoken-polyjuice-v1.3.0/validator.debug
+a1e5e6885d9c9fb465655e2c42a234b989ae1732  /scripts/godwoken-polyjuice-v1.3.0/validator_log
+8db84dd427884bda3cfb8efe91651c1b44318eb5  /scripts/godwoken-polyjuice-v1.3.0/validator_log.debug
+8fd6c431fd0c35eb3ddcbd0c187551c00807620c  /scripts/godwoken-polyjuice-v1.3.0/generator_log.aot
+8fd6c431fd0c35eb3ddcbd0c187551c00807620c  /scripts/godwoken-polyjuice-v1.3.0/generator_log
+3a8b3ce21d8f47fd6cc00b7469ce76c5c841f6a7  /scripts/godwoken-polyjuice-v1.3.0/generator.asm
+
+############################## polyjuice-v1.2.0 ################################
+# Godwoken testnet_v1 blocks[110000..180000) use godwoken-polyjuice-v1.2.0
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/1.2.0
+b287e270d518620592822f908aa24752613edd0d  /scripts/godwoken-polyjuice-v1.2.0/generator_log.debug
+5b216531ea89d9da981937f4e0e9761243ff2bb0  /scripts/godwoken-polyjuice-v1.2.0/generator.debug
+86e2b0ecf246584ada7e64e4b5ebbac6918d7551  /scripts/godwoken-polyjuice-v1.2.0/validator
+b237ed5461b22079c0ec54d6db6dc10d6519ac3a  /scripts/godwoken-polyjuice-v1.2.0/generator
+b237ed5461b22079c0ec54d6db6dc10d6519ac3a  /scripts/godwoken-polyjuice-v1.2.0/generator.aot
+5faedf249944ef516780581bdab4fe307882c87d  /scripts/godwoken-polyjuice-v1.2.0/generator_log.asm
+50ff83099f174ff5c34d73e56c8eec04235e1352  /scripts/godwoken-polyjuice-v1.2.0/validator.debug
+41f24f61ea0b195245d6da8a98c02ae45efa35a6  /scripts/godwoken-polyjuice-v1.2.0/validator_log
+b7ab7425ffb17203d35f5dd2706c8161e4b70c25  /scripts/godwoken-polyjuice-v1.2.0/validator_log.debug
+d0059d518c764e034f30823283fed5cd6082e308  /scripts/godwoken-polyjuice-v1.2.0/generator_log.aot
+d0059d518c764e034f30823283fed5cd6082e308  /scripts/godwoken-polyjuice-v1.2.0/generator_log
+b8a17d45ccce7459e8e8da9e519dd5d9e1e320ab  /scripts/godwoken-polyjuice-v1.2.0/generator.asm
+
+############################ polyjuice-v1.1.5-beta #############################
+# Godwoken testnet_v1 blocks[0..110000) use polyjuice-v1.1.5-beta
+# https://github.com/godwokenrises/godwoken-polyjuice/releases/tag/v1.1.5-beta
+77d28b59cdd676c9f8e2f1a5e67d4e4e459964ff  /scripts/godwoken-polyjuice-v1.1.5-beta/generator_log.debug
+4af40a410c9c77ad70125c61d2b9fd5e01187a30  /scripts/godwoken-polyjuice-v1.1.5-beta/generator.debug
+d5cacaa93d92adc9748d4ed6e88259522b21161a  /scripts/godwoken-polyjuice-v1.1.5-beta/validator
+9f0188ce6a63728dc94866ef2afdd4a1be3f92d3  /scripts/godwoken-polyjuice-v1.1.5-beta/generator
+9f0188ce6a63728dc94866ef2afdd4a1be3f92d3  /scripts/godwoken-polyjuice-v1.1.5-beta/generator.aot
+b1ad76ebfd33d78dfe64eb83ccda48aa894eb1bf  /scripts/godwoken-polyjuice-v1.1.5-beta/generator_log.asm
+ac794559ba1ed447bbc4d981760dcdd5b206761b  /scripts/godwoken-polyjuice-v1.1.5-beta/validator.debug
+72c65857191fb3573082e575c4895198c4fc0847  /scripts/godwoken-polyjuice-v1.1.5-beta/validator_log
+4f3f1e5fc557477fb1f9430771e8adacd1b384f2  /scripts/godwoken-polyjuice-v1.1.5-beta/validator_log.debug
+6a48d77057e5f0273979940f58df91c03059a84e  /scripts/godwoken-polyjuice-v1.1.5-beta/generator_log.aot
+6a48d77057e5f0273979940f58df91c03059a84e  /scripts/godwoken-polyjuice-v1.1.5-beta/generator_log
+1c420832bcecf00e9507679e8d978167f24ba6c8  /scripts/godwoken-polyjuice-v1.1.5-beta/generator.asm

--- a/docker/gw-healthcheck.sh
+++ b/docker/gw-healthcheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Query whether a Godwoken readonly node is ready to serve
+# see: https://github.com/godwokenrises/godwoken/pull/644
+echo '{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "gw_get_mem_pool_state_ready",
+  "params": []
+}' \
+| tr -d '\n' \
+| curl --silent -H 'content-type: application/json' -d @- \
+http://127.0.0.1:8119 \
+| awk 'BEGIN { FS=":"; RS="," }; { if ($1 == "\"result\"") {print $2} }' \
+| egrep true || exit 1

--- a/docker/tool.sh
+++ b/docker/tool.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+check_scripts_files_exists(){
+    local -a arr=( 
+        "eth-account-lock"   "deposit-lock"     "custodian-lock"  "stake-lock"
+        "tron-account-lock"  "withdrawal-lock"  "challenge-lock"  "omni_lock"
+		
+        "always-success"     "state-validator"
+        
+        "meta-contract-generator"  "sudt-generator"  "eth-addr-reg-generator"
+		"meta-contract-validator"  "sudt-validator"  "eth-addr-reg-validator"
+	) 
+    local path=`pwd`/test-result/scripts/godwoken-scripts
+	check_multiple_files_exists "$path" "${arr[@]}"
+}
+
+check_polyjuice_files_exists(){
+    local -a arr=( 
+		"generator"        "generator_log"        "validator"        "validator_log"
+        "generator.debug"  "generator_log.debug"  "validator.debug"  "validator_log.debug"
+	) 
+    local path=`pwd`/test-result/scripts/godwoken-polyjuice
+    check_multiple_files_exists "$path" "${arr[@]}" 
+}
+
+check_multiple_files_exists(){
+    local check_path=$1
+    local -a arr=("$@")
+    
+    cd $check_path
+	for i in "${arr[@]}" 
+	do 
+        if [ "$i" != "$check_path" ]; then # the first one is just the check_path.
+	      [ -f "$i" ] && echo "test pass, found $i." || (echo "test failed, $i not found"; exit 1) ;
+        fi
+    done 
+}


### PR DESCRIPTION
1. Moved https://github.com/godwokenrises/godwoken-docker-prebuilds into Godwoken monorepo
2. Cache the built result to speed up the building process, such as:
   - component.ckb-production-scripts
   - component.gwos
   - component.gwos-evm
   - component.godwoken
3. Run godwoken-tests on the built image