### PR TITLE
chore: bump version to 1.8.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+## [v1.8.0-rc1] - 2022-12-09
+
+In this version, an upgrading of on-chain scripts is included:
+
+- feat: optimize Godwoken finality mechanism [#836](https://github.com/godwokenrises/godwoken/pull/836)
+- feat: deprecate verifications for state_checkpoint_list and prev_state_checkpoint [#883](https://github.com/godwokenrises/godwoken/pull/883)
+
+We also introduce a change to activate the new behavior.
+
+- feat: determine global state version according to fork height[#858](https://github.com/godwokenrises/godwoken/pull/858)
+
+Other changes:
+
+- perf: optional SMT trie feature and migrate command [#859](https://github.com/godwokenrises/godwoken/pull/882)
+- feat: optimized trace and metrics [#865](https://github.com/godwokenrises/godwoken/pull/865)
+- fix(withdrawal): finalized withdrawal take longer time to unlock [#892](https://github.com/godwokenrises/godwoken/pull/892)
+- chore(CI): add docker-prebuilds into monorepo [#885](https://github.com/godwokenrises/godwoken/pull/885)
+- feat: support non-x86 build [#882](https://github.com/godwokenrises/godwoken/pull/882)
+
 ## [v1.7.3] - 2022-11-27
 
 - config: deny unknown fields in the config toml file [#862](https://github.com/godwokenrises/godwoken/pull/862)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "godwoken-bin"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-types",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "gw-benches"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "gw-block-producer"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "gw-chain"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "gw-challenge"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "gw-common"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "gw-config"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "ckb-fixed-hash",
  "gw-jsonrpc-types",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "gw-db"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-rocksdb",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "gw-dynamic-config"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "gw-generator"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1810,14 +1810,14 @@ dependencies = [
 
 [[package]]
 name = "gw-hash"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "blake2b-ref 0.3.1",
 ]
 
 [[package]]
 name = "gw-jsonrpc-types"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "gw-mem-pool"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "gw-metrics"
-version = "1.7.1"
+version = "1.8.0-rc1"
 dependencies = [
  "arc-swap",
  "gw-common",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "gw-p2p-network"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "gw-polyjuice-sender-recover"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "gw-common",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "gw-replay-chain"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "async-jsonrpc-client",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-client"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-server"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "gw-store"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "gw-telemetry"
-version = "1.7.1"
+version = "1.8.0-rc1"
 dependencies = [
  "chrono",
  "faster-hex 0.6.1",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tests"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "async-jsonrpc-client",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tools"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "gw-traits"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "gw-common",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tx-filter"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "gw-common",
  "gw-config",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "gw-types"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "cfg-if 0.1.10",
  "ckb-fixed-hash",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "gw-utils"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-crypto",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "gw-version"
-version = "1.7.3"
+version = "1.8.0-rc1"
 dependencies = [
  "anyhow",
 ]

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-benches"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 description = "Godwoken benchmarks."

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-block-producer"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-chain"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/challenge/Cargo.toml
+++ b/crates/challenge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-challenge"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-common"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-config"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-db"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/dynamic-config/Cargo.toml
+++ b/crates/dynamic-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-dynamic-config"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-generator"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/godwoken-bin/Cargo.toml
+++ b/crates/godwoken-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godwoken-bin"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-hash"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/jsonrpc-types/Cargo.toml
+++ b/crates/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-jsonrpc-types"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-mem-pool"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-metrics"
-version = "1.7.1"
+version = "1.8.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/p2p-network/Cargo.toml
+++ b/crates/p2p-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-p2p-network"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/polyjuice-sender-recover/Cargo.toml
+++ b/crates/polyjuice-sender-recover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-polyjuice-sender-recover"
-version = "1.7.3"
+version = "1.8.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/replay-chain/Cargo.toml
+++ b/crates/replay-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-replay-chain"
-version = "1.7.3"
+version = "1.8.0-rc1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-client"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-server"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2018"
 

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-store"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-telemetry"
-version = "1.7.1"
+version = "1.8.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tests"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2018"
 

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tools"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/traits/Cargo.toml
+++ b/crates/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-traits"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/tx-filter/Cargo.toml
+++ b/crates/tx-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tx-filter"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-types"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-utils"
-version = "1.7.3"
+version = "1.8.0-rc1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-version"
-version = "1.7.3"
+version = "1.8.0-rc1"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/devtools/bump.sh
+++ b/devtools/bump.sh
@@ -10,7 +10,7 @@ main() {
     exit 1
   fi
   local v="$1"
-  find . -name 'Cargo.toml' -print0 | xargs -0 sed -i.bak \
+  find ./crates -name 'Cargo.toml' -print0 | xargs -0 sed -i.bak \
     -e 's/^version = .*/version = "'"$v"'"/' \
     -e 's/\({.*path = ".*",.* version = "= \)[^"]*/\1'"$v"'/'
   find . -name 'Cargo.toml.bak' -exec rm -f {} \;


### PR DESCRIPTION
# 1.8.0-rc1

In this version, an upgrading of on-chain scripts is included:

- feat: optimize Godwoken finality mechanism [#836](https://github.com/godwokenrises/godwoken/pull/836)
- feat: deprecate verifications for state_checkpoint_list and prev_state_checkpoint [#883](https://github.com/godwokenrises/godwoken/pull/883)

We also introduce a change to activate the new behavior.

- feat: determine global state version according to fork height[#858](https://github.com/godwokenrises/godwoken/pull/858)

Other changes:

- perf: optional SMT trie feature and migrate command [#859](https://github.com/godwokenrises/godwoken/pull/859)
- feat: optimized trace and metrics [#865](https://github.com/godwokenrises/godwoken/pull/865)
- fix(withdrawal): finalized withdrawal take longer time to unlock [#892](https://github.com/godwokenrises/godwoken/pull/892)
- chore(CI): add docker-prebuilds into monorepo [#885](https://github.com/godwokenrises/godwoken/pull/885)
- feat: support non-x86 build [#882](https://github.com/godwokenrises/godwoken/pull/882)