### PR TITLE
chore: refactor rpc server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,15 +1364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "erased-serde"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003000e712ad0f95857bd4d2ef8d1890069e06554101697d12050668b2f6f020"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,15 +1426,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "extensions"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258f70bd2b060d448403a66d420e81dcac3e5247a4928a887404a5e03715e2e0"
-dependencies = [
- "fxhash",
-]
 
 [[package]]
 name = "faster-hex"
@@ -1642,15 +1624,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1960,6 +1933,7 @@ dependencies = [
  "gw-common",
  "gw-types",
  "serde",
+ "serde_repr",
 ]
 
 [[package]]
@@ -2104,6 +2078,7 @@ version = "1.8.0-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "bytes",
  "ckb-crypto",
  "ckb-fixed-hash",
@@ -2130,14 +2105,14 @@ dependencies = [
  "gw-utils",
  "gw-version",
  "hyper",
- "jsonrpc-v2",
+ "jsonrpc-core",
+ "jsonrpc-utils",
  "log",
- "lru 0.7.8",
+ "lru",
  "once_cell",
  "pprof",
  "serde",
  "serde_json",
- "socket2",
  "tikv-jemalloc-ctl",
  "tikv-jemalloc-sys",
  "tokio",
@@ -2227,7 +2202,7 @@ dependencies = [
  "gw-types",
  "gw-utils",
  "hex",
- "jsonrpc-v2",
+ "jsonrpc-core",
  "lazy_static",
  "rand 0.8.5",
  "secp256k1 0.24.1",
@@ -2258,7 +2233,6 @@ dependencies = [
  "ckb-types",
  "clap 3.2.22",
  "csv",
- "dashmap",
  "faster-hex 0.5.0",
  "gw-common",
  "gw-config",
@@ -2272,7 +2246,6 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "log",
- "lru 0.8.1",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "reqwest",
@@ -2767,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-utils"
-version = "0.2.0-preview.3"
+version = "0.2.0-preview.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c253344ac8b67b5a8bceb24a1cd7a9b8e3d3494988d523320c2997131f80c6"
+checksum = "54dd93f34cfc767ad3680d69b8a3e62c9e92e3163f2d65a5bc83fa7f57b4db7b"
 dependencies = [
  "anyhow",
  "axum",
@@ -2787,30 +2760,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-utils-macros"
-version = "0.2.0-preview.3"
+version = "0.2.0-preview.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e576f36c2a03d4b38d0744a43ef384158121d43635c4ada1ec03eed0b25c006a"
+checksum = "1d4da84a65ec88023b2cebc0f08273bb4db8affcf187eec7c078b560e58a630d"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "jsonrpc-v2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5b309ff4f83be463974f916218283e4d9e04798ae856dd6f6968ce67654db6"
-dependencies = [
- "async-trait",
- "bytes",
- "erased-serde",
- "extensions",
- "futures",
- "hyper",
- "serde",
- "serde_json",
- "tower-service",
 ]
 
 [[package]]
@@ -2892,15 +2848,6 @@ name = "lru"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
-name = "lru"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
  "hashbrown",
 ]
@@ -4284,6 +4231,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/block-producer/src/test_mode_control.rs
+++ b/crates/block-producer/src/test_mode_control.rs
@@ -6,7 +6,7 @@ use gw_generator::types::vm::ChallengeContext;
 use gw_jsonrpc_types::test_mode::ChallengeType;
 use gw_jsonrpc_types::{godwoken::GlobalState as JsonGlobalState, test_mode::TestModePayload};
 use gw_rpc_client::rpc_client::RPCClient;
-use gw_rpc_server::registry::TestModeRPC;
+use gw_rpc_server::registry::TestModeRpc;
 use gw_smt::smt::{Blake2bHasher, SMTH256};
 use gw_smt::smt_h256_ext::SMTH256Ext;
 use gw_store::traits::chain_store::ChainStore;
@@ -304,8 +304,8 @@ impl TestModeControl {
 }
 
 #[async_trait]
-impl TestModeRPC for TestModeControl {
-    async fn get_global_state(&self) -> Result<JsonGlobalState> {
+impl TestModeRpc for TestModeControl {
+    async fn tests_get_global_state(&self) -> gw_rpc_server::registry::Result<JsonGlobalState> {
         let rollup_cell = {
             let opt = self.rpc_client.query_rollup_cell().await?;
             opt.ok_or_else(|| anyhow!("rollup cell not found"))?
@@ -317,7 +317,10 @@ impl TestModeRPC for TestModeControl {
         Ok(global_state.into())
     }
 
-    async fn produce_block(&self, payload: TestModePayload) -> Result<()> {
+    async fn tests_produce_block(
+        &self,
+        payload: TestModePayload,
+    ) -> gw_rpc_server::registry::Result<()> {
         log::info!("receive tests produce block payload: {:?}", payload);
 
         *self.payload.lock().await = Some(payload);

--- a/crates/jsonrpc-types/Cargo.toml
+++ b/crates/jsonrpc-types/Cargo.toml
@@ -14,3 +14,4 @@ gw-common = { path = "../../gwos/crates/common" }
 ckb-jsonrpc-types = "0.105.1"
 ckb-fixed-hash = "0.105.1"
 anyhow = "1.0"
+serde_repr = "0.1.10"

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -33,17 +33,18 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 futures = "0.3.13"
 hyper = { version = "0.14", features = ["server"] }
-jsonrpc-v2 = { version = "0.10.0", default-features = false, features = ["hyper-integration", "easy-errors"] }
 log = "0.4.14"
 serde_json = "1.0"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }
-bytes-v10 = { version = "1.0", package = "bytes" }
+bytes = "1.0"
 async-trait = "0.1"
 lru = "0.7"
-socket2 = { version = "0.4", features = ["all"] }
 pprof = { version = "0.6", features = ["flamegraph", "cpp", "protobuf"]}
 once_cell = "1.8"
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.4.2" }
 jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.4.2" }
 errno = "*"
 tracing = { version = "0.1", features = ["attributes"] }
+jsonrpc-utils = "0.2.0-preview.2"
+jsonrpc-core = "18.0.0"
+axum = "0.6.1"

--- a/crates/rpc-server/src/server.rs
+++ b/crates/rpc-server/src/server.rs
@@ -1,31 +1,35 @@
-// Taken and adapted from https://github.com/smol-rs/smol/blob/ad0839e1b3700dd33abb9bf23c1efd3c83b5bb2d/examples/hyper-server.rs
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use anyhow::{Error, Result};
-use gw_telemetry::trace::http::HeaderExtractor;
-use gw_telemetry::traits::{TelemetryContextNewSpan, TelemetryContextRemote};
+use anyhow::Result;
+use axum::{
+    extract::State,
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+    Extension, Router,
+};
+use bytes::Bytes;
+use gw_telemetry::{
+    trace::http::HeaderExtractor,
+    traits::{TelemetryContextNewSpan, TelemetryContextRemote},
+};
 use gw_utils::liveness::Liveness;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{body::HttpBody, server::conn::AddrIncoming, Body, Method, Request, Response, Server};
-use tokio::net::TcpListener;
-
-use jsonrpc_v2::{RequestKind, ResponseObjects, Router, Server as JsonrpcServer};
-use tokio::sync::{broadcast, mpsc};
+use hyper::server::conn::AddrIncoming;
+use jsonrpc_core::MetaIoHandler;
+use jsonrpc_utils::{axum_utils::handle_jsonrpc, pub_sub::Session};
+use tokio::{
+    net::TcpListener,
+    sync::{broadcast, mpsc},
+};
 use tracing::Instrument;
-
-use crate::registry::Registry;
 
 pub async fn start_jsonrpc_server(
     listen_addr: SocketAddr,
-    registry: Registry,
+    handler: Arc<MetaIoHandler<Option<Session>>>,
     liveness: Arc<Liveness>,
     _shutdown_send: mpsc::Sender<()>,
     mut sub_shutdown: broadcast::Receiver<()>,
 ) -> Result<()> {
-    let rpc_server = registry.build_rpc_server()?;
-
     let listener = TcpListener::bind(listen_addr).await?;
 
     // Format the full address.
@@ -34,25 +38,17 @@ pub async fn start_jsonrpc_server(
 
     let mut incoming = AddrIncoming::from_listener(listener)?;
     incoming.set_keepalive(Some(Duration::from_secs(10)));
+    incoming.set_nodelay(true);
 
-    // Start a hyper server.
-    let server = Server::builder(incoming)
-        .tcp_nodelay(true)
-        .serve(make_service_fn(move |_| {
-            let rpc_server = Arc::clone(&rpc_server);
-            let liveness = liveness.clone();
-            async move {
-                Ok::<_, Error>(service_fn(move |req| {
-                    let remote_ctx = gw_telemetry::extract_context(&HeaderExtractor(req.headers()));
-                    let otel_ctx = gw_telemetry::current_context().with_remote_context(&remote_ctx);
+    let app = Router::new()
+        .route("/livez", get(serve_liveness))
+        .with_state(liveness)
+        .route("/metrics", get(serve_metrics))
+        .route("/", post(handle_jsonrpc_with_tracing))
+        .route("/*path", post(handle_jsonrpc_with_tracing))
+        .with_state(handler);
 
-                    let serve_span = otel_ctx.new_span(tracing::info_span!("rpc.serve"));
-                    serve_span.record("path", req.uri().path());
-
-                    serve(Arc::clone(&rpc_server), liveness.clone(), req).instrument(serve_span)
-                }))
-            }
-        }));
+    let server = axum::Server::builder(incoming).serve(app.into_make_service());
     let graceful = server.with_graceful_shutdown(async {
         let _ = sub_shutdown.recv().await;
         log::info!("rpc server exited successfully");
@@ -62,91 +58,35 @@ pub async fn start_jsonrpc_server(
     Ok(())
 }
 
-// Serves a request and returns a response.
-async fn serve<R: Router + 'static>(
-    rpc: Arc<JsonrpcServer<R>>,
-    liveness: Arc<Liveness>,
-    req: Request<Body>,
-) -> Result<Response<Body>> {
-    if (req.method() == Method::GET || req.method() == Method::HEAD) && req.uri().path() == "/livez"
-    {
-        return hyper::Response::builder()
-            .status(if liveness.is_live() {
-                hyper::StatusCode::OK
-            } else {
-                hyper::StatusCode::SERVICE_UNAVAILABLE
-            })
-            .body(Body::empty())
-            .map_err(anyhow::Error::new);
-    }
-
-    if (req.method() == Method::GET || req.method() == Method::HEAD)
-        && req.uri().path() == "/metrics"
-    {
-        let mut buf = Vec::new();
-        // XXX: HEAD response won't have content-length header.
-        if req.method() != Method::HEAD {
-            gw_metrics::scrape(&mut buf)?;
-        }
-        return hyper::Response::builder()
-            .status(hyper::StatusCode::OK)
-            .header(
-                hyper::header::CONTENT_TYPE,
-                "application/openmetrics-text; version=1.0.0; charset=utf-8",
-            )
-            .body(buf.into())
-            .map_err(anyhow::Error::new);
-    }
-
-    if req.method() == Method::OPTIONS {
-        return hyper::Response::builder()
-            .status(hyper::StatusCode::NO_CONTENT)
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Methods", "*")
-            .header("Access-Control-Allow-Headers", "*")
-            .body(Body::empty())
-            .map_err(|e| anyhow::anyhow!("JSONRPC Preflight Request error: {:?}", e));
-    }
-
-    // Handler here is adapted from https://github.com/kardeiz/jsonrpc-v2/blob/1acf0b911c698413950d0b101ec4255cabd0d4ec/src/lib.rs#L1302
-    let mut buf = if let Some(content_length) = req
-        .headers()
-        .get(hyper::header::CONTENT_LENGTH)
-        .and_then(|x| x.to_str().ok())
-        .and_then(|x| x.parse().ok())
-    {
-        bytes_v10::BytesMut::with_capacity(content_length)
-    } else {
-        bytes_v10::BytesMut::default()
-    };
-
-    let mut body = req.into_body();
-
-    while let Some(chunk) = body.data().await {
-        buf.extend(chunk?);
-    }
-
-    match rpc
-        .handle(RequestKind::Bytes(buf.freeze()))
-        .instrument(tracing::info_span!("rpc.handle"))
+async fn handle_jsonrpc_with_tracing(
+    State(handler): State<Arc<MetaIoHandler<Option<Session>>>>,
+    headers: HeaderMap,
+    req_body: Bytes,
+) -> impl IntoResponse {
+    let remote_ctx = gw_telemetry::extract_context(&HeaderExtractor(&headers));
+    let otel_ctx = gw_telemetry::current_context().with_remote_context(&remote_ctx);
+    let serve_span = otel_ctx.new_span(tracing::info_span!("rpc.serve"));
+    handle_jsonrpc(Extension(handler), req_body)
+        .instrument(serve_span)
         .await
-    {
-        ResponseObjects::Empty => hyper::Response::builder()
-            .status(hyper::StatusCode::NO_CONTENT)
-            .body(hyper::Body::from(Vec::<u8>::new()))
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>),
-        json => serde_json::to_vec(&json)
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
-            .and_then(|json| {
-                hyper::Response::builder()
-                    .status(hyper::StatusCode::OK)
-                    .header("Content-Type", "application/json")
-                    .header("Access-Control-Allow-Origin", "*")
-                    .header("Access-Control-Allow-Methods", "*")
-                    .header("Access-Control-Allow-Headers", "*")
-                    .body(hyper::Body::from(json))
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
-            }),
+}
+
+async fn serve_liveness(l: State<Arc<Liveness>>) -> impl IntoResponse {
+    if l.is_live() {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
     }
-    .map_err(|e| anyhow::anyhow!("JSONRPC Request error: {:?}", e))
+}
+
+async fn serve_metrics() -> Result<impl IntoResponse, StatusCode> {
+    let mut buf = Vec::new();
+    gw_metrics::scrape(&mut buf).map_err(|_e| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok((
+        [(
+            header::CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )],
+        buf,
+    ))
 }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -49,4 +49,4 @@ tokio = "1"
 env_logger = "0.8"
 tempfile = "3"
 async-trait = "0.1"
-jsonrpc-v2 = { version = "0.10.0", default-features = false, features = ["easy-errors"] }
+jsonrpc-core = "18.0.0"

--- a/crates/tests/src/tests/rpc_server/execute_raw_l2transaction.rs
+++ b/crates/tests/src/tests/rpc_server/execute_raw_l2transaction.rs
@@ -521,7 +521,7 @@ async fn test_invalid_registry_address() {
         .unwrap_err();
 
     eprintln!("err {}", err);
-    assert!(err.to_string().contains("Invalid params"));
+    assert!(err.to_string().contains("no registry address"));
 
     // Invalid registry address
     let err = rpc_server

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -45,8 +45,6 @@ csv = "1.1.6"
 bech32 = "0.8.1"
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["tracing-log"] }
 parking_lot = "0.12"
-lru = "0.8"
-dashmap = "5.4"
 
 [dev-dependencies]
 ckb-chain-spec = "0.105.1"


### PR DESCRIPTION
This is followup of #919.

Refactor rpc server with jsonrpc-utils to simplify `Data` passing and optional parameter handling.