### PR TITLE
feat(withdrawal): set block timepoint to finalized timestamp

### DIFF
--- a/crates/block-producer/src/withdrawal_unlocker.rs
+++ b/crates/block-producer/src/withdrawal_unlocker.rs
@@ -185,10 +185,11 @@ pub trait BuildUnlockWithdrawalToOwner {
         };
 
         let global_state = global_state_from_slice(&rollup_cell.data)?;
-        let compatible_finalized_timepoint = CompatibleFinalizedTimepoint::from_global_state(
-            &global_state,
-            self.rollup_config().finality_blocks().unpack(),
-        );
+        let compatible_finalized_timepoint =
+            CompatibleFinalizedTimepoint::from_global_state_tip_block_timestamp(
+                &global_state,
+                self.rollup_config().finality_blocks().unpack(),
+            );
         let unlockable_withdrawals = self
             .query_unlockable_withdrawals(&compatible_finalized_timepoint, unlocked)
             .await?;

--- a/crates/generator/src/utils.rs
+++ b/crates/generator/src/utils.rs
@@ -57,7 +57,7 @@ pub fn build_withdrawal_cell_output(
         let withdrawal_lock_args = WithdrawalLockArgs::new_builder()
             .account_script_hash(req.raw().account_script_hash())
             .withdrawal_block_hash(Into::<[u8; 32]>::into(*block_hash).pack())
-            .withdrawal_block_timepoint(block_timepoint.full_value().pack())
+            .finalized_timepoint(block_timepoint.full_value().pack())
             .owner_lock_hash(req.raw().owner_lock_hash())
             .build();
 
@@ -234,7 +234,7 @@ mod test {
         );
         assert_eq!(lock_args.withdrawal_block_hash(), block_hash.pack());
         assert_eq!(
-            lock_args.withdrawal_block_timepoint().unpack(),
+            lock_args.finalized_timepoint().unpack(),
             block_timepoint.full_value()
         );
         assert_eq!(lock_args.owner_lock_hash(), owner_lock.hash().pack());

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -1374,12 +1374,12 @@ pub struct WithdrawalLockArgs {
     // block timestamp.
 
     // Before switching to v2, `withdrawal_block_number` should be `Some(block_number)` and
-    // `withdrawal_block_timestamp` should be `None`; afterwards, `withdrawal_block_number` will
-    // become `None` and `withdrawal_block_timestamp` will become `Some(block_timestamp)`.
+    // `withdrawal_finalized_timestamp` should be `None`; afterwards, `withdrawal_block_number` will
+    // become `None` and `withdrawal_finalized_timestamp` will become `Some(block_timestamp)`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_block_number: Option<Uint64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub withdrawal_block_timestamp: Option<Uint64>,
+    pub withdrawal_finalized_timestamp: Option<Uint64>,
 
     // layer1 lock to withdraw after challenge period
     pub owner_lock_hash: H256,
@@ -1393,16 +1393,15 @@ impl TryFrom<WithdrawalLockArgs> for packed::WithdrawalLockArgs {
             account_script_hash,
             withdrawal_block_hash,
             withdrawal_block_number,
-            withdrawal_block_timestamp,
+            withdrawal_finalized_timestamp,
             owner_lock_hash,
         } = json;
-        let withdrawal_block_timepoint = match (withdrawal_block_number, withdrawal_block_timestamp)
-        {
+        let finalized_timepoint = match (withdrawal_block_number, withdrawal_finalized_timestamp) {
             (Some(block_number), None) => Timepoint::from_block_number(block_number.value()),
             (None, Some(timestamp)) => Timepoint::from_timestamp(timestamp.value()),
             (bn, bt) => {
                 return Err(anyhow!(
-                    "conflict withdrawal_block_number {:?} and withdrawal_block_timestamp {:?}",
+                    "conflict withdrawal_block_number {:?} and withdrawal_finalized_timestamp {:?}",
                     bn,
                     bt
                 ));
@@ -1412,7 +1411,7 @@ impl TryFrom<WithdrawalLockArgs> for packed::WithdrawalLockArgs {
         Ok(packed::WithdrawalLockArgs::new_builder()
             .account_script_hash(account_script_hash.pack())
             .withdrawal_block_hash(withdrawal_block_hash.pack())
-            .withdrawal_block_timepoint(withdrawal_block_timepoint.full_value().pack())
+            .finalized_timepoint(finalized_timepoint.full_value().pack())
             .owner_lock_hash(owner_lock_hash.pack())
             .build())
     }
@@ -1420,10 +1419,8 @@ impl TryFrom<WithdrawalLockArgs> for packed::WithdrawalLockArgs {
 
 impl From<packed::WithdrawalLockArgs> for WithdrawalLockArgs {
     fn from(data: packed::WithdrawalLockArgs) -> WithdrawalLockArgs {
-        let withdrawal_block_timepoint =
-            Timepoint::from_full_value(data.withdrawal_block_timepoint().unpack());
-        let (withdrawal_block_number, withdrawal_block_timestamp) = match withdrawal_block_timepoint
-        {
+        let finalized_timepoint = Timepoint::from_full_value(data.finalized_timepoint().unpack());
+        let (withdrawal_block_number, withdrawal_finalized_timestamp) = match finalized_timepoint {
             Timepoint::BlockNumber(block_number) => (Some(block_number), None),
             Timepoint::Timestamp(timestamp) => (None, Some(timestamp)),
         };
@@ -1432,7 +1429,7 @@ impl From<packed::WithdrawalLockArgs> for WithdrawalLockArgs {
             owner_lock_hash: data.owner_lock_hash().unpack(),
             withdrawal_block_hash: data.withdrawal_block_hash().unpack(),
             withdrawal_block_number: withdrawal_block_number.map(Into::into),
-            withdrawal_block_timestamp: withdrawal_block_timestamp.map(Into::into),
+            withdrawal_finalized_timestamp: withdrawal_finalized_timestamp.map(Into::into),
         }
     }
 }

--- a/crates/mem-pool/src/withdrawal.rs
+++ b/crates/mem-pool/src/withdrawal.rs
@@ -125,7 +125,8 @@ impl<'a> Generator<'a> {
                 .use_timestamp_as_timepoint(block_number)
             {
                 let block_timestamp = block.raw().timestamp().unpack();
-                Timepoint::from_timestamp(block_timestamp)
+                let finality_time_in_ms = self.rollup_context.rollup_config.finality_time_in_ms();
+                Timepoint::from_timestamp(block_timestamp.saturating_add(finality_time_in_ms))
             } else {
                 Timepoint::from_block_number(block_number)
             }

--- a/crates/rpc-client/src/withdrawal.rs
+++ b/crates/rpc-client/src/withdrawal.rs
@@ -51,7 +51,7 @@ fn verify_finalized_owner_lock(
     };
 
     if !compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
-        lock_args.withdrawal_block_timepoint().unpack(),
+        lock_args.finalized_timepoint().unpack(),
     )) {
         bail!("unfinalized withdrawal");
     }
@@ -102,7 +102,7 @@ mod test {
             CompatibleFinalizedTimepoint::from_block_number(finalized_block_number, 0);
         let lock_args = WithdrawalLockArgs::new_builder()
             .owner_lock_hash(owner_lock.hash().pack())
-            .withdrawal_block_timepoint(last_finalized_timepoint.full_value().pack())
+            .finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .build();
 
         let mut args = rollup_type_hash.to_vec();
@@ -138,7 +138,7 @@ mod test {
         let err_lock_args = lock_args
             .clone()
             .as_builder()
-            .withdrawal_block_timepoint((last_finalized_timepoint.full_value() + 1).pack())
+            .finalized_timepoint((last_finalized_timepoint.full_value() + 1).pack())
             .build();
 
         let mut args = rollup_type_hash.to_vec();
@@ -220,7 +220,7 @@ mod test {
         let last_finalized_timepoint = Timepoint::from_block_number(100);
         let lock_args = WithdrawalLockArgs::new_builder()
             .owner_lock_hash(owner_lock.hash().pack())
-            .withdrawal_block_timepoint(last_finalized_timepoint.full_value().pack())
+            .finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .build();
 
         let mut args = rollup_type_hash.to_vec();

--- a/crates/tools/src/withdraw.rs
+++ b/crates/tools/src/withdraw.rs
@@ -222,7 +222,7 @@ fn minimal_withdrawal_capacity(is_sudt: bool) -> Result<u64> {
     let dummy_withdrawal_lock_args = WithdrawalLockArgs::new_builder()
         .account_script_hash(dummy_hash.pack())
         .withdrawal_block_hash(dummy_hash.pack())
-        .withdrawal_block_timepoint(dummy_timepoint.full_value().pack())
+        .finalized_timepoint(dummy_timepoint.full_value().pack())
         .owner_lock_hash(dummy_hash.pack())
         .build();
 

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -206,7 +206,7 @@ struct UnlockCustodianViaRevertWitness {
 struct WithdrawalLockArgs {
     withdrawal_block_hash: Byte32,
     // Timepoint format
-    withdrawal_block_timepoint: Uint64,
+    finalized_timepoint: Uint64,
     account_script_hash: Byte32,
     // layer1 lock to withdraw after challenge period
     owner_lock_hash: Byte32,

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -7943,8 +7943,8 @@ impl ::core::fmt::Display for WithdrawalLockArgs {
         write!(
             f,
             ", {}: {}",
-            "withdrawal_block_timepoint",
-            self.withdrawal_block_timepoint()
+            "finalized_timepoint",
+            self.finalized_timepoint()
         )?;
         write!(
             f,
@@ -7974,7 +7974,7 @@ impl WithdrawalLockArgs {
     pub fn withdrawal_block_hash(&self) -> Byte32 {
         Byte32::new_unchecked(self.0.slice(0..32))
     }
-    pub fn withdrawal_block_timepoint(&self) -> Uint64 {
+    pub fn finalized_timepoint(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(32..40))
     }
     pub fn account_script_hash(&self) -> Byte32 {
@@ -8011,7 +8011,7 @@ impl molecule::prelude::Entity for WithdrawalLockArgs {
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
             .withdrawal_block_hash(self.withdrawal_block_hash())
-            .withdrawal_block_timepoint(self.withdrawal_block_timepoint())
+            .finalized_timepoint(self.finalized_timepoint())
             .account_script_hash(self.account_script_hash())
             .owner_lock_hash(self.owner_lock_hash())
     }
@@ -8044,8 +8044,8 @@ impl<'r> ::core::fmt::Display for WithdrawalLockArgsReader<'r> {
         write!(
             f,
             ", {}: {}",
-            "withdrawal_block_timepoint",
-            self.withdrawal_block_timepoint()
+            "finalized_timepoint",
+            self.finalized_timepoint()
         )?;
         write!(
             f,
@@ -8064,7 +8064,7 @@ impl<'r> WithdrawalLockArgsReader<'r> {
     pub fn withdrawal_block_hash(&self) -> Byte32Reader<'r> {
         Byte32Reader::new_unchecked(&self.as_slice()[0..32])
     }
-    pub fn withdrawal_block_timepoint(&self) -> Uint64Reader<'r> {
+    pub fn finalized_timepoint(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[32..40])
     }
     pub fn account_script_hash(&self) -> Byte32Reader<'r> {
@@ -8098,7 +8098,7 @@ impl<'r> molecule::prelude::Reader<'r> for WithdrawalLockArgsReader<'r> {
 #[derive(Debug, Default)]
 pub struct WithdrawalLockArgsBuilder {
     pub(crate) withdrawal_block_hash: Byte32,
-    pub(crate) withdrawal_block_timepoint: Uint64,
+    pub(crate) finalized_timepoint: Uint64,
     pub(crate) account_script_hash: Byte32,
     pub(crate) owner_lock_hash: Byte32,
 }
@@ -8110,8 +8110,8 @@ impl WithdrawalLockArgsBuilder {
         self.withdrawal_block_hash = v;
         self
     }
-    pub fn withdrawal_block_timepoint(mut self, v: Uint64) -> Self {
-        self.withdrawal_block_timepoint = v;
+    pub fn finalized_timepoint(mut self, v: Uint64) -> Self {
+        self.finalized_timepoint = v;
         self
     }
     pub fn account_script_hash(mut self, v: Byte32) -> Self {
@@ -8131,7 +8131,7 @@ impl molecule::prelude::Builder for WithdrawalLockArgsBuilder {
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         writer.write_all(self.withdrawal_block_hash.as_slice())?;
-        writer.write_all(self.withdrawal_block_timepoint.as_slice())?;
+        writer.write_all(self.finalized_timepoint.as_slice())?;
         writer.write_all(self.account_script_hash.as_slice())?;
         writer.write_all(self.owner_lock_hash.as_slice())?;
         Ok(())

--- a/crates/types/src/offchain/compatible_finalized_timepoint.rs
+++ b/crates/types/src/offchain/compatible_finalized_timepoint.rs
@@ -69,4 +69,12 @@ impl CompatibleFinalizedTimepoint {
             finalized_block_number: block_number.saturating_sub(finality_as_blocks),
         }
     }
+
+    // Test case use only!
+    pub fn from_timestamp(timestamp: u64) -> Self {
+        Self {
+            finalized_timestamp: Some(timestamp),
+            finalized_block_number: 0,
+        }
+    }
 }

--- a/crates/types/src/offchain/compatible_finalized_timepoint.rs
+++ b/crates/types/src/offchain/compatible_finalized_timepoint.rs
@@ -30,6 +30,21 @@ impl CompatibleFinalizedTimepoint {
         }
     }
 
+    /// Create CompatibleFinalizedTimepoint using tip block timestamp as finalized timestamp
+    pub fn from_global_state_tip_block_timestamp(
+        global_state: &GlobalState,
+        rollup_config_finality: u64,
+    ) -> Self {
+        let mut timepoint = Self::from_global_state(global_state, rollup_config_finality);
+
+        if timepoint.finalized_timestamp.is_some() {
+            // Override with tip block timestamp
+            timepoint.finalized_timestamp = Some(global_state.tip_block_timestamp().unpack());
+        }
+
+        timepoint
+    }
+
     /// Returns true if `timepoint` is finalized.
     pub fn is_finalized(&self, timepoint: &Timepoint) -> bool {
         match timepoint {

--- a/docs/deposit_and_withdrawal.md
+++ b/docs/deposit_and_withdrawal.md
@@ -89,14 +89,14 @@ Withdrawal lock guarantees the cell can only be unlocked after `finality blocks`
 ```
 struct WithdrawalLockArgs {
     withdrawal_block_hash: Byte32,
-    withdrawal_block_timepoint: Uint64,
+    finalized_timepoint: Uint64,
     account_script_hash: Byte32,
     // layer1 lock to withdraw after challenge period
     owner_lock_hash: Byte32,
 }
 ```
 
-`withdrawal_block_hash` and `withdrawal_block_timepoint` record which layer2 block included the withdrawal. `account_script_hash` represent the layer2 account. `owner_lock_hash` represent the layer1 lock that user used to unlock the cell.
+`withdrawal_block_hash` and `finalized_timepoint` record which layer2 block included the withdrawal. `account_script_hash` represent the layer2 account. `owner_lock_hash` represent the layer1 lock that user used to unlock the cell.
 
 CKB requires `capacity` to cover the cost of the cell, so the minimal withdrawal CKB that Godwoken allows is as follows:
 

--- a/docs/finality_mechanism_changes.md
+++ b/docs/finality_mechanism_changes.md
@@ -33,11 +33,11 @@ Here are some test vectors:
 - The `timepoint_flag == 0` indicates that its `timepoint_value` is the **finalized block number**, so any blocks with a lower number are finalized.
 - The `timepoint_flag == 1` indicates that its `timepoint_value` is the **finalized timestamp**, so any blocks with a lower timestamp are finalized.
 
-### Interpretation of `WithdrawalLockArgs.withdrawal_block_timepoint`
+### Interpretation of `WithdrawalLockArgs.finalized_timepoint`
 
-> **NOTE**: **[`WithdrawalLockArgs.withdrawal_block_number`](https://github.com/godwokenrises/godwoken/blob/5617b579927d85509e8f88ac4fb4493ef449b642/crates/types/schemas/godwoken.mol#L206) was renamed to [`WithdrawalLockArgs.withdrawal_block_timepoint`](https://github.com/godwokenrises/godwoken/pull/836/files#diff-96e540dc83a433d447e1d2dae392fc5eafce72e839ea3900f6f1f8638aaada6bL206-R209).**
+> **NOTE**: **[`WithdrawalLockArgs.withdrawal_block_number`](https://github.com/godwokenrises/godwoken/blob/5617b579927d85509e8f88ac4fb4493ef449b642/crates/types/schemas/godwoken.mol#L206) was renamed to [`WithdrawalLockArgs.finalized_timepoint`](https://github.com/godwokenrises/godwoken/pull/836/files#diff-96e540dc83a433d447e1d2dae392fc5eafce72e839ea3900f6f1f8638aaada6bL206-R209).**
 
-`WithdrawalLockArgs.withdrawal_block_timepoint` was changed to type `Timepoint`:
+`WithdrawalLockArgs.finalized_timepoint` was changed to type `Timepoint`:
 - If `timepoint_flag == 0` then its `timepoint_value` is the **withdrawn block number**, so it becomes finalized when the tip block number exceeds `rollup_config.finality_blocks` blocks above the **withdrawn block number**.
 - If `timepoint_flag == 1` then its `timepoint_value` is the **withdrawn block timestamp**, so it becomes finalized when `GlobalState.last_finalized_timepoint` exceeds the **withdrawn block timestamp**.
 
@@ -66,8 +66,8 @@ fn is_withdrawal_finalized(
     global_state: &GlobalState,
     withdrawal_lock_args: &WithdrawalLockArgs
 ) -> bool {
-    let withdrawn_timepoint = withdrawal_lock_args.withdrawal_block_timepoint().unpack();
-    let finalized_timepoint = global_state.last_finalized_timepoint().unpack();
+    let withdrawn_finalized_timepoint = withdrawal_lock_args.finalized_timepoint().unpack();
+    let finalized_timepoint = global_state.tip_block_timestamp().unpack();
     let finalized_block_number = global_state.block().count().unpack() - 1 - rollup_config.finality_blocks().unpack();
 
     // Alternatively, you can use a shorter equivalent code snippet:
@@ -105,7 +105,7 @@ fn estimate_future_pending_time(
     withdrawal_lock_args: &WithdrawalLockArgs,
 ) -> u64 {
     let finalized_block_number = global_state.block().count().unpack() - 1 - rollup_config.finality_blocks().unpack();
-    match Timepoint::from_full_value(withdrawal_lock_args.withdrawal_block_timepoint().unpack()) {
+    match Timepoint::from_full_value(withdrawal_lock_args.finalized_timepoint().unpack()) {
         Timepoint::BlockNumber(wbn) => {
             max(0, wbn - finalized_block_number) * ESTIMATE_BLOCK_INTERVAL
         }
@@ -114,7 +114,7 @@ fn estimate_future_pending_time(
                 global_state.last_finalized_timepoint().unpack() >= TIMEPOINT_FLAG_MASK,
                 "Observing a timestamp-based withdrawal, we can be sure that global_state.last_finalized_timepoint() is also timestamp-based"
             );
-            let finalized_timestamp = global_state.last_finalized_timepoint().unpack() ^ TIMEPOINT_FLAG_MASK;
+            let finalized_timestamp = global_state.tip_block_timestamp().unpack();
             max(0, wts - finalized_timestamp)
         }
     }

--- a/gwos/README.md
+++ b/gwos/README.md
@@ -102,7 +102,7 @@ Withdrawal cells are generated in the `RollupSubmitBlock` action according to th
 
 The withdrawal lock has two unlock paths:
 
-1. Unlock by withdrawer after the `WithdrawalLockArgs#withdrawal_block_timepoint` is finalized.
+1. Unlock by withdrawer after the `WithdrawalLockArgs#finalized_timepoint` is passed.
 2. Unlock as a reverted cell in the `RollupSubmitBlock` action, a corresponded custodian cell will be generated.
 
 ### Challenge lock

--- a/gwos/c/godwoken.mol
+++ b/gwos/c/godwoken.mol
@@ -203,7 +203,7 @@ struct UnlockCustodianViaRevertWitness {
 // a rollup_type_hash exists before this args, to make args friendly to prefix search
 struct WithdrawalLockArgs {
     withdrawal_block_hash: Byte32,
-    withdrawal_block_timepoint: Uint64,
+    finalized_timepoint: Uint64,
     account_script_hash: Byte32,
     // layer1 lock to withdraw after challenge period
     owner_lock_hash: Byte32,

--- a/gwos/contracts/state-validator/src/verifications/submit_block.rs
+++ b/gwos/contracts/state-validator/src/verifications/submit_block.rs
@@ -72,7 +72,7 @@ fn check_withdrawal_cells<'a>(
     mut withdrawal_requests: Vec<WithdrawalRequestReader<'a>>,
     withdrawal_cells: &[WithdrawalCell],
 ) -> Result<(), Error> {
-    let expected_withdrawal_block_timepoint = {
+    let expected_finalized_timepoint = {
         let block_timepoint = context.block_timepoint().full_value();
         if Fork::use_timestamp_as_timepoint(context.post_version) {
             // Use finalized timestamp from the future
@@ -91,11 +91,11 @@ fn check_withdrawal_cells<'a>(
             return Err(Error::InvalidWithdrawalCell);
         }
 
-        if cell.args.withdrawal_block_timepoint().unpack() != expected_withdrawal_block_timepoint {
+        if cell.args.finalized_timepoint().unpack() != expected_finalized_timepoint {
             debug!(
-                "withdrawal_cell.args.withdrawal_block_timepoint != expected block timepoint, {} != {}",
-                cell.args.withdrawal_block_timepoint().unpack(),
-                expected_withdrawal_block_timepoint
+                "withdrawal_cell.args.finalized_timepoint != expected block timepoint, {} != {}",
+                cell.args.finalized_timepoint().unpack(),
+                expected_finalized_timepoint
             );
             return Err(Error::InvalidWithdrawalCell);
         }

--- a/gwos/contracts/withdrawal-lock/src/entry.rs
+++ b/gwos/contracts/withdrawal-lock/src/entry.rs
@@ -159,15 +159,15 @@ pub fn main() -> Result<(), Error> {
             Ok(())
         }
         UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaFinalize(_unlock_args) => {
-            let withdrawal_block_timepoint =
-                Timepoint::from_full_value(lock_args.withdrawal_block_timepoint().unpack());
+            let finalized_timepoint =
+                Timepoint::from_full_value(lock_args.finalized_timepoint().unpack());
 
-            match &withdrawal_block_timepoint {
+            match &finalized_timepoint {
                 Timepoint::Timestamp(finalized_timestamp) => {
                     check_finalized_timestamp_less_than_since(*finalized_timestamp)?
                 }
                 Timepoint::BlockNumber(_) => {
-                    check_finalized_block_number(&rollup_type_hash, &withdrawal_block_timepoint)?
+                    check_finalized_block_number(&rollup_type_hash, &finalized_timepoint)?
                 }
             }
 
@@ -255,7 +255,7 @@ fn check_finalized_timestamp_less_than_since(finalized_timestamp: u64) -> Result
 
 fn check_finalized_block_number(
     rollup_type_hash: &[u8; 32],
-    withdrawal_block_timepoint: &Timepoint,
+    finalized_timepoint: &Timepoint,
 ) -> Result<(), Error> {
     // try search rollup state from deps
     let global_state = match search_rollup_state(&rollup_type_hash, Source::CellDep)? {
@@ -269,7 +269,7 @@ fn check_finalized_block_number(
     let config = load_rollup_config(&global_state.rollup_config_hash().unpack())?;
 
     // check finality
-    if is_finalized(&config, &global_state, withdrawal_block_timepoint) {
+    if is_finalized(&config, &global_state, finalized_timepoint) {
         Ok(())
     } else {
         Err(Error::NotFinalized)


### PR DESCRIPTION
Set `withdrawal_block_timepoint` to finalized timestamp, so we can unlock it without rollup cell dep.