### PR TITLE
improve smt migration

### DIFF
--- a/crates/godwoken-bin/src/subcommand/migrate/mod.rs
+++ b/crates/godwoken-bin/src/subcommand/migrate/mod.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::Parser;
-use gw_config::Config;
+use clap::{ArgGroup, Parser};
+use gw_config::{Config, StoreConfig};
 use gw_store::migrate::{init_migration_factory, open_or_create_db};
 use gw_telemetry::trace;
 
@@ -14,26 +14,40 @@ pub const COMMAND_MIGRATE: &str = "migrate";
 /// Perform db migrations
 #[derive(Parser)]
 #[clap(name = COMMAND_MIGRATE)]
+// One (and only one) of config or db must be present.
+#[clap(group(ArgGroup::new("db-or-config").required(true)))]
 pub struct MigrateCommand {
     /// Godwoken config file path
-    #[clap(long)]
-    config: PathBuf,
+    #[clap(short, long, group = "db-or-config")]
+    config: Option<PathBuf>,
+    /// Db path
+    #[clap(long, group = "db-or-config")]
+    db: Option<PathBuf>,
 }
 
 impl MigrateCommand {
     pub fn run(self) -> Result<()> {
         let _guard = trace::init()?;
 
-        let content = std::fs::read(&self.config)
-            .with_context(|| format!("read config file from {}", self.config.to_string_lossy()))?;
-        let config: Config = toml::from_slice(&content).context("parse config file")?;
+        let store_config = if let Some(ref config_path) = self.config {
+            let content = std::fs::read(config_path).with_context(|| {
+                format!("read config file from {}", config_path.to_string_lossy())
+            })?;
+            let config: Config = toml::from_slice(&content).context("parse config file")?;
+            config.store
+        } else {
+            StoreConfig {
+                path: self.db.unwrap(),
+                ..Default::default()
+            }
+        };
 
         // Replace migration placeholders with real migrations, and run the migrations.
         #[allow(unused_mut)]
         let mut factory = init_migration_factory();
         #[cfg(feature = "smt-trie")]
         assert!(factory.insert(Box::new(smt_trie::SMTTrieMigration)));
-        open_or_create_db(&config.store, factory).context("open and migrate database")?;
+        open_or_create_db(&store_config, factory).context("open and migrate database")?;
 
         Ok(())
     }

--- a/crates/store/src/migrate.rs
+++ b/crates/store/src/migrate.rs
@@ -39,7 +39,7 @@ pub fn open_or_create_db(config: &StoreConfig, factory: MigrationFactory) -> Res
             }
             Ordering::Equal => Ok(Store::open(config, COLUMNS)?.into_inner()),
             Ordering::Less => {
-                log::info!("process fast migrations ...");
+                log::info!("process migrations ...");
 
                 let db = Store::open(config, COLUMNS)?.into_inner();
 

--- a/crates/store/src/smt/smt_store/smt_block.rs
+++ b/crates/store/src/smt/smt_store/smt_block.rs
@@ -25,8 +25,7 @@ pub struct SMTBlockStore<DB>(DB);
 
 impl<DB: KVStoreRead + ChainStore> SMTBlockStore<DB> {
     pub fn to_smt(self) -> anyhow::Result<SMT<Self>> {
-        let root = self.inner_store().get_block_smt_root()?;
-        Ok(SMT::new(root.into(), self))
+        Ok(SMT::new_with_store(self)?)
     }
 }
 
@@ -37,6 +36,10 @@ impl<DB> SMTBlockStore<DB> {
 
     pub fn inner_store(&self) -> &DB {
         &self.0
+    }
+
+    pub fn inner_store_mut(&mut self) -> &mut DB {
+        &mut self.0
     }
 }
 

--- a/crates/store/src/smt/smt_store/smt_reverted_block.rs
+++ b/crates/store/src/smt/smt_store/smt_reverted_block.rs
@@ -22,8 +22,7 @@ pub struct SMTRevertedBlockStore<DB>(DB);
 
 impl<DB: KVStore + ChainStore> SMTRevertedBlockStore<DB> {
     pub fn to_smt(self) -> anyhow::Result<SMT<Self>> {
-        let root = self.inner_store().get_reverted_block_smt_root()?;
-        Ok(SMT::new(root.into(), self))
+        Ok(SMT::new_with_store(self)?)
     }
 }
 


### PR DESCRIPTION
- Commit periodically so that we don't use too much memory
- Fix root check when the migration is interrupted and rerun
- Support `--db=db_path` in addition to `--config`
- Progress indication
