### PR TITLE
chore(jsonrpc-types): switch timepoint to timestamp

### DIFF
--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -180,7 +180,7 @@ pub fn produce_block(
         .block(post_block)
         .tip_block_hash(block.hash().pack())
         .tip_block_timestamp(block.raw().timestamp())
-        .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+        .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
         .reverted_block_root(Into::<[u8; 32]>::into(reverted_block_root).pack())
         .rollup_config_hash(rollup_config_hash.pack())
         .status((Status::Running as u8).into())

--- a/crates/block-producer/src/withdrawal.rs
+++ b/crates/block-producer/src/withdrawal.rs
@@ -434,7 +434,7 @@ mod test {
         // Output should only change lock to owner lock
         let last_finalized_timepoint = Timepoint::from_block_number(100);
         let global_state = GlobalState::new_builder()
-            .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+            .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .build();
 
         let rollup_type = Script::new_builder()

--- a/crates/challenge/src/offchain/mock_block.rs
+++ b/crates/challenge/src/offchain/mock_block.rs
@@ -329,7 +329,7 @@ impl MockBlockParam {
             .account(post_account)
             .block(post_block)
             .tip_block_hash(raw_block.hash().pack())
-            .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+            .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .reverted_block_root(self.reverted_block_root.clone())
             .rollup_config_hash(self.rollup_config_hash.clone())
             .status((Status::Halting as u8).into())

--- a/crates/challenge/src/revert.rs
+++ b/crates/challenge/src/revert.rs
@@ -128,7 +128,7 @@ impl<'a> Revert<'a> {
             .block(block_merkle_state)
             .tip_block_hash(first_reverted_block.parent_block_hash())
             .tip_block_timestamp(self.revert_witness.new_tip_block.timestamp())
-            .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+            .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .reverted_block_root(self.post_reverted_block_root.pack())
             .status(running_status.into())
             .build();

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -724,14 +724,14 @@ impl From<GlobalState> for packed::GlobalState {
             .account(account.into())
             .block(block.into())
             .reverted_block_root(reverted_block_root.pack())
-            .last_finalized_block_number(last_finalized_block_number.pack())
+            .last_finalized_timepoint(last_finalized_block_number.pack())
             .status((status as u8).into())
             .build()
     }
 }
 impl From<packed::GlobalState> for GlobalState {
     fn from(global_state: packed::GlobalState) -> GlobalState {
-        let last_finalized_block_number: u64 = global_state.last_finalized_block_number().unpack();
+        let last_finalized_block_number: u64 = global_state.last_finalized_timepoint().unpack();
         let status: u8 = global_state.status().into();
         Self {
             account: global_state.account().into(),
@@ -1343,7 +1343,6 @@ pub struct WithdrawalLockArgs {
     // Before switching to v2, `withdrawal_block_number` should be `Some(block_number)` and
     // `withdrawal_block_timestamp` should be `None`; afterwards, `withdrawal_block_number` will
     // become `None` and `withdrawal_block_timestamp` will become `Some(block_timestamp)`.
-
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_block_number: Option<Uint64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -2,6 +2,7 @@ use crate::blockchain::Script;
 use anyhow::{anyhow, Error as JsonError};
 use ckb_fixed_hash::{H160, H256};
 use ckb_jsonrpc_types::{JsonBytes, Uint128, Uint32, Uint64};
+use gw_types::core::Timepoint;
 use gw_types::{bytes::Bytes, offchain, packed, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
@@ -1334,36 +1335,72 @@ pub struct FeeConfig {
 pub struct WithdrawalLockArgs {
     pub account_script_hash: H256,
     pub withdrawal_block_hash: H256,
-    pub withdrawal_block_number: Uint64,
+
+    // As Godwoken switches from v1 to v2 by bumping GlobalState.version from 1 to 2, the withdrawn
+    // timepoint representation by the withdrawn block number will be replaced by the withdrawn
+    // block timestamp.
+
+    // Before switching to v2, `withdrawal_block_number` should be `Some(block_number)` and
+    // `withdrawal_block_timestamp` should be `None`; afterwards, `withdrawal_block_number` will
+    // become `None` and `withdrawal_block_timestamp` will become `Some(block_timestamp)`.
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub withdrawal_block_number: Option<Uint64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub withdrawal_block_timestamp: Option<Uint64>,
+
     // layer1 lock to withdraw after challenge period
     pub owner_lock_hash: H256,
 }
 
-impl From<WithdrawalLockArgs> for packed::WithdrawalLockArgs {
-    fn from(json: WithdrawalLockArgs) -> packed::WithdrawalLockArgs {
+impl TryFrom<WithdrawalLockArgs> for packed::WithdrawalLockArgs {
+    type Error = JsonError;
+
+    fn try_from(json: WithdrawalLockArgs) -> Result<packed::WithdrawalLockArgs, Self::Error> {
         let WithdrawalLockArgs {
             account_script_hash,
             withdrawal_block_hash,
             withdrawal_block_number,
+            withdrawal_block_timestamp,
             owner_lock_hash,
         } = json;
-        packed::WithdrawalLockArgs::new_builder()
+        let withdrawal_block_timepoint = match (withdrawal_block_number, withdrawal_block_timestamp)
+        {
+            (Some(block_number), None) => Timepoint::from_block_number(block_number.value()),
+            (None, Some(timestamp)) => Timepoint::from_timestamp(timestamp.value()),
+            (bn, bt) => {
+                return Err(anyhow!(
+                    "conflict withdrawal_block_number {:?} and withdrawal_block_timestamp {:?}",
+                    bn,
+                    bt
+                ));
+            }
+        };
+
+        Ok(packed::WithdrawalLockArgs::new_builder()
             .account_script_hash(account_script_hash.pack())
             .withdrawal_block_hash(withdrawal_block_hash.pack())
-            .withdrawal_block_timepoint(withdrawal_block_number.value().pack())
+            .withdrawal_block_timepoint(withdrawal_block_timepoint.full_value().pack())
             .owner_lock_hash(owner_lock_hash.pack())
-            .build()
+            .build())
     }
 }
 
 impl From<packed::WithdrawalLockArgs> for WithdrawalLockArgs {
     fn from(data: packed::WithdrawalLockArgs) -> WithdrawalLockArgs {
-        let withdrawal_block_number: u64 = data.withdrawal_block_timepoint().unpack();
+        let withdrawal_block_timepoint =
+            Timepoint::from_full_value(data.withdrawal_block_timepoint().unpack());
+        let (withdrawal_block_number, withdrawal_block_timestamp) = match withdrawal_block_timepoint
+        {
+            Timepoint::BlockNumber(block_number) => (Some(block_number), None),
+            Timepoint::Timestamp(timestamp) => (None, Some(timestamp)),
+        };
         Self {
             account_script_hash: data.account_script_hash().unpack(),
             owner_lock_hash: data.owner_lock_hash().unpack(),
             withdrawal_block_hash: data.withdrawal_block_hash().unpack(),
-            withdrawal_block_number: withdrawal_block_number.into(),
+            withdrawal_block_number: withdrawal_block_number.map(Into::into),
+            withdrawal_block_timestamp: withdrawal_block_timestamp.map(Into::into),
         }
     }
 }

--- a/crates/tests/src/script_tests/state_validator/revert.rs
+++ b/crates/tests/src/script_tests/state_validator/revert.rs
@@ -26,7 +26,7 @@ use gw_common::{
 use gw_store::state::history::history_state::RWConfig;
 use gw_store::state::BlockStateDB;
 use gw_store::traits::chain_store::ChainStore;
-use gw_types::core::{AllowedContractType, AllowedEoaType};
+use gw_types::core::{AllowedContractType, AllowedEoaType, Timepoint};
 use gw_types::packed::{AllowedTypeHash, Fee};
 use gw_types::U256;
 use gw_types::{
@@ -334,7 +334,7 @@ async fn test_revert() {
             .unwrap();
         *reverted_block_tree.root()
     };
-    let last_finalized_block_number = {
+    let last_finalized_timepoint = {
         let number: u64 = challenged_block.raw().number().unpack();
         let finalize_blocks = chain
             .generator()
@@ -342,13 +342,13 @@ async fn test_revert() {
             .rollup_config
             .finality_blocks()
             .unpack();
-        (number - 1).saturating_sub(finalize_blocks)
+        Timepoint::from_block_number((number - 1).saturating_sub(finalize_blocks))
     };
     let rollup_cell_data = global_state
         .as_builder()
         .status(Status::Running.into())
         .reverted_block_root(Pack::pack(&post_reverted_block_root))
-        .last_finalized_block_number(Pack::pack(&last_finalized_block_number))
+        .last_finalized_timepoint(Pack::pack(&last_finalized_timepoint.full_value()))
         .account(challenged_block.raw().prev_account())
         .block(prev_block_merkle)
         .tip_block_hash(challenged_block.raw().parent_block_hash())

--- a/crates/tests/src/script_tests/withdrawal.rs
+++ b/crates/tests/src/script_tests/withdrawal.rs
@@ -45,7 +45,7 @@ fn test_unlock_withdrawal_via_finalize_by_input_owner_cell() {
     let rollup_cell = {
         let global_state = GlobalState::new_builder()
             .rollup_config_hash(verify_ctx.rollup_config().hash().pack())
-            .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+            .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .block(block_merkle_state)
             .build();
 
@@ -193,7 +193,7 @@ fn test_unlock_withdrawal_via_finalize_by_switch_indexed_output_to_owner_lock() 
     let rollup_cell = {
         let global_state = GlobalState::new_builder()
             .rollup_config_hash(verify_ctx.rollup_config().hash().pack())
-            .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+            .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .block(block_merkle_state)
             .build();
 
@@ -371,7 +371,7 @@ fn test_unlock_withdrawal_via_finalize_fallback_to_input_owner_cell() {
     let rollup_cell = {
         let global_state = GlobalState::new_builder()
             .rollup_config_hash(verify_ctx.rollup_config().hash().pack())
-            .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+            .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .block(block_merkle_state)
             .build();
 

--- a/crates/tests/src/tests/calc_finalizing_range.rs
+++ b/crates/tests/src/tests/calc_finalizing_range.rs
@@ -84,7 +84,7 @@ async fn test_calc_finalizing_range() {
                         .build(),
                 )
                 .tip_block_timestamp(timestamp.pack())
-                .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+                .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
                 .build()
         })
         .collect::<Vec<_>>();

--- a/crates/tests/src/tests/export_import_block.rs
+++ b/crates/tests/src/tests/export_import_block.rs
@@ -70,7 +70,7 @@ async fn test_export_import_block() {
 
     let last_finalized_timepoint = Timepoint::from_block_number(100);
     let global_state = GlobalState::new_builder()
-        .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+        .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
         .rollup_config_hash(rollup_config.hash().pack())
         .build();
 

--- a/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
+++ b/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
@@ -135,7 +135,7 @@ async fn test_build_unlock_to_owner_tx() {
     let last_finalized_block_number = 100;
     let last_finalized_timepoint = Timepoint::from_block_number(last_finalized_block_number);
     let global_state = GlobalState::new_builder()
-        .last_finalized_block_number(last_finalized_timepoint.full_value().pack())
+        .last_finalized_timepoint(last_finalized_timepoint.full_value().pack())
         .block(
             BlockMerkleState::new_builder()
                 .count(

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -18,7 +18,7 @@ struct GlobalStateV0 {
     block: BlockMerkleState,
     reverted_block_root: Byte32,
     tip_block_hash: Byte32,
-    last_finalized_block_number: Uint64,
+    last_finalized_timepoint: Uint64,
     // 0: running, 1: halting
     status: byte,
 }
@@ -31,7 +31,7 @@ struct GlobalState {
     tip_block_hash: Byte32,
     tip_block_timestamp: Uint64,
     // Timepoint format
-    last_finalized_block_number: Uint64,
+    last_finalized_timepoint: Uint64,
     // 0: running, 1: halting
     status: byte,
     version: byte,

--- a/crates/types/src/core.rs
+++ b/crates/types/src/core.rs
@@ -188,7 +188,7 @@ impl From<GlobalStateV0> for GlobalState {
             .block(global_state_v0.block())
             .reverted_block_root(global_state_v0.reverted_block_root())
             .tip_block_hash(global_state_v0.tip_block_hash())
-            .last_finalized_block_number(global_state_v0.last_finalized_block_number())
+            .last_finalized_timepoint(global_state_v0.last_finalized_timepoint())
             .status(global_state_v0.status())
             .tip_block_timestamp(0u64.pack())
             .version(0.into())

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -632,8 +632,8 @@ impl ::core::fmt::Display for GlobalStateV0 {
         write!(
             f,
             ", {}: {}",
-            "last_finalized_block_number",
-            self.last_finalized_block_number()
+            "last_finalized_timepoint",
+            self.last_finalized_timepoint()
         )?;
         write!(f, ", {}: {}", "status", self.status())?;
         write!(f, " }}")
@@ -672,7 +672,7 @@ impl GlobalStateV0 {
     pub fn tip_block_hash(&self) -> Byte32 {
         Byte32::new_unchecked(self.0.slice(140..172))
     }
-    pub fn last_finalized_block_number(&self) -> Uint64 {
+    pub fn last_finalized_timepoint(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(172..180))
     }
     pub fn status(&self) -> Byte {
@@ -710,7 +710,7 @@ impl molecule::prelude::Entity for GlobalStateV0 {
             .block(self.block())
             .reverted_block_root(self.reverted_block_root())
             .tip_block_hash(self.tip_block_hash())
-            .last_finalized_block_number(self.last_finalized_block_number())
+            .last_finalized_timepoint(self.last_finalized_timepoint())
             .status(self.status())
     }
 }
@@ -746,8 +746,8 @@ impl<'r> ::core::fmt::Display for GlobalStateV0Reader<'r> {
         write!(
             f,
             ", {}: {}",
-            "last_finalized_block_number",
-            self.last_finalized_block_number()
+            "last_finalized_timepoint",
+            self.last_finalized_timepoint()
         )?;
         write!(f, ", {}: {}", "status", self.status())?;
         write!(f, " }}")
@@ -772,7 +772,7 @@ impl<'r> GlobalStateV0Reader<'r> {
     pub fn tip_block_hash(&self) -> Byte32Reader<'r> {
         Byte32Reader::new_unchecked(&self.as_slice()[140..172])
     }
-    pub fn last_finalized_block_number(&self) -> Uint64Reader<'r> {
+    pub fn last_finalized_timepoint(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[172..180])
     }
     pub fn status(&self) -> ByteReader<'r> {
@@ -807,7 +807,7 @@ pub struct GlobalStateV0Builder {
     pub(crate) block: BlockMerkleState,
     pub(crate) reverted_block_root: Byte32,
     pub(crate) tip_block_hash: Byte32,
-    pub(crate) last_finalized_block_number: Uint64,
+    pub(crate) last_finalized_timepoint: Uint64,
     pub(crate) status: Byte,
 }
 impl GlobalStateV0Builder {
@@ -834,8 +834,8 @@ impl GlobalStateV0Builder {
         self.tip_block_hash = v;
         self
     }
-    pub fn last_finalized_block_number(mut self, v: Uint64) -> Self {
-        self.last_finalized_block_number = v;
+    pub fn last_finalized_timepoint(mut self, v: Uint64) -> Self {
+        self.last_finalized_timepoint = v;
         self
     }
     pub fn status(mut self, v: Byte) -> Self {
@@ -855,7 +855,7 @@ impl molecule::prelude::Builder for GlobalStateV0Builder {
         writer.write_all(self.block.as_slice())?;
         writer.write_all(self.reverted_block_root.as_slice())?;
         writer.write_all(self.tip_block_hash.as_slice())?;
-        writer.write_all(self.last_finalized_block_number.as_slice())?;
+        writer.write_all(self.last_finalized_timepoint.as_slice())?;
         writer.write_all(self.status.as_slice())?;
         Ok(())
     }
@@ -904,8 +904,8 @@ impl ::core::fmt::Display for GlobalState {
         write!(
             f,
             ", {}: {}",
-            "last_finalized_block_number",
-            self.last_finalized_block_number()
+            "last_finalized_timepoint",
+            self.last_finalized_timepoint()
         )?;
         write!(f, ", {}: {}", "status", self.status())?;
         write!(f, ", {}: {}", "version", self.version())?;
@@ -948,7 +948,7 @@ impl GlobalState {
     pub fn tip_block_timestamp(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(172..180))
     }
-    pub fn last_finalized_block_number(&self) -> Uint64 {
+    pub fn last_finalized_timepoint(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(180..188))
     }
     pub fn status(&self) -> Byte {
@@ -990,7 +990,7 @@ impl molecule::prelude::Entity for GlobalState {
             .reverted_block_root(self.reverted_block_root())
             .tip_block_hash(self.tip_block_hash())
             .tip_block_timestamp(self.tip_block_timestamp())
-            .last_finalized_block_number(self.last_finalized_block_number())
+            .last_finalized_timepoint(self.last_finalized_timepoint())
             .status(self.status())
             .version(self.version())
     }
@@ -1033,8 +1033,8 @@ impl<'r> ::core::fmt::Display for GlobalStateReader<'r> {
         write!(
             f,
             ", {}: {}",
-            "last_finalized_block_number",
-            self.last_finalized_block_number()
+            "last_finalized_timepoint",
+            self.last_finalized_timepoint()
         )?;
         write!(f, ", {}: {}", "status", self.status())?;
         write!(f, ", {}: {}", "version", self.version())?;
@@ -1063,7 +1063,7 @@ impl<'r> GlobalStateReader<'r> {
     pub fn tip_block_timestamp(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[172..180])
     }
-    pub fn last_finalized_block_number(&self) -> Uint64Reader<'r> {
+    pub fn last_finalized_timepoint(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[180..188])
     }
     pub fn status(&self) -> ByteReader<'r> {
@@ -1102,7 +1102,7 @@ pub struct GlobalStateBuilder {
     pub(crate) reverted_block_root: Byte32,
     pub(crate) tip_block_hash: Byte32,
     pub(crate) tip_block_timestamp: Uint64,
-    pub(crate) last_finalized_block_number: Uint64,
+    pub(crate) last_finalized_timepoint: Uint64,
     pub(crate) status: Byte,
     pub(crate) version: Byte,
 }
@@ -1134,8 +1134,8 @@ impl GlobalStateBuilder {
         self.tip_block_timestamp = v;
         self
     }
-    pub fn last_finalized_block_number(mut self, v: Uint64) -> Self {
-        self.last_finalized_block_number = v;
+    pub fn last_finalized_timepoint(mut self, v: Uint64) -> Self {
+        self.last_finalized_timepoint = v;
         self
     }
     pub fn status(mut self, v: Byte) -> Self {
@@ -1160,7 +1160,7 @@ impl molecule::prelude::Builder for GlobalStateBuilder {
         writer.write_all(self.reverted_block_root.as_slice())?;
         writer.write_all(self.tip_block_hash.as_slice())?;
         writer.write_all(self.tip_block_timestamp.as_slice())?;
-        writer.write_all(self.last_finalized_block_number.as_slice())?;
+        writer.write_all(self.last_finalized_timepoint.as_slice())?;
         writer.write_all(self.status.as_slice())?;
         writer.write_all(self.version.as_slice())?;
         Ok(())

--- a/crates/types/src/offchain/compatible_finalized_timepoint.rs
+++ b/crates/types/src/offchain/compatible_finalized_timepoint.rs
@@ -14,7 +14,7 @@ pub struct CompatibleFinalizedTimepoint {
 
 impl CompatibleFinalizedTimepoint {
     pub fn from_global_state(global_state: &GlobalState, rollup_config_finality: u64) -> Self {
-        match Timepoint::from_full_value(global_state.last_finalized_block_number().unpack()) {
+        match Timepoint::from_full_value(global_state.last_finalized_timepoint().unpack()) {
             Timepoint::BlockNumber(finalized_block_number) => Self {
                 finalized_block_number,
                 finalized_timestamp: None,


### PR DESCRIPTION
**NOTE: Due to the fact that the two updated JSONRPC types are not open to any RPC interfaces, this PR does not break anything.**

---

As Godwoken switches from v1 to v2 by bumping GlobalState.version from 1 to 2, timepoint representation will change from block number to timestamp.

According to the Global State version, the two following JSONRPC types have different fields:
- [`GlobalState`](https://github.com/nervosnetwork/godwoken/blob/b44480f25f5d61f2be605d8dd00b1ea1f74be147/crates/jsonrpc-types/src/godwoken.rs#L704-L722)
  - When Global State version is v1, `GlobalState` in JSON is
  ```
  {
      "account": ...,
      "block": ...,
      "reverted_block_root": ...,
      "status": ...,
      "last_finalized_block_number": <the last finalized block number>
  }
  ```

  - When Global State version is v2, `GlobalState` in JSON is

  ```
  {
      "account": ...,
      "block": ...,
      "reverted_block_root": ...,
      "status": ...,
      "last_finalized_timestamp": <the last finalized timestamp>
  }
  ```

- [`WithdrawalLockArgs`](https://github.com/godwokenrises/godwoken/blob/b44480f25f5d61f2be605d8dd00b1ea1f74be147/crates/jsonrpc-types/src/godwoken.rs#L1368-L1386)
  - When Global State version is v1, `WithdrawalLockArgs` in JSON is
  ```
  {
    "account_script_hash": ...,
    "withdrawal_block_hash": ...,
    "withdrawal_block_number": ...,
    "owner_lock_hash": ...,
    "withdrawal_block_number": <the withdrawn block number>
  }
  ```
  - When Global State version is v2,  `WithdrawalLockArgs` in JSON is
  ```
  {
    "account_script_hash": ...,
    "withdrawal_block_hash": ...,
    "withdrawal_block_number": ...,
    "owner_lock_hash": ...,
    "withdrawal_block_timestamp": <the withdrawn block timestamp>
  }
  ```