### PR TITLE
refactor: rename structure fields

### DIFF
--- a/crates/block-producer/src/custodian.rs
+++ b/crates/block-producer/src/custodian.rs
@@ -140,7 +140,7 @@ async fn query_mergeable_ckb_custodians(
             };
             if !compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
                 custodian_lock_args_reader
-                    .deposit_block_timepoint()
+                    .deposit_finalized_timepoint()
                     .unpack(),
             )) {
                 continue;

--- a/crates/block-producer/src/stake.rs
+++ b/crates/block-producer/src/stake.rs
@@ -39,7 +39,7 @@ pub async fn generate(
     local_cells_manager: &LocalCellsManager,
 ) -> Result<GeneratedStake> {
     let owner_lock_hash = lock_script.hash();
-    let stake_block_timepoint = finalized_timepoint(
+    let stake_finalized_timepoint = finalized_timepoint(
         &rollup_context.rollup_config,
         &rollup_context.fork_config,
         block.raw().number().unpack(),
@@ -48,7 +48,7 @@ pub async fn generate(
     let lock_args: Bytes = {
         let stake_lock_args = StakeLockArgs::new_builder()
             .owner_lock_hash(owner_lock_hash.pack())
-            .stake_block_timepoint(stake_block_timepoint.full_value().pack())
+            .stake_finalized_timepoint(stake_finalized_timepoint.full_value().pack())
             .build();
         let rollup_type_hash = rollup_context.rollup_script_hash.as_slice().iter();
         rollup_type_hash
@@ -180,7 +180,7 @@ pub async fn query_stake(
             match &compatible_finalize_timepoint_opt {
                 Some(compatible_finalized_timepoint) => {
                     compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
-                        stake_lock_args.stake_block_timepoint().unpack(),
+                        stake_lock_args.stake_finalized_timepoint().unpack(),
                     )) && stake_lock_args.owner_lock_hash().as_slice() == owner_lock_hash
                 }
                 None => stake_lock_args.owner_lock_hash().as_slice() == owner_lock_hash,

--- a/crates/generator/src/utils.rs
+++ b/crates/generator/src/utils.rs
@@ -50,7 +50,7 @@ pub fn build_withdrawal_cell_output(
     rollup_context: &RollupContext,
     req: &WithdrawalRequestExtra,
     block_hash: &H256,
-    block_timepoint: &Timepoint,
+    finalized_timepoint: &Timepoint,
     opt_asset_script: Option<Script>,
 ) -> Result<(CellOutput, Bytes), WithdrawalCellError> {
     let withdrawal_capacity: u64 = req.raw().capacity().unpack();
@@ -58,7 +58,7 @@ pub fn build_withdrawal_cell_output(
         let withdrawal_lock_args = WithdrawalLockArgs::new_builder()
             .account_script_hash(req.raw().account_script_hash())
             .withdrawal_block_hash(Into::<[u8; 32]>::into(*block_hash).pack())
-            .withdrawal_block_timepoint(block_timepoint.full_value().pack())
+            .withdrawal_finalized_timepoint(finalized_timepoint.full_value().pack())
             .owner_lock_hash(req.raw().owner_lock_hash())
             .build();
 
@@ -234,7 +234,7 @@ mod test {
         );
         assert_eq!(lock_args.withdrawal_block_hash(), block_hash.pack());
         assert_eq!(
-            lock_args.withdrawal_block_timepoint().unpack(),
+            lock_args.withdrawal_finalized_timepoint().unpack(),
             block_timepoint.full_value()
         );
         assert_eq!(lock_args.owner_lock_hash(), owner_lock.hash().pack());

--- a/crates/jsonrpc-types/src/godwoken.rs
+++ b/crates/jsonrpc-types/src/godwoken.rs
@@ -1371,12 +1371,12 @@ pub struct WithdrawalLockArgs {
     // block timestamp.
 
     // Before switching to v2, `withdrawal_block_number` should be `Some(block_number)` and
-    // `withdrawal_block_timestamp` should be `None`; afterwards, `withdrawal_block_number` will
-    // become `None` and `withdrawal_block_timestamp` will become `Some(block_timestamp)`.
+    // `withdrawal_finalized_timestamp` should be `None`; afterwards, `withdrawal_block_number` will
+    // become `None` and `withdrawal_finalized_timestamp` will become `Some(finalized_timestamp)`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_block_number: Option<Uint64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub withdrawal_block_timestamp: Option<Uint64>,
+    pub withdrawal_finalized_timestamp: Option<Uint64>,
 
     // layer1 lock to withdraw after challenge period
     pub owner_lock_hash: H256,
@@ -1390,26 +1390,26 @@ impl TryFrom<WithdrawalLockArgs> for packed::WithdrawalLockArgs {
             account_script_hash,
             withdrawal_block_hash,
             withdrawal_block_number,
-            withdrawal_block_timestamp,
+            withdrawal_finalized_timestamp,
             owner_lock_hash,
         } = json;
-        let withdrawal_block_timepoint = match (withdrawal_block_number, withdrawal_block_timestamp)
-        {
-            (Some(block_number), None) => Timepoint::from_block_number(block_number.value()),
-            (None, Some(timestamp)) => Timepoint::from_timestamp(timestamp.value()),
-            (bn, bt) => {
-                return Err(anyhow!(
-                    "conflict withdrawal_block_number {:?} and withdrawal_block_timestamp {:?}",
+        let withdrawal_finalized_timepoint =
+            match (withdrawal_block_number, withdrawal_finalized_timestamp) {
+                (Some(block_number), None) => Timepoint::from_block_number(block_number.value()),
+                (None, Some(timestamp)) => Timepoint::from_timestamp(timestamp.value()),
+                (bn, bt) => {
+                    return Err(anyhow!(
+                    "conflict withdrawal_block_number {:?} and withdrawal_finalized_timestamp {:?}",
                     bn,
                     bt
                 ));
-            }
-        };
+                }
+            };
 
         Ok(packed::WithdrawalLockArgs::new_builder()
             .account_script_hash(account_script_hash.pack())
             .withdrawal_block_hash(withdrawal_block_hash.pack())
-            .withdrawal_block_timepoint(withdrawal_block_timepoint.full_value().pack())
+            .withdrawal_finalized_timepoint(withdrawal_finalized_timepoint.full_value().pack())
             .owner_lock_hash(owner_lock_hash.pack())
             .build())
     }
@@ -1417,19 +1417,19 @@ impl TryFrom<WithdrawalLockArgs> for packed::WithdrawalLockArgs {
 
 impl From<packed::WithdrawalLockArgs> for WithdrawalLockArgs {
     fn from(data: packed::WithdrawalLockArgs) -> WithdrawalLockArgs {
-        let withdrawal_block_timepoint =
-            Timepoint::from_full_value(data.withdrawal_block_timepoint().unpack());
-        let (withdrawal_block_number, withdrawal_block_timestamp) = match withdrawal_block_timepoint
-        {
-            Timepoint::BlockNumber(block_number) => (Some(block_number), None),
-            Timepoint::Timestamp(timestamp) => (None, Some(timestamp)),
-        };
+        let withdrawal_finalized_timepoint =
+            Timepoint::from_full_value(data.withdrawal_finalized_timepoint().unpack());
+        let (withdrawal_block_number, withdrawal_finalized_timestamp) =
+            match withdrawal_finalized_timepoint {
+                Timepoint::BlockNumber(block_number) => (Some(block_number), None),
+                Timepoint::Timestamp(timestamp) => (None, Some(timestamp)),
+            };
         Self {
             account_script_hash: data.account_script_hash().unpack(),
             owner_lock_hash: data.owner_lock_hash().unpack(),
             withdrawal_block_hash: data.withdrawal_block_hash().unpack(),
             withdrawal_block_number: withdrawal_block_number.map(Into::into),
-            withdrawal_block_timestamp: withdrawal_block_timestamp.map(Into::into),
+            withdrawal_finalized_timestamp: withdrawal_finalized_timestamp.map(Into::into),
         }
     }
 }

--- a/crates/mem-pool/src/custodian.rs
+++ b/crates/mem-pool/src/custodian.rs
@@ -32,7 +32,7 @@ use crate::constants::MAX_CUSTODIANS;
 pub fn to_custodian_cell(
     rollup_context: &RollupContext,
     block_hash: &H256,
-    block_timepoint: &Timepoint,
+    finalized_timepoint: &Timepoint,
     deposit_info: &DepositInfo,
 ) -> Result<(CellOutput, Bytes), u128> {
     let lock_args: Bytes = {
@@ -43,7 +43,7 @@ pub fn to_custodian_cell(
 
         let custodian_lock_args = CustodianLockArgs::new_builder()
             .deposit_block_hash(Into::<[u8; 32]>::into(*block_hash).pack())
-            .deposit_block_timepoint(block_timepoint.full_value().pack())
+            .deposit_finalized_timepoint(finalized_timepoint.full_value().pack())
             .deposit_lock_args(deposit_lock_args)
             .build();
 
@@ -298,7 +298,7 @@ async fn query_finalized_custodian_cells(
             };
 
             if !compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
-                custodian_lock_args.deposit_block_timepoint().unpack(),
+                custodian_lock_args.deposit_finalized_timepoint().unpack(),
             )) {
                 continue;
             }
@@ -464,7 +464,7 @@ mod tests {
     ) -> Vec<CellInfo> {
         let args = {
             let custodian_lock_args = CustodianLockArgs::new_builder()
-                .deposit_block_timepoint(last_finalized_timepoint.full_value().pack())
+                .deposit_finalized_timepoint(last_finalized_timepoint.full_value().pack())
                 .build();
 
             let mut args = rollup_context.rollup_script_hash.as_slice().to_vec();

--- a/crates/rpc-client/src/indexer_client.rs
+++ b/crates/rpc-client/src/indexer_client.rs
@@ -176,7 +176,7 @@ impl CKBIndexerClient {
                     let args = cell.output.lock.args.into_bytes();
                     let args = CustodianLockArgs::from_slice(&args[32..]).unwrap();
                     compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
-                        args.deposit_block_timepoint().unpack(),
+                        args.deposit_finalized_timepoint().unpack(),
                     ))
                 };
                 if is_finalized {

--- a/crates/rpc-client/src/rpc_client.rs
+++ b/crates/rpc-client/src/rpc_client.rs
@@ -1132,7 +1132,7 @@ impl RPCClient {
                     Err(_) => continue,
                 };
                 if !compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
-                    custodian_lock_args.deposit_block_timepoint().unpack(),
+                    custodian_lock_args.deposit_finalized_timepoint().unpack(),
                 )) {
                     continue;
                 }
@@ -1231,7 +1231,7 @@ impl RPCClient {
                 };
 
                 if !compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
-                    custodian_lock_args.deposit_block_timepoint().unpack(),
+                    custodian_lock_args.deposit_finalized_timepoint().unpack(),
                 )) {
                     continue;
                 }

--- a/crates/rpc-client/src/withdrawal.rs
+++ b/crates/rpc-client/src/withdrawal.rs
@@ -51,7 +51,7 @@ fn verify_finalized_owner_lock(
     };
 
     if !compatible_finalized_timepoint.is_finalized(&Timepoint::from_full_value(
-        lock_args.withdrawal_block_timepoint().unpack(),
+        lock_args.withdrawal_finalized_timepoint().unpack(),
     )) {
         bail!("unfinalized withdrawal");
     }
@@ -101,7 +101,7 @@ mod test {
             CompatibleFinalizedTimepoint::from_block_number(finalized_block_number, 0);
         let lock_args = WithdrawalLockArgs::new_builder()
             .owner_lock_hash(owner_lock.hash().pack())
-            .withdrawal_block_timepoint(last_finalized_timepoint.full_value().pack())
+            .withdrawal_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .build();
 
         let mut args = rollup_type_hash.to_vec();
@@ -137,7 +137,7 @@ mod test {
         let err_lock_args = lock_args
             .clone()
             .as_builder()
-            .withdrawal_block_timepoint((last_finalized_timepoint.full_value() + 1).pack())
+            .withdrawal_finalized_timepoint((last_finalized_timepoint.full_value() + 1).pack())
             .build();
 
         let mut args = rollup_type_hash.to_vec();
@@ -219,7 +219,7 @@ mod test {
         let last_finalized_timepoint = Timepoint::from_block_number(100);
         let lock_args = WithdrawalLockArgs::new_builder()
             .owner_lock_hash(owner_lock.hash().pack())
-            .withdrawal_block_timepoint(last_finalized_timepoint.full_value().pack())
+            .withdrawal_finalized_timepoint(last_finalized_timepoint.full_value().pack())
             .build();
 
         let mut args = rollup_type_hash.to_vec();

--- a/crates/tests/src/script_tests/custodian_lock.rs
+++ b/crates/tests/src/script_tests/custodian_lock.rs
@@ -24,8 +24,8 @@ struct CaseParam {
     finalized_block_number: u64,
     // GlobalState.last_finalized_timepoint
     finalized_block_timestamp: u64,
-    // CustodianLockArgs.deposit_block_timepoint
-    deposit_block_timepoint: Timepoint,
+    // CustodianLockArgs.deposit_finalized_timepoint
+    deposit_finalized_timepoint: Timepoint,
     // expected running result of the test case, Ok(()) or Err(exit_code)
     expected_result: Result<(), i8>,
 }
@@ -49,7 +49,7 @@ fn test_finality_of_custodian_lock() {
             id: 0,
             finalized_block_number,
             finalized_block_timestamp,
-            deposit_block_timepoint: finalized_timepoint_by_block_number,
+            deposit_finalized_timepoint: finalized_timepoint_by_block_number,
             expected_result: Ok(()),
         },
         CaseParam {
@@ -57,7 +57,7 @@ fn test_finality_of_custodian_lock() {
             id: 1,
             finalized_block_number,
             finalized_block_timestamp,
-            deposit_block_timepoint: unfinalized_timepoint_by_block_number,
+            deposit_finalized_timepoint: unfinalized_timepoint_by_block_number,
             expected_result: Err(INDEX_OUT_OF_BOUND_EXIT_CODE),
         },
         CaseParam {
@@ -65,7 +65,7 @@ fn test_finality_of_custodian_lock() {
             id: 2,
             finalized_block_number,
             finalized_block_timestamp,
-            deposit_block_timepoint: finalized_timepoint_by_block_timestamp,
+            deposit_finalized_timepoint: finalized_timepoint_by_block_timestamp,
             expected_result: Ok(()),
         },
         CaseParam {
@@ -73,7 +73,7 @@ fn test_finality_of_custodian_lock() {
             id: 3,
             finalized_block_number,
             finalized_block_timestamp,
-            deposit_block_timepoint: unfinalized_timepoint_by_block_timestamp,
+            deposit_finalized_timepoint: unfinalized_timepoint_by_block_timestamp,
             expected_result: Err(INDEX_OUT_OF_BOUND_EXIT_CODE),
         },
     ];
@@ -86,7 +86,7 @@ fn run_case(case: CaseParam) {
         id: _id,
         finalized_block_number,
         finalized_block_timestamp,
-        deposit_block_timepoint,
+        deposit_finalized_timepoint,
         expected_result,
     } = case;
     let rollup_config = default_rollup_config();
@@ -129,7 +129,9 @@ fn run_case(case: CaseParam) {
                 .hash_type(ScriptHashType::Type.into())
                 .args({
                     let custodian_lock_args = CustodianLockArgs::new_builder()
-                        .deposit_block_timepoint(deposit_block_timepoint.full_value().pack())
+                        .deposit_finalized_timepoint(
+                            deposit_finalized_timepoint.full_value().pack(),
+                        )
                         .build();
                     let mut args = Vec::new();
                     args.extend_from_slice(rollup_state_type_hash.as_slice());

--- a/crates/tests/src/script_tests/stake_lock.rs
+++ b/crates/tests/src/script_tests/stake_lock.rs
@@ -25,8 +25,8 @@ struct CaseParam {
     finalized_block_number: u64,
     // GlobalState.last_finalized_timepoint
     finalized_block_timestamp: u64,
-    // StakeLockArgs.stake_block_timepoint
-    stake_block_timepoint: Timepoint,
+    // StakeLockArgs.stake_finalized_timepoint
+    stake_finalized_timepoint: Timepoint,
     // expected running result of the test case, Ok(()) or Err(exit_code)
     expected_result: Result<(), i8>,
 }
@@ -50,7 +50,7 @@ fn test_finality_of_stake_lock() {
             id: 0,
             finalized_block_number,
             finalized_block_timestamp,
-            stake_block_timepoint: finalized_timepoint_by_block_number,
+            stake_finalized_timepoint: finalized_timepoint_by_block_number,
             expected_result: Ok(()),
         },
         CaseParam {
@@ -58,7 +58,7 @@ fn test_finality_of_stake_lock() {
             id: 1,
             finalized_block_number,
             finalized_block_timestamp,
-            stake_block_timepoint: unfinalized_timepoint_by_block_number,
+            stake_finalized_timepoint: unfinalized_timepoint_by_block_number,
             expected_result: Err(INVALID_STAKE_CELL_UNLOCK_EXIT_CODE),
         },
         CaseParam {
@@ -66,7 +66,7 @@ fn test_finality_of_stake_lock() {
             id: 2,
             finalized_block_number,
             finalized_block_timestamp,
-            stake_block_timepoint: finalized_timepoint_by_block_timestamp,
+            stake_finalized_timepoint: finalized_timepoint_by_block_timestamp,
             expected_result: Ok(()),
         },
         CaseParam {
@@ -74,7 +74,7 @@ fn test_finality_of_stake_lock() {
             id: 3,
             finalized_block_number,
             finalized_block_timestamp,
-            stake_block_timepoint: unfinalized_timepoint_by_block_timestamp,
+            stake_finalized_timepoint: unfinalized_timepoint_by_block_timestamp,
             expected_result: Err(INVALID_STAKE_CELL_UNLOCK_EXIT_CODE),
         },
     ];
@@ -87,7 +87,7 @@ fn run_case(case: CaseParam) {
         id: _id,
         finalized_block_number,
         finalized_block_timestamp,
-        stake_block_timepoint,
+        stake_finalized_timepoint,
         expected_result,
     } = case;
     let rollup_config = default_rollup_config();
@@ -136,7 +136,7 @@ fn run_case(case: CaseParam) {
                 .args({
                     let stake_lock_args = StakeLockArgs::new_builder()
                         .owner_lock_hash(Byte32::new_unchecked(stake_owner_lock_hash.as_bytes()))
-                        .stake_block_timepoint(stake_block_timepoint.full_value().pack())
+                        .stake_finalized_timepoint(stake_finalized_timepoint.full_value().pack())
                         .build();
                     let mut args = Vec::new();
                     args.extend_from_slice(rollup_state_type_hash.as_slice());

--- a/crates/tests/src/script_tests/state_validator/submit_block.rs
+++ b/crates/tests/src/script_tests/state_validator/submit_block.rs
@@ -91,7 +91,7 @@ async fn test_submit_block() {
     };
     let output_stake_cell = {
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(Pack::pack(&1))
+            .stake_finalized_timepoint(Pack::pack(&1))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -211,7 +211,7 @@ async fn test_replace_rollup_cell_lock() {
     };
     let output_stake_cell = {
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(Pack::pack(&1))
+            .stake_finalized_timepoint(Pack::pack(&1))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -346,7 +346,7 @@ async fn test_downgrade_rollup_cell() {
     };
     let output_stake_cell = {
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(Pack::pack(&1))
+            .stake_finalized_timepoint(Pack::pack(&1))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -480,7 +480,7 @@ async fn test_v1_block_timestamp_smaller_or_equal_than_previous_block_in_submit_
     };
     let output_stake_cell = {
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(Pack::pack(&1))
+            .stake_finalized_timepoint(Pack::pack(&1))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -690,7 +690,7 @@ async fn test_v1_block_timestamp_bigger_than_rollup_input_since_in_submit_block(
     };
     let output_stake_cell = {
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(Pack::pack(&1))
+            .stake_finalized_timepoint(Pack::pack(&1))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -831,7 +831,7 @@ async fn test_v0_v1_wrong_global_state_tip_block_timestamp_in_submit_block() {
     };
     let output_stake_cell = {
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(Pack::pack(&1))
+            .stake_finalized_timepoint(Pack::pack(&1))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -1058,7 +1058,7 @@ async fn test_check_reverted_cells_in_submit_block() {
     };
     let output_stake_cell = {
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(Pack::pack(&1))
+            .stake_finalized_timepoint(Pack::pack(&1))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -1101,7 +1101,7 @@ async fn test_check_reverted_cells_in_submit_block() {
         let args = CustodianLockArgs::new_builder()
             .deposit_lock_args(deposit_args.clone())
             .deposit_block_hash(Pack::pack(&revert_block_hash))
-            .deposit_block_timepoint(Pack::pack(&revert_block_number))
+            .deposit_finalized_timepoint(Pack::pack(&revert_block_number))
             .build();
         let cell = build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -1126,7 +1126,7 @@ async fn test_check_reverted_cells_in_submit_block() {
         let owner_lock = Script::default();
         let lock_args = WithdrawalLockArgs::new_builder()
             .withdrawal_block_hash(Pack::pack(&revert_block_hash))
-            .withdrawal_block_timepoint(Pack::pack(&revert_block_number))
+            .withdrawal_finalized_timepoint(Pack::pack(&revert_block_number))
             .owner_lock_hash(Pack::pack(&owner_lock.hash()))
             .build();
         let mut args = Vec::new();
@@ -1145,7 +1145,7 @@ async fn test_check_reverted_cells_in_submit_block() {
     let output_reverted_custodian_cell = {
         let args = CustodianLockArgs::new_builder()
             .deposit_block_hash(Pack::pack(&[0u8; 32]))
-            .deposit_block_timepoint(Pack::pack(&0))
+            .deposit_finalized_timepoint(Pack::pack(&0))
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -1163,7 +1163,7 @@ async fn test_check_reverted_cells_in_submit_block() {
             .map(|_| {
                 let args = CustodianLockArgs::new_builder()
                     .deposit_block_hash(Pack::pack(&[0u8; 32]))
-                    .deposit_block_timepoint(Pack::pack(&0))
+                    .deposit_finalized_timepoint(Pack::pack(&0))
                     .build();
                 let cell = build_rollup_locked_cell(
                     &rollup_type_script.hash(),
@@ -1183,7 +1183,7 @@ async fn test_check_reverted_cells_in_submit_block() {
             .map(|_| {
                 let args = CustodianLockArgs::new_builder()
                     .deposit_block_hash(Pack::pack(&[0u8; 32]))
-                    .deposit_block_timepoint(Pack::pack(&0))
+                    .deposit_finalized_timepoint(Pack::pack(&0))
                     .build();
                 build_rollup_locked_cell(
                     &rollup_type_script.hash(),
@@ -1478,7 +1478,7 @@ async fn test_withdrawal_cell_lock_args_with_owner_lock_in_submit_block() {
     let output_stake_cell = {
         let block_number = block_result.block.raw().number();
         let lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(block_number)
+            .stake_finalized_timepoint(block_number)
             .build();
         build_rollup_locked_cell(
             &rollup_type_script.hash(),
@@ -1519,7 +1519,7 @@ async fn test_withdrawal_cell_lock_args_with_owner_lock_in_submit_block() {
     // build withdrawal output
     let output_withdrawal_cell = {
         let lock_args = WithdrawalLockArgs::new_builder()
-            .withdrawal_block_timepoint(block_result.block.raw().number())
+            .withdrawal_finalized_timepoint(block_result.block.raw().number())
             .withdrawal_block_hash(Pack::pack(&block_result.block.raw().hash()))
             .account_script_hash(Pack::pack(&account_script.hash()))
             .owner_lock_hash(Pack::pack(&account_script.hash()))

--- a/crates/tests/src/script_tests/withdrawal.rs
+++ b/crates/tests/src/script_tests/withdrawal.rs
@@ -39,12 +39,12 @@ fn test_unlock_withdrawal_via_finalize_by_input_owner_cell() {
     let rollup_type_hash = rollup_type_script.hash();
     let (mut verify_ctx, script_ctx) = build_verify_context();
 
-    let withdrawal_block_timepoint =
+    let withdrawal_finalized_timepoint =
         Timepoint::from_block_number(rand::random::<u32>() as u64 + 100);
     let (block_merkle_state, last_finalized_timepoint) =
         mock_global_state_timepoint_by_finalized_timepoint(
             &verify_ctx.rollup_config(),
-            &withdrawal_block_timepoint,
+            &withdrawal_finalized_timepoint,
         );
     let rollup_cell = {
         let global_state = GlobalState::new_builder()
@@ -96,7 +96,7 @@ fn test_unlock_withdrawal_via_finalize_by_input_owner_cell() {
         let lock_args = WithdrawalLockArgs::new_builder()
             .account_script_hash(random_always_success_script().to_gw().hash().pack())
             .withdrawal_block_hash(random_always_success_script().to_gw().hash().pack())
-            .withdrawal_block_timepoint(withdrawal_block_timepoint.full_value().pack())
+            .withdrawal_finalized_timepoint(withdrawal_finalized_timepoint.full_value().pack())
             .owner_lock_hash(owner_lock.hash().pack())
             .build();
         let mut args = Vec::new();
@@ -187,12 +187,12 @@ fn test_unlock_withdrawal_via_finalize_by_switch_indexed_output_to_owner_lock() 
     let rollup_type_hash = rollup_type_script.hash();
     let (mut verify_ctx, script_ctx) = build_verify_context();
 
-    let withdrawal_block_timepoint =
+    let withdrawal_finalized_timepoint =
         Timepoint::from_block_number(rand::random::<u32>() as u64 + 100);
     let (block_merkle_state, last_finalized_timepoint) =
         mock_global_state_timepoint_by_finalized_timepoint(
             &verify_ctx.rollup_config(),
-            &withdrawal_block_timepoint,
+            &withdrawal_finalized_timepoint,
         );
     let rollup_cell = {
         let global_state = GlobalState::new_builder()
@@ -219,7 +219,7 @@ fn test_unlock_withdrawal_via_finalize_by_switch_indexed_output_to_owner_lock() 
         let lock_args = WithdrawalLockArgs::new_builder()
             .account_script_hash(random_always_success_script().to_gw().hash().pack())
             .withdrawal_block_hash(random_always_success_script().to_gw().hash().pack())
-            .withdrawal_block_timepoint(withdrawal_block_timepoint.full_value().pack())
+            .withdrawal_finalized_timepoint(withdrawal_finalized_timepoint.full_value().pack())
             .owner_lock_hash(owner_lock.hash().pack())
             .build();
 
@@ -365,12 +365,12 @@ fn test_unlock_withdrawal_via_finalize_fallback_to_input_owner_cell() {
     let rollup_type_hash = rollup_type_script.hash();
     let (mut verify_ctx, script_ctx) = build_verify_context();
 
-    let withdrawal_block_timepoint =
+    let withdrawal_finalized_timepoint =
         Timepoint::from_block_number(rand::random::<u32>() as u64 + 100);
     let (block_merkle_state, last_finalized_timepoint) =
         mock_global_state_timepoint_by_finalized_timepoint(
             &verify_ctx.rollup_config(),
-            &withdrawal_block_timepoint,
+            &withdrawal_finalized_timepoint,
         );
     let rollup_cell = {
         let global_state = GlobalState::new_builder()
@@ -417,7 +417,7 @@ fn test_unlock_withdrawal_via_finalize_fallback_to_input_owner_cell() {
         let lock_args = WithdrawalLockArgs::new_builder()
             .account_script_hash(random_always_success_script().to_gw().hash().pack())
             .withdrawal_block_hash(random_always_success_script().to_gw().hash().pack())
-            .withdrawal_block_timepoint(withdrawal_block_timepoint.full_value().pack())
+            .withdrawal_finalized_timepoint(withdrawal_finalized_timepoint.full_value().pack())
             .owner_lock_hash(owner_lock.hash().pack())
             .build();
 

--- a/crates/tests/src/script_tests/withdrawal/finality.rs
+++ b/crates/tests/src/script_tests/withdrawal/finality.rs
@@ -34,8 +34,8 @@ struct CaseParam {
     tip_block_number: u64,
     // GlobalState.last_finalized_timepoint
     global_state_last_finalized_timepoint: Timepoint,
-    // WithdrawalLockArgs.withdrawal_block_timepoint
-    withdrawal_block_timepoint: Timepoint,
+    // WithdrawalLockArgs.withdrawal_finalized_timepoint
+    withdrawal_finalized_timepoint: Timepoint,
     // Input since
     since: Uint64,
 
@@ -62,7 +62,7 @@ fn test_finality_of_withdrawal_lock() {
             id: 0,
             tip_block_number,
             global_state_last_finalized_timepoint: global_state_last_finalized_timepoint.clone(),
-            withdrawal_block_timepoint: Timepoint::from_block_number(
+            withdrawal_finalized_timepoint: Timepoint::from_block_number(
                 tip_block_number - DEFAULT_FINALITY_BLOCKS,
             ),
             since: Default::default(),
@@ -75,7 +75,7 @@ fn test_finality_of_withdrawal_lock() {
             id: 1,
             tip_block_number,
             global_state_last_finalized_timepoint: global_state_last_finalized_timepoint.clone(),
-            withdrawal_block_timepoint: Timepoint::from_block_number(
+            withdrawal_finalized_timepoint: Timepoint::from_block_number(
                 tip_block_number + 1 - DEFAULT_FINALITY_BLOCKS,
             ),
             since: Default::default(),
@@ -88,7 +88,7 @@ fn test_finality_of_withdrawal_lock() {
             id: 2,
             tip_block_number,
             global_state_last_finalized_timepoint: global_state_last_finalized_timepoint.clone(),
-            withdrawal_block_timepoint: global_state_last_finalized_timepoint.clone(),
+            withdrawal_finalized_timepoint: global_state_last_finalized_timepoint.clone(),
             since: since_timestamp(random_timestamp),
             unlock_path_include_one_owner_input: true,
             unlock_path_same_index_same_content_output: false,
@@ -99,7 +99,7 @@ fn test_finality_of_withdrawal_lock() {
             id: 3,
             tip_block_number,
             global_state_last_finalized_timepoint: global_state_last_finalized_timepoint.clone(),
-            withdrawal_block_timepoint: global_state_last_finalized_timepoint.clone(),
+            withdrawal_finalized_timepoint: global_state_last_finalized_timepoint.clone(),
             since: since_timestamp(random_timestamp - 1000),
             unlock_path_include_one_owner_input: true,
             unlock_path_same_index_same_content_output: false,
@@ -110,7 +110,7 @@ fn test_finality_of_withdrawal_lock() {
             id: 4,
             tip_block_number,
             global_state_last_finalized_timepoint: global_state_last_finalized_timepoint.clone(),
-            withdrawal_block_timepoint: Timepoint::from_block_number(
+            withdrawal_finalized_timepoint: Timepoint::from_block_number(
                 tip_block_number - DEFAULT_FINALITY_BLOCKS,
             ),
             since: Default::default(),
@@ -123,7 +123,7 @@ fn test_finality_of_withdrawal_lock() {
             id: 5,
             tip_block_number,
             global_state_last_finalized_timepoint,
-            withdrawal_block_timepoint: Timepoint::from_block_number(
+            withdrawal_finalized_timepoint: Timepoint::from_block_number(
                 tip_block_number - DEFAULT_FINALITY_BLOCKS,
             ),
             since: Default::default(),
@@ -141,7 +141,7 @@ fn run_case(case: CaseParam) {
         id: _id,
         tip_block_number,
         global_state_last_finalized_timepoint,
-        withdrawal_block_timepoint,
+        withdrawal_finalized_timepoint,
         since,
         expected_result,
         unlock_path_same_index_same_content_output,
@@ -205,7 +205,9 @@ fn run_case(case: CaseParam) {
                         .owner_lock_hash(Byte32::new_unchecked(
                             withdrawal_owner_lock_hash.as_bytes(),
                         ))
-                        .withdrawal_block_timepoint(withdrawal_block_timepoint.full_value().pack())
+                        .withdrawal_finalized_timepoint(
+                            withdrawal_finalized_timepoint.full_value().pack(),
+                        )
                         .build();
                     let mut args = Vec::new();
                     args.extend_from_slice(rollup_state_type_hash.as_slice());

--- a/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
+++ b/crates/tests/src/tests/unlock_withdrawal_to_owner.rs
@@ -384,10 +384,10 @@ async fn test_build_unlock_to_owner_tx() {
         }
     };
     let output_stake = {
-        let stake_block_timepoint =
+        let stake_finalized_timepoint =
             Timepoint::from_block_number(withdrawal_block_result.block.raw().number().unpack());
         let stake_lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(stake_block_timepoint.full_value().pack())
+            .stake_finalized_timepoint(stake_finalized_timepoint.full_value().pack())
             .build();
 
         let mut lock_args = rollup_script_hash.as_slice().to_vec();
@@ -652,10 +652,10 @@ async fn test_build_unlock_to_owner_tx() {
     let output_rollup_cell = (rollup_cell.output, block_result.global_state.as_bytes());
 
     let output_stake = {
-        let stake_block_timepoint =
+        let stake_finalized_timepoint =
             Timepoint::from_block_number(block_result.block.raw().number().unpack());
         let stake_lock_args = StakeLockArgs::new_builder()
-            .stake_block_timepoint(stake_block_timepoint.full_value().pack())
+            .stake_finalized_timepoint(stake_finalized_timepoint.full_value().pack())
             .build();
 
         let mut lock_args = rollup_script_hash.as_slice().to_vec();

--- a/crates/tools/src/deposit_ckb.rs
+++ b/crates/tools/src/deposit_ckb.rs
@@ -247,7 +247,7 @@ fn minimal_deposit_capacity(deposit_lock_args: &DepositLockArgs) -> Result<u64> 
 
     let custodian_lock_args = CustodianLockArgs::new_builder()
         .deposit_block_hash(gw_types::prelude::Pack::pack(&dummy_hash))
-        .deposit_block_timepoint(gw_types::prelude::Pack::pack(&dummy_timepoint.full_value()))
+        .deposit_finalized_timepoint(gw_types::prelude::Pack::pack(&dummy_timepoint.full_value()))
         .deposit_lock_args(deposit_lock_args.clone())
         .build();
 

--- a/crates/tools/src/withdraw.rs
+++ b/crates/tools/src/withdraw.rs
@@ -224,7 +224,7 @@ fn minimal_withdrawal_capacity(is_sudt: bool) -> Result<u64> {
     let dummy_withdrawal_lock_args = WithdrawalLockArgs::new_builder()
         .account_script_hash(dummy_hash.pack())
         .withdrawal_block_hash(dummy_hash.pack())
-        .withdrawal_block_timepoint(dummy_timepoint.full_value().pack())
+        .withdrawal_finalized_timepoint(dummy_timepoint.full_value().pack())
         .owner_lock_hash(dummy_hash.pack())
         .build();
 

--- a/docs/deposit_and_withdrawal.md
+++ b/docs/deposit_and_withdrawal.md
@@ -53,12 +53,12 @@ The first 32 bytes of `args` is a unique value associated with the rollup instan
 ```
 table CustodianLockArgs {
     deposit_block_hash: Byte32,
-    deposit_block_timepoint: Uint64,
+    deposit_finalized_timepoint: Uint64,
     deposit_lock_args: DepositLockArgs,
 }
 ```
 
-`CustodianLockArgs` saves the entire deposit info, `deposit_lock_args` is from the original deposit cell's args, `deposit_block_hash` and `deposit_block_timepoint` denotes the layer2 block that include the deposit.
+`CustodianLockArgs` saves the entire deposit info, `deposit_lock_args` is from the original deposit cell's args, `deposit_block_hash` and `deposit_finalized_timepoint` denotes the layer2 block that include the deposit.
 
 CKB requires `capacity` to cover the cost of the cell, the `capacity` of the deposited cell must also cover the custodian cell, so the minimal deposit CKB that Godwoken allows is as follows:
 
@@ -89,14 +89,14 @@ Withdrawal lock guarantees the cell can only be unlocked after `finality blocks`
 ```
 struct WithdrawalLockArgs {
     withdrawal_block_hash: Byte32,
-    withdrawal_block_timepoint: Uint64,
+    withdrawal_finalized_timepoint: Uint64,
     account_script_hash: Byte32,
     // layer1 lock to withdraw after challenge period
     owner_lock_hash: Byte32,
 }
 ```
 
-`withdrawal_block_hash` and `withdrawal_block_timepoint` record which layer2 block included the withdrawal. `account_script_hash` represent the layer2 account. `owner_lock_hash` represent the layer1 lock that user used to unlock the cell.
+`withdrawal_block_hash` and `withdrawal_finalized_timepoint` record which layer2 block included the withdrawal. `account_script_hash` represent the layer2 account. `owner_lock_hash` represent the layer1 lock that user used to unlock the cell.
 
 CKB requires `capacity` to cover the cost of the cell, so the minimal withdrawal CKB that Godwoken allows is as follows:
 

--- a/docs/finality_mechanism_changes.md
+++ b/docs/finality_mechanism_changes.md
@@ -33,11 +33,11 @@ Here are some test vectors:
 - The `timepoint_flag == 0` indicates that its `timepoint_value` is the **finalized block number**, so any blocks with a lower number are finalized.
 - The `timepoint_flag == 1` indicates that its `timepoint_value` is the **finalized timestamp**, so any blocks with a lower timestamp are finalized.
 
-### Interpretation of `WithdrawalLockArgs.withdrawal_block_timepoint`
+### Interpretation of `WithdrawalLockArgs.withdrawal_finalized_timepoint`
 
-> **NOTE**: **[`WithdrawalLockArgs.withdrawal_block_number`](https://github.com/godwokenrises/godwoken/blob/5617b579927d85509e8f88ac4fb4493ef449b642/crates/types/schemas/godwoken.mol#L206) was renamed to [`WithdrawalLockArgs.withdrawal_block_timepoint`](https://github.com/godwokenrises/godwoken/pull/836/files#diff-96e540dc83a433d447e1d2dae392fc5eafce72e839ea3900f6f1f8638aaada6bL206-R209).**
+> **NOTE**: **[`WithdrawalLockArgs.withdrawal_block_number`](https://github.com/godwokenrises/godwoken/blob/5617b579927d85509e8f88ac4fb4493ef449b642/crates/types/schemas/godwoken.mol#L206) was renamed to [`WithdrawalLockArgs.withdrawal_finalized_timepoint`](https://github.com/godwokenrises/godwoken/pull/836/files#diff-96e540dc83a433d447e1d2dae392fc5eafce72e839ea3900f6f1f8638aaada6bL206-R209).**
 
-`WithdrawalLockArgs.withdrawal_block_timepoint` was changed to type `Timepoint`:
+`WithdrawalLockArgs.withdrawal_finalized_timepoint` was changed to type `Timepoint`:
 - If `timepoint_flag == 0` then its `timepoint_value` is the **withdrawn block number**, so it becomes finalized when the tip block number exceeds `rollup_config.finality_blocks` blocks above the **withdrawn block number**.
 - If `timepoint_flag == 1` then its `timepoint_value` is the **withdrawn block timestamp**, so it becomes finalized when `GlobalState.last_finalized_timepoint` exceeds the **withdrawn block timestamp**.
 
@@ -66,7 +66,7 @@ fn is_withdrawal_finalized(
     global_state: &GlobalState,
     withdrawal_lock_args: &WithdrawalLockArgs
 ) -> bool {
-    let withdrawn_timepoint = withdrawal_lock_args.withdrawal_block_timepoint().unpack();
+    let withdrawn_timepoint = withdrawal_lock_args.withdrawal_finalized_timepoint().unpack();
     let finalized_timepoint = global_state.last_finalized_timepoint().unpack();
     let finalized_block_number = global_state.block().count().unpack() - 1 - rollup_config.finality_blocks().unpack();
 
@@ -105,7 +105,7 @@ fn estimate_future_pending_time(
     withdrawal_lock_args: &WithdrawalLockArgs,
 ) -> u64 {
     let finalized_block_number = global_state.block().count().unpack() - 1 - rollup_config.finality_blocks().unpack();
-    match Timepoint::from_full_value(withdrawal_lock_args.withdrawal_block_timepoint().unpack()) {
+    match Timepoint::from_full_value(withdrawal_lock_args.withdrawal_finalized_timepoint().unpack()) {
         Timepoint::BlockNumber(wbn) => {
             max(0, wbn - finalized_block_number) * ESTIMATE_BLOCK_INTERVAL
         }

--- a/docs/life_of_a_godwoken_transaction.md
+++ b/docs/life_of_a_godwoken_transaction.md
@@ -142,7 +142,7 @@ Like deposit cells, custodian cells have pre-determined `code_hash` and `hash_ty
 ```
 table CustodianLockArgs {
     deposit_block_hash: Byte32,
-    deposit_block_timepoint: Uint64,
+    deposit_finalized_timepoint: Uint64,
     // used for revert this cell to deposit request cell
     // after finalize, this lock is meaningless
     deposit_lock_args: DepositLockArgs,

--- a/gwos/README.md
+++ b/gwos/README.md
@@ -72,11 +72,11 @@ The `lock` fields of the Rollup cell have relatively standalone rules, in the or
 ### Stake lock
 
 A block producer is required to provide a stake cell to perform the `RollupSubmitBlock` action.
-The stake lock args is `StakeLockArgs`, after submitting a layer-2 block, the `args.stake_block_timepoint` is updated to the latest block's timepoint.
+The stake lock args is `StakeLockArgs`, after submitting a layer-2 block, the `args.stake_finalized_timepoint` is updated to the latest block's timepoint.
 
 Stake lock can be unlocked in two paths:
 
-1. Unlock by the submitter after `args.stake_block_timepoint`'s block is finalized.
+1. Unlock by the submitter after `args.stake_finalized_timepoint`'s block is finalized.
 2. Unlock by the challenger in the `RollupRevert` action.
 
 ### Deposit lock
@@ -87,9 +87,9 @@ The sender can unlock a deposit cell after `cancel_timeout` if the deposit is no
 
 ### Custodian lock
 
-Rollup uses the custodian lock to hold the deposited assets. Custodian lock's args is a structure `CustodianLockArgs`, the field `deposit_block_timepoint` represents the block that the deposit is processed.
+Rollup uses the custodian lock to hold the deposited assets. Custodian lock's args is a structure `CustodianLockArgs`, the field `deposit_finalized_timepoint` represents the block that the deposit is processed.
 
-The `deposit_block_timepoint` also denotes whether the custodian lock is finalized or unfinalized.
+The `deposit_finalized_timepoint` also denotes whether the custodian lock is finalized or unfinalized.
 For unfinalized custodian cells, once the deposit block is reverted, these cells must be also reverted to the deposit cells.
 For finalized custodian cells, since they are finalized, we can free merge or split these cells.
 
@@ -101,7 +101,7 @@ Withdrawal cells are generated in the `RollupSubmitBlock` action according to th
 
 The withdrawal lock has two unlock paths:
 
-1. Unlock by withdrawer after the `WithdrawalLockArgs#withdrawal_block_timepoint` is finalized.
+1. Unlock by withdrawer after the `WithdrawalLockArgs#withdrawal_finalized_timepoint` is finalized.
 2. Unlock as a reverted cell in the `RollupSubmitBlock` action, a corresponded custodian cell will be generated.
 
 ### Challenge lock

--- a/gwos/contracts/custodian-lock/src/entry.rs
+++ b/gwos/contracts/custodian-lock/src/entry.rs
@@ -64,7 +64,7 @@ pub fn main() -> Result<(), Error> {
     let is_finalized = is_finalized(
         &config,
         &global_state,
-        &Timepoint::from_full_value(lock_args.deposit_block_timepoint().unpack()),
+        &Timepoint::from_full_value(lock_args.deposit_finalized_timepoint().unpack()),
     );
     if is_finalized {
         // this custodian lock is already finalized, rollup will handle the logic

--- a/gwos/contracts/stake-lock/src/entry.rs
+++ b/gwos/contracts/stake-lock/src/entry.rs
@@ -54,13 +54,13 @@ pub fn main() -> Result<(), Error> {
     // Unlock by User
     // read global state from rollup cell in deps
     if let Some(global_state) = search_rollup_state(&rollup_type_hash, Source::CellDep)? {
-        // 1. check if stake_block_timepoint is finalized
+        // 1. check if stake_finalized_timepoint is finalized
         // 2. check if owner_lock_hash exists in input cells
         let config = load_rollup_config(&global_state.rollup_config_hash().unpack())?;
         let is_finalized = is_finalized(
             &config,
             &global_state,
-            &Timepoint::from_full_value(lock_args.stake_block_timepoint().unpack()),
+            &Timepoint::from_full_value(lock_args.stake_finalized_timepoint().unpack()),
         );
         if is_finalized
             && search_lock_hash(&lock_args.owner_lock_hash().unpack(), Source::Input).is_some()

--- a/gwos/contracts/state-validator/src/verifications/submit_block.rs
+++ b/gwos/contracts/state-validator/src/verifications/submit_block.rs
@@ -80,12 +80,12 @@ fn check_withdrawal_cells<'a>(
             return Err(Error::InvalidWithdrawalCell);
         }
 
-        if cell.args.withdrawal_block_timepoint().unpack()
+        if cell.args.withdrawal_finalized_timepoint().unpack()
             != context.finalized_timepoint().full_value()
         {
             debug!(
-                "withdrawal_cell.args.withdrawal_block_timepoint != context.block_timepoint, {} != {}",
-                cell.args.withdrawal_block_timepoint().unpack(),
+                "withdrawal_cell.args.withdrawal_finalized_timepoint != context.block_timepoint, {} != {}",
+                cell.args.withdrawal_finalized_timepoint().unpack(),
                 context.finalized_timepoint().full_value()
             );
             return Err(Error::InvalidWithdrawalCell);
@@ -139,7 +139,7 @@ fn check_input_custodian_cells(
                 is_finalized(
                     config,
                     prev_global_state,
-                    &Timepoint::from_full_value(cell.args.deposit_block_timepoint().unpack()),
+                    &Timepoint::from_full_value(cell.args.deposit_finalized_timepoint().unpack()),
                 )
             });
     // check unfinalized custodian cells == reverted deposit requests
@@ -188,11 +188,11 @@ fn check_output_custodian_cells(
                 is_finalized(
                     config,
                     prev_global_state,
-                    &Timepoint::from_full_value(cell.args.deposit_block_timepoint().unpack()),
+                    &Timepoint::from_full_value(cell.args.deposit_finalized_timepoint().unpack()),
                 )
             });
     // check deposits request cells == unfinalized custodian cells
-    // check l2block's timepoint == unfinalized custodian cells' deposit_block_timepoint
+    // check l2block's timepoint == unfinalized custodian cells' deposit_finalized_timepoint
     // check l2block's block_hash == unfinalized custodian cells' deposit_block_hash
     for custodian_cell in unfinalized_custodian_cells {
         let index = deposit_cells
@@ -200,7 +200,7 @@ fn check_output_custodian_cells(
             .position(|cell| {
                 custodian_cell.args.deposit_lock_args() == cell.args
                     && custodian_cell.args.deposit_block_hash() == context.block_hash.pack()
-                    && custodian_cell.args.deposit_block_timepoint().unpack()
+                    && custodian_cell.args.deposit_finalized_timepoint().unpack()
                         == context.finalized_timepoint().full_value()
                     && custodian_cell.value == cell.value
             })
@@ -580,7 +580,7 @@ fn verify_block_producer(
         let expected_stake_lock_args = input_stake_cell
             .args
             .as_builder()
-            .stake_block_timepoint(context.finalized_timepoint().full_value().pack())
+            .stake_finalized_timepoint(context.finalized_timepoint().full_value().pack())
             .build();
         if expected_stake_lock_args != output_stake_cell.args
             || input_stake_cell.capacity > output_stake_cell.capacity

--- a/gwos/contracts/withdrawal-lock/src/entry.rs
+++ b/gwos/contracts/withdrawal-lock/src/entry.rs
@@ -137,8 +137,8 @@ pub fn main() -> Result<(), Error> {
             };
             let custodian_deposit_block_hash: [u8; 32] =
                 custodian_lock_args.deposit_block_hash().unpack();
-            let custodian_deposit_block_timepoint: u64 =
-                custodian_lock_args.deposit_block_timepoint().unpack();
+            let custodian_deposit_finalized_timepoint: u64 =
+                custodian_lock_args.deposit_finalized_timepoint().unpack();
             let global_state = search_rollup_state(&rollup_type_hash, Source::Input)?
                 .ok_or(Error::RollupCellNotFound)?;
             let config = load_rollup_config(&global_state.rollup_config_hash().unpack())?;
@@ -146,7 +146,7 @@ pub fn main() -> Result<(), Error> {
                 != config.custodian_script_type_hash().as_slice()
                 || custodian_lock.hash_type() != ScriptHashType::Type.into()
                 || custodian_deposit_block_hash != FINALIZED_BLOCK_HASH
-                || custodian_deposit_block_timepoint != FINALIZED_BLOCK_TIMEPOINT
+                || custodian_deposit_finalized_timepoint != FINALIZED_BLOCK_TIMEPOINT
             {
                 return Err(Error::InvalidOutput);
             }
@@ -156,9 +156,9 @@ pub fn main() -> Result<(), Error> {
             Ok(())
         }
         UnlockWithdrawalWitnessUnion::UnlockWithdrawalViaFinalize(_unlock_args) => {
-            let withdrawal_block_timepoint =
-                Timepoint::from_full_value(lock_args.withdrawal_block_timepoint().unpack());
-            match &withdrawal_block_timepoint {
+            let withdrawal_finalized_timepoint =
+                Timepoint::from_full_value(lock_args.withdrawal_finalized_timepoint().unpack());
+            match &withdrawal_finalized_timepoint {
                 Timepoint::BlockNumber(_) => {
                     let global_state =
                         match search_rollup_state(&rollup_type_hash, Source::CellDep)? {
@@ -170,7 +170,7 @@ pub fn main() -> Result<(), Error> {
                             }
                         };
                     let config = load_rollup_config(&global_state.rollup_config_hash().unpack())?;
-                    if !is_finalized(&config, &global_state, &withdrawal_block_timepoint) {
+                    if !is_finalized(&config, &global_state, &withdrawal_finalized_timepoint) {
                         return Err(Error::NotFinalized);
                     }
                 }

--- a/gwos/crates/types/schemas/godwoken.mol
+++ b/gwos/crates/types/schemas/godwoken.mol
@@ -189,7 +189,7 @@ table DepositLockArgs {
 table CustodianLockArgs {
     deposit_block_hash: Byte32,
     // Timepoint format
-    deposit_block_timepoint: Uint64,
+    deposit_finalized_timepoint: Uint64,
     // used for revert this cell to deposit request cell
     // after finalize, this lock is meaningless
     deposit_lock_args: DepositLockArgs,
@@ -206,7 +206,7 @@ struct UnlockCustodianViaRevertWitness {
 struct WithdrawalLockArgs {
     withdrawal_block_hash: Byte32,
     // Timepoint format
-    withdrawal_block_timepoint: Uint64,
+    withdrawal_finalized_timepoint: Uint64,
     account_script_hash: Byte32,
     // layer1 lock to withdraw after challenge period
     owner_lock_hash: Byte32,
@@ -228,7 +228,7 @@ struct UnlockWithdrawalViaRevert {
 struct StakeLockArgs {
     owner_lock_hash: Byte32,
     // Timepoint format
-    stake_block_timepoint: Uint64,
+    stake_finalized_timepoint: Uint64,
 }
 // --- end of stake lock ---
 

--- a/gwos/crates/types/src/generated/godwoken.rs
+++ b/gwos/crates/types/src/generated/godwoken.rs
@@ -7482,8 +7482,8 @@ impl ::core::fmt::Display for CustodianLockArgs {
         write!(
             f,
             ", {}: {}",
-            "deposit_block_timepoint",
-            self.deposit_block_timepoint()
+            "deposit_finalized_timepoint",
+            self.deposit_finalized_timepoint()
         )?;
         write!(f, ", {}: {}", "deposit_lock_args", self.deposit_lock_args())?;
         let extra_count = self.count_extra_fields();
@@ -7531,7 +7531,7 @@ impl CustodianLockArgs {
         let end = molecule::unpack_number(&slice[8..]) as usize;
         Byte32::new_unchecked(self.0.slice(start..end))
     }
-    pub fn deposit_block_timepoint(&self) -> Uint64 {
+    pub fn deposit_finalized_timepoint(&self) -> Uint64 {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
         let end = molecule::unpack_number(&slice[12..]) as usize;
@@ -7575,7 +7575,7 @@ impl molecule::prelude::Entity for CustodianLockArgs {
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
             .deposit_block_hash(self.deposit_block_hash())
-            .deposit_block_timepoint(self.deposit_block_timepoint())
+            .deposit_finalized_timepoint(self.deposit_finalized_timepoint())
             .deposit_lock_args(self.deposit_lock_args())
     }
 }
@@ -7602,8 +7602,8 @@ impl<'r> ::core::fmt::Display for CustodianLockArgsReader<'r> {
         write!(
             f,
             ", {}: {}",
-            "deposit_block_timepoint",
-            self.deposit_block_timepoint()
+            "deposit_finalized_timepoint",
+            self.deposit_finalized_timepoint()
         )?;
         write!(f, ", {}: {}", "deposit_lock_args", self.deposit_lock_args())?;
         let extra_count = self.count_extra_fields();
@@ -7637,7 +7637,7 @@ impl<'r> CustodianLockArgsReader<'r> {
         let end = molecule::unpack_number(&slice[8..]) as usize;
         Byte32Reader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn deposit_block_timepoint(&self) -> Uint64Reader<'r> {
+    pub fn deposit_finalized_timepoint(&self) -> Uint64Reader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
         let end = molecule::unpack_number(&slice[12..]) as usize;
@@ -7712,7 +7712,7 @@ impl<'r> molecule::prelude::Reader<'r> for CustodianLockArgsReader<'r> {
 #[derive(Debug, Default)]
 pub struct CustodianLockArgsBuilder {
     pub(crate) deposit_block_hash: Byte32,
-    pub(crate) deposit_block_timepoint: Uint64,
+    pub(crate) deposit_finalized_timepoint: Uint64,
     pub(crate) deposit_lock_args: DepositLockArgs,
 }
 impl CustodianLockArgsBuilder {
@@ -7721,8 +7721,8 @@ impl CustodianLockArgsBuilder {
         self.deposit_block_hash = v;
         self
     }
-    pub fn deposit_block_timepoint(mut self, v: Uint64) -> Self {
-        self.deposit_block_timepoint = v;
+    pub fn deposit_finalized_timepoint(mut self, v: Uint64) -> Self {
+        self.deposit_finalized_timepoint = v;
         self
     }
     pub fn deposit_lock_args(mut self, v: DepositLockArgs) -> Self {
@@ -7736,7 +7736,7 @@ impl molecule::prelude::Builder for CustodianLockArgsBuilder {
     fn expected_length(&self) -> usize {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.deposit_block_hash.as_slice().len()
-            + self.deposit_block_timepoint.as_slice().len()
+            + self.deposit_finalized_timepoint.as_slice().len()
             + self.deposit_lock_args.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
@@ -7745,7 +7745,7 @@ impl molecule::prelude::Builder for CustodianLockArgsBuilder {
         offsets.push(total_size);
         total_size += self.deposit_block_hash.as_slice().len();
         offsets.push(total_size);
-        total_size += self.deposit_block_timepoint.as_slice().len();
+        total_size += self.deposit_finalized_timepoint.as_slice().len();
         offsets.push(total_size);
         total_size += self.deposit_lock_args.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
@@ -7753,7 +7753,7 @@ impl molecule::prelude::Builder for CustodianLockArgsBuilder {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
         }
         writer.write_all(self.deposit_block_hash.as_slice())?;
-        writer.write_all(self.deposit_block_timepoint.as_slice())?;
+        writer.write_all(self.deposit_finalized_timepoint.as_slice())?;
         writer.write_all(self.deposit_lock_args.as_slice())?;
         Ok(())
     }
@@ -7943,8 +7943,8 @@ impl ::core::fmt::Display for WithdrawalLockArgs {
         write!(
             f,
             ", {}: {}",
-            "withdrawal_block_timepoint",
-            self.withdrawal_block_timepoint()
+            "withdrawal_finalized_timepoint",
+            self.withdrawal_finalized_timepoint()
         )?;
         write!(
             f,
@@ -7974,7 +7974,7 @@ impl WithdrawalLockArgs {
     pub fn withdrawal_block_hash(&self) -> Byte32 {
         Byte32::new_unchecked(self.0.slice(0..32))
     }
-    pub fn withdrawal_block_timepoint(&self) -> Uint64 {
+    pub fn withdrawal_finalized_timepoint(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(32..40))
     }
     pub fn account_script_hash(&self) -> Byte32 {
@@ -8011,7 +8011,7 @@ impl molecule::prelude::Entity for WithdrawalLockArgs {
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
             .withdrawal_block_hash(self.withdrawal_block_hash())
-            .withdrawal_block_timepoint(self.withdrawal_block_timepoint())
+            .withdrawal_finalized_timepoint(self.withdrawal_finalized_timepoint())
             .account_script_hash(self.account_script_hash())
             .owner_lock_hash(self.owner_lock_hash())
     }
@@ -8044,8 +8044,8 @@ impl<'r> ::core::fmt::Display for WithdrawalLockArgsReader<'r> {
         write!(
             f,
             ", {}: {}",
-            "withdrawal_block_timepoint",
-            self.withdrawal_block_timepoint()
+            "withdrawal_finalized_timepoint",
+            self.withdrawal_finalized_timepoint()
         )?;
         write!(
             f,
@@ -8064,7 +8064,7 @@ impl<'r> WithdrawalLockArgsReader<'r> {
     pub fn withdrawal_block_hash(&self) -> Byte32Reader<'r> {
         Byte32Reader::new_unchecked(&self.as_slice()[0..32])
     }
-    pub fn withdrawal_block_timepoint(&self) -> Uint64Reader<'r> {
+    pub fn withdrawal_finalized_timepoint(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[32..40])
     }
     pub fn account_script_hash(&self) -> Byte32Reader<'r> {
@@ -8098,7 +8098,7 @@ impl<'r> molecule::prelude::Reader<'r> for WithdrawalLockArgsReader<'r> {
 #[derive(Debug, Default)]
 pub struct WithdrawalLockArgsBuilder {
     pub(crate) withdrawal_block_hash: Byte32,
-    pub(crate) withdrawal_block_timepoint: Uint64,
+    pub(crate) withdrawal_finalized_timepoint: Uint64,
     pub(crate) account_script_hash: Byte32,
     pub(crate) owner_lock_hash: Byte32,
 }
@@ -8110,8 +8110,8 @@ impl WithdrawalLockArgsBuilder {
         self.withdrawal_block_hash = v;
         self
     }
-    pub fn withdrawal_block_timepoint(mut self, v: Uint64) -> Self {
-        self.withdrawal_block_timepoint = v;
+    pub fn withdrawal_finalized_timepoint(mut self, v: Uint64) -> Self {
+        self.withdrawal_finalized_timepoint = v;
         self
     }
     pub fn account_script_hash(mut self, v: Byte32) -> Self {
@@ -8131,7 +8131,7 @@ impl molecule::prelude::Builder for WithdrawalLockArgsBuilder {
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         writer.write_all(self.withdrawal_block_hash.as_slice())?;
-        writer.write_all(self.withdrawal_block_timepoint.as_slice())?;
+        writer.write_all(self.withdrawal_finalized_timepoint.as_slice())?;
         writer.write_all(self.account_script_hash.as_slice())?;
         writer.write_all(self.owner_lock_hash.as_slice())?;
         Ok(())
@@ -8850,8 +8850,8 @@ impl ::core::fmt::Display for StakeLockArgs {
         write!(
             f,
             ", {}: {}",
-            "stake_block_timepoint",
-            self.stake_block_timepoint()
+            "stake_finalized_timepoint",
+            self.stake_finalized_timepoint()
         )?;
         write!(f, " }}")
     }
@@ -8872,7 +8872,7 @@ impl StakeLockArgs {
     pub fn owner_lock_hash(&self) -> Byte32 {
         Byte32::new_unchecked(self.0.slice(0..32))
     }
-    pub fn stake_block_timepoint(&self) -> Uint64 {
+    pub fn stake_finalized_timepoint(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(32..40))
     }
     pub fn as_reader<'r>(&'r self) -> StakeLockArgsReader<'r> {
@@ -8903,7 +8903,7 @@ impl molecule::prelude::Entity for StakeLockArgs {
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
             .owner_lock_hash(self.owner_lock_hash())
-            .stake_block_timepoint(self.stake_block_timepoint())
+            .stake_finalized_timepoint(self.stake_finalized_timepoint())
     }
 }
 #[derive(Clone, Copy)]
@@ -8929,8 +8929,8 @@ impl<'r> ::core::fmt::Display for StakeLockArgsReader<'r> {
         write!(
             f,
             ", {}: {}",
-            "stake_block_timepoint",
-            self.stake_block_timepoint()
+            "stake_finalized_timepoint",
+            self.stake_finalized_timepoint()
         )?;
         write!(f, " }}")
     }
@@ -8942,7 +8942,7 @@ impl<'r> StakeLockArgsReader<'r> {
     pub fn owner_lock_hash(&self) -> Byte32Reader<'r> {
         Byte32Reader::new_unchecked(&self.as_slice()[0..32])
     }
-    pub fn stake_block_timepoint(&self) -> Uint64Reader<'r> {
+    pub fn stake_finalized_timepoint(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[32..40])
     }
 }
@@ -8970,7 +8970,7 @@ impl<'r> molecule::prelude::Reader<'r> for StakeLockArgsReader<'r> {
 #[derive(Debug, Default)]
 pub struct StakeLockArgsBuilder {
     pub(crate) owner_lock_hash: Byte32,
-    pub(crate) stake_block_timepoint: Uint64,
+    pub(crate) stake_finalized_timepoint: Uint64,
 }
 impl StakeLockArgsBuilder {
     pub const TOTAL_SIZE: usize = 40;
@@ -8980,8 +8980,8 @@ impl StakeLockArgsBuilder {
         self.owner_lock_hash = v;
         self
     }
-    pub fn stake_block_timepoint(mut self, v: Uint64) -> Self {
-        self.stake_block_timepoint = v;
+    pub fn stake_finalized_timepoint(mut self, v: Uint64) -> Self {
+        self.stake_finalized_timepoint = v;
         self
     }
 }
@@ -8993,7 +8993,7 @@ impl molecule::prelude::Builder for StakeLockArgsBuilder {
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         writer.write_all(self.owner_lock_hash.as_slice())?;
-        writer.write_all(self.stake_block_timepoint.as_slice())?;
+        writer.write_all(self.stake_finalized_timepoint.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {


### PR DESCRIPTION
Molecule:

- `CustodianLockArgs#deposit_block_timepoint` -> `deposit_finalized_timepoint`
- `WithdrawalLockArgs#withdrawal_block_timepoint` -> `withdrawal_finalized_timepoint`
- `StakeLockArgs#stake_block_timepoint` -> `stake_finalized_timepoint`

JronRPC:

- `WithdrawalLockArgs#withdrawal_block_timepoint` -> `withdrawal_finalized_timepoint`