### PR TITLE
feat: support CKB built-in indexer

### DIFF
--- a/crates/block-producer/src/runner.rs
+++ b/crates/block-producer/src/runner.rs
@@ -280,8 +280,12 @@ impl BaseInitComponents {
         };
         let rollup_type_script: Script = config.chain.rollup_type_script.clone().into();
         let rpc_client = {
-            let indexer_client = CKBIndexerClient::with_url(&config.rpc_client.indexer_url)?;
             let ckb_client = CKBClient::with_url(&config.rpc_client.ckb_url)?;
+            let indexer_client = if let Some(ref indexer_url) = config.rpc_client.indexer_url {
+                CKBIndexerClient::with_url(indexer_url)?
+            } else {
+                CKBIndexerClient::new(ckb_client.client().clone(), false)
+            };
             let rollup_type_script =
                 ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
             RPCClient::new(

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -79,7 +79,10 @@ pub struct RPCServerConfig {
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RPCClientConfig {
-    pub indexer_url: String,
+    /// Specify standalone ckb indexer URL.
+    ///
+    /// If this is None we use CKB builtin indexer RPC instead.
+    pub indexer_url: Option<String>,
     pub ckb_url: String,
 }
 

--- a/crates/replay-chain/src/setup.rs
+++ b/crates/replay-chain/src/setup.rs
@@ -61,8 +61,12 @@ pub async fn setup(args: SetupArgs) -> Result<Context> {
     };
     let secp_data: Bytes = {
         let rpc_client = {
-            let indexer_client = CKBIndexerClient::with_url(&config.rpc_client.indexer_url)?;
             let ckb_client = CKBClient::with_url(&config.rpc_client.ckb_url)?;
+            let indexer_client = if let Some(ref indexer_url) = config.rpc_client.indexer_url {
+                CKBIndexerClient::with_url(indexer_url)?
+            } else {
+                CKBIndexerClient::new(ckb_client.client().clone(), false)
+            };
             let rollup_type_script =
                 ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
             RPCClient::new(

--- a/crates/rpc-client/src/ckb_client.rs
+++ b/crates/rpc-client/src/ckb_client.rs
@@ -33,7 +33,7 @@ impl CKBClient {
         Ok(Self::new(client))
     }
 
-    fn client(&self) -> &HttpClient {
+    pub fn client(&self) -> &HttpClient {
         &self.ckb_client
     }
 

--- a/crates/rpc-client/src/indexer_client.rs
+++ b/crates/rpc-client/src/indexer_client.rs
@@ -11,29 +11,60 @@ use ckb_types::prelude::Entity;
 use gw_jsonrpc_types::ckb_jsonrpc_types::{JsonBytes, Uint32};
 use gw_types::core::Timepoint;
 use gw_types::offchain::{CompatibleFinalizedTimepoint, CustodianStat, SUDTStat};
-use gw_types::packed::CustodianLockArgs;
+use gw_types::packed::{CustodianLockArgs, NumberHash};
 use gw_types::{packed::Script, prelude::*};
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use tracing::instrument;
 
 #[derive(Clone)]
-pub struct CKBIndexerClient(HttpClient);
+pub struct CKBIndexerClient {
+    client: HttpClient,
+    // True when using standalone CKB indexer, false when using the new built in CKB indexer.
+    is_standalone: bool,
+}
 
 impl CKBIndexerClient {
-    pub fn new(ckb_indexer_client: HttpClient) -> Self {
-        Self(ckb_indexer_client)
+    pub fn new(ckb_indexer_client: HttpClient, is_standalone: bool) -> Self {
+        Self {
+            client: ckb_indexer_client,
+            is_standalone,
+        }
     }
 
+    /// Create a new CKBIndexerClient with ckb RPC url.
+    pub fn with_ckb_url(url: &str) -> Result<Self> {
+        let client = HttpClient::builder()
+            .timeout(DEFAULT_HTTP_TIMEOUT)
+            .build(url)?;
+        Ok(Self::new(client, false))
+    }
+
+    /// Create a new CKBIndexerClient with standalone indexer url.
     pub fn with_url(url: &str) -> Result<Self> {
         let client = HttpClient::builder()
             .timeout(DEFAULT_HTTP_TIMEOUT)
             .build(url)?;
-        Ok(Self::new(client))
+        Ok(Self::new(client, true))
     }
 
     fn client(&self) -> &HttpClient {
-        &self.0
+        &self.client
+    }
+
+    #[instrument(skip_all)]
+    pub async fn get_tip(&self) -> Result<NumberHash> {
+        let number_hash: gw_jsonrpc_types::blockchain::NumberHash = self
+            .request(
+                if self.is_standalone {
+                    "get_tip"
+                } else {
+                    "get_indexer_tip"
+                },
+                None,
+            )
+            .await?;
+        Ok(number_hash.into())
     }
 
     #[instrument(skip_all, fields(method = method))]

--- a/crates/rpc-client/src/rpc_client.rs
+++ b/crates/rpc-client/src/rpc_client.rs
@@ -372,11 +372,8 @@ impl RPCClient {
         }))
     }
 
-    #[instrument(skip_all)]
     pub async fn get_tip(&self) -> Result<NumberHash> {
-        let number_hash: gw_jsonrpc_types::blockchain::NumberHash =
-            self.indexer.request("get_tip", None).await?;
-        Ok(number_hash.into())
+        self.indexer.get_tip().await
     }
 
     #[instrument(skip_all, fields(block_hash = %block_hash.pack()))]

--- a/crates/tests/src/testing_tool/rpc_server.rs
+++ b/crates/tests/src/testing_tool/rpc_server.rs
@@ -48,9 +48,8 @@ impl RPCServer {
         let rollup_config = generator.rollup_context().rollup_config.to_owned();
         let rollup_context = generator.rollup_context().to_owned();
         let rpc_client = {
-            let indexer_client =
-                CKBIndexerClient::with_url(&RPCClientConfig::default().indexer_url).unwrap();
             let ckb_client = CKBClient::with_url(&RPCClientConfig::default().ckb_url).unwrap();
+            let indexer_client = CKBIndexerClient::new(ckb_client.client().clone(), false);
             let rollup_type_script =
                 ckb_types::packed::Script::new_unchecked(rollup_type_script.as_bytes());
             RPCClient::new(

--- a/crates/tools/src/generate_config.rs
+++ b/crates/tools/src/generate_config.rs
@@ -27,7 +27,7 @@ pub struct GenerateNodeConfigArgs<'a> {
     pub scripts_deployment: &'a ScriptsDeploymentResult,
     pub privkey_path: &'a Path,
     pub ckb_url: String,
-    pub indexer_url: String,
+    pub indexer_url: Option<String>,
     pub build_scripts_result: &'a BuildScriptsResult,
     pub server_url: String,
     pub user_rollup_config: &'a UserRollupConfig,

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -75,8 +75,6 @@ async fn main() -> Result<()> {
     let arg_indexer_rpc = Arg::with_name("indexer-rpc-url")
         .long("ckb-indexer-rpc")
         .takes_value(true)
-        .default_value("http://127.0.0.1:8116")
-        .required(true)
         .help("The URL of ckb indexer");
     let arg_deployment_results_path = Arg::with_name("scripts-deployment-path")
         .long("scripts-deployment-path")
@@ -818,7 +816,7 @@ async fn main() -> Result<()> {
         .subcommand(
             SubCommand::with_name("stat-custodian-ckb")
                 .about("Output amount of layer2 custodian CKB")
-                .arg(arg_indexer_rpc.clone())
+                .arg(arg_indexer_rpc.clone().required(true))
                 .arg(
                     Arg::with_name("rollup-type-hash")
                         .long("rollup-type-hash")
@@ -938,7 +936,7 @@ async fn main() -> Result<()> {
         }
         Some(("generate-config", m)) => {
             let ckb_url = m.value_of("ckb-rpc-url").unwrap().to_string();
-            let indexer_url = m.value_of("indexer-rpc-url").unwrap().to_string();
+            let indexer_url = m.value_of("indexer-rpc-url").map(Into::into);
             let scripts_results_path = Path::new(m.value_of("scripts-deployment-path").unwrap());
             let genesis_path = Path::new(m.value_of("genesis-deployment-path").unwrap());
             let user_rollup_config_path = Path::new(m.value_of("user-rollup-config-path").unwrap());
@@ -1036,7 +1034,7 @@ async fn main() -> Result<()> {
         }
         Some(("update-cell", m)) => {
             let ckb_rpc_url = m.value_of("ckb-rpc-url").unwrap();
-            let indexer_rpc_url = m.value_of("indexer-rpc-url").unwrap();
+            let indexer_rpc_url = m.value_of("indexer-rpc-url");
             let tx_hash = cli_args::to_h256(m.value_of("tx-hash").unwrap())?;
             let index: u32 = m.value_of("index").unwrap().parse()?;
             let type_id = cli_args::to_h256(m.value_of("type-id").unwrap())?;
@@ -1116,7 +1114,7 @@ async fn main() -> Result<()> {
         }
         Some(("setup", m)) => {
             let ckb_rpc_url = m.value_of("ckb-rpc-url").unwrap();
-            let indexer_url = m.value_of("indexer-rpc-url").unwrap();
+            let indexer_url = m.value_of("indexer-rpc-url");
             let setup_config_path = Path::new(m.value_of("setup-config-path").unwrap());
             let mode = value_t!(m, "mode", prepare_scripts::ScriptsBuildMode).unwrap();
             let wallet_network = value_t!(m, "network", setup::WalletNetwork).unwrap();

--- a/crates/tools/src/setup.rs
+++ b/crates/tools/src/setup.rs
@@ -44,7 +44,7 @@ impl NodeWalletInfo {
 
 pub struct SetupArgs<'a> {
     pub ckb_rpc_url: &'a str,
-    pub indexer_url: &'a str,
+    pub indexer_url: Option<&'a str>,
     pub mode: ScriptsBuildMode,
     pub build_scripts_config_path: &'a Path,
     pub privkey_path: &'a Path,
@@ -166,7 +166,7 @@ pub async fn setup(args: SetupArgs<'_>) {
             scripts_deployment: &deploy_scripts_result,
             privkey_path: &privkey_path,
             ckb_url: ckb_rpc_url.to_string(),
-            indexer_url: indexer_url.to_string(),
+            indexer_url: indexer_url.map(Into::into),
             build_scripts_result: &build_scripts_result,
             server_url: server_url.to_string(),
             user_rollup_config: &rollup_config,

--- a/crates/tools/src/update_cell.rs
+++ b/crates/tools/src/update_cell.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 
 pub struct UpdateCellArgs<'a, P> {
     pub ckb_rpc_url: &'a str,
-    pub indexer_rpc_url: &'a str,
+    pub indexer_rpc_url: Option<&'a str>,
     pub tx_hash: [u8; 32],
     pub index: u32,
     pub type_id: [u8; 32],
@@ -39,7 +39,11 @@ pub async fn update_cell<P: AsRef<Path>>(args: UpdateCellArgs<'_, P>) -> Result<
     } = args;
 
     let mut rpc_client = CkbRpcClient::new(ckb_rpc_url);
-    let indexer_client = CKBIndexerClient::with_url(indexer_rpc_url)?;
+    let indexer_client = if let Some(indexer_url) = indexer_rpc_url {
+        CKBIndexerClient::with_url(indexer_url)
+    } else {
+        CKBIndexerClient::with_ckb_url(ckb_rpc_url)
+    }?;
     // check existed_cell
     let tx_with_status = rpc_client
         .get_transaction(tx_hash.into())


### PR DESCRIPTION
If a CKB indexer RPC url is explicitly specified, we assume that we are
connecting to a standalone indexer (i.e. we use `get_tip`).

Otherwise we just use CKB RPC url and assume that we are connecting to
CKB builtin indexer (i.e. we use `get_indexer_tip`).

BREAKING CHANGE:

There are some small breaking changes for gw-tools: if the `ckb-indexer-rpc` arg is not specified, we default to using CKB built-in indexer instead of "127.0.0.1:8116".