### PR TITLE
chore(ci): rm kicker ref

### DIFF
--- a/.github/workflows/godwoken-tests.yml
+++ b/.github/workflows/godwoken-tests.yml
@@ -21,5 +21,3 @@ jobs:
         MANUAL_BUILD_WEB3_INDEXER=true
         WEB3_GIT_URL="https://github.com/${{ github.repository }}"
         WEB3_GIT_CHECKOUT=${{ github.ref }}
-        GODWOKEN_KICKER_REPO=RetricSu/godwoken-kicker
-        GODWOKEN_KICKER_REF=fix-manual-build-web3


### PR DESCRIPTION
- https://github.com/godwokenrises/godwoken-kicker/pull/333

since the kicker pr is already merged, we can remove the kicker ref in ci.