### PR TITLE
fix(withdrawal): finalized withdrawal take longer time to unlock

### DIFF
--- a/crates/block-producer/src/psc.rs
+++ b/crates/block-producer/src/psc.rs
@@ -75,8 +75,6 @@ pub struct PSCContext {
     pub chain: Arc<Mutex<Chain>>,
     pub mem_pool: Arc<Mutex<MemPool>>,
     pub block_producer: BlockProducer,
-    // Use mutex to make rust happy. Actually we won't refresh or access this at
-    // the same time.
     pub local_cells_manager: Arc<Mutex<LocalCellsManager>>,
     pub chain_updater: ChainUpdater,
     pub rollup_type_script: Script,

--- a/crates/block-producer/src/psc.rs
+++ b/crates/block-producer/src/psc.rs
@@ -77,7 +77,7 @@ pub struct PSCContext {
     pub block_producer: BlockProducer,
     // Use mutex to make rust happy. Actually we won't refresh or access this at
     // the same time.
-    pub local_cells_manager: Mutex<LocalCellsManager>,
+    pub local_cells_manager: Arc<Mutex<LocalCellsManager>>,
     pub chain_updater: ChainUpdater,
     pub rollup_type_script: Script,
     pub psc_config: PscConfig,

--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -591,6 +591,7 @@ pub async fn run(config: Config, skip_config_check: bool) -> Result<()> {
         rollup_type_script.clone(),
     );
 
+    let local_cells_manager = Arc::new(Mutex::new(LocalCellsManager::default()));
     let (block_producer, challenger, test_mode_control, withdrawal_unlocker, cleaner) = match config
         .node_mode
     {
@@ -631,6 +632,7 @@ pub async fn run(config: Config, skip_config_check: bool) -> Result<()> {
 
             let withdrawal_unlocker = FinalizedWithdrawalUnlocker::new(
                 rpc_client.clone(),
+                local_cells_manager.clone(),
                 ckb_genesis_info.clone(),
                 contracts_dep_manager.clone(),
                 unlocker_wallet,
@@ -798,7 +800,7 @@ pub async fn run(config: Config, skip_config_check: bool) -> Result<()> {
             rpc_client: rpc_client.clone(),
             chain: chain.clone(),
             mem_pool,
-            local_cells_manager: Mutex::new(LocalCellsManager::default()),
+            local_cells_manager,
             chain_updater: chain_updater.clone(),
             rollup_type_script: rollup_type_script.clone(),
             psc_config: config.block_producer.as_ref().unwrap().psc_config.clone(),


### PR DESCRIPTION
Rollup cell queried from ckb-indexer may be outdated, because PSC store latest rollup cell outpoint in local cells manager. In order to reduce chance of getting outdated outpoint, we query from local cells manager first.