### PR TITLE
fix(docs): typo in timepoint relevant docs

### DIFF
--- a/docs/deposit_and_withdrawal.md
+++ b/docs/deposit_and_withdrawal.md
@@ -129,7 +129,7 @@ Withdrawal lock guarantees the cell can only be unlocked after `finality blocks`
 struct WithdrawalLockArgsV0 {
     account_script_hash: Byte32,
     withdrawal_block_hash: Byte32,
-    withdrawal_block_timepoint: Uint64,
+    withdrawal_block_number: Uint64,
     // buyer can pay sell_amount token to unlock
     sudt_script_hash: Byte32,
     sell_amount: Uint128,

--- a/docs/finality_mechanism_changes.md
+++ b/docs/finality_mechanism_changes.md
@@ -7,7 +7,7 @@ https://github.com/godwokenrises/godwoken/pull/836 changes the way to determine 
 ### `Timepoint`
 
 To understand specific changes, we must understand `Timepoint`, a new underlying type introduced in https://github.com/godwokenrises/godwoken/pull/836.
-A `Timepoint` is a type, underlying `u64`, that is interpretated according to its highest bit.
+A `Timepoint` is a type, underlying `u64`, that is interpreted according to its highest bit.
 
   - When the highest bit is `0`, the rest bits are represented by block number
   - When the highest bit is `1`, the rest bits are represented by timestamp


### PR DESCRIPTION
Correcting some words/terms in the docs:
- interpretated -> interpreted (typo)
- withdrawal_block_timepoint -> withdrawal_block_number (WithdrawalLockArgsV0 should be the same?)