### PR TITLE
chore: bump version to 1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+## [v1.7.4] - 2022-11-27
+
+- Fix community reported security issues. [#932](https://github.com/godwokenrises/godwoken/pull/932)  [#937](https://github.com/godwokenrises/godwoken/pull/937)
+
 ## [v1.7.3] - 2022-11-27
 
 - config: deny unknown fields in the config toml file [#862](https://github.com/godwokenrises/godwoken/pull/862)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "godwoken-bin"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "ckb-types",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "gw-benches"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "criterion",
  "gw-common",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "gw-block-producer"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "gw-chain"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "gw-challenge"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "gw-common"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "gw-config"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "ckb-fixed-hash",
  "gw-jsonrpc-types",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "gw-db"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "ckb-rocksdb",
  "gw-config",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "gw-dynamic-config"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "gw-generator"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1819,14 +1819,14 @@ dependencies = [
 
 [[package]]
 name = "gw-hash"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "blake2b-ref 0.3.1",
 ]
 
 [[package]]
 name = "gw-jsonrpc-types"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "gw-mem-pool"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "gw-p2p-network"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "gw-polyjuice-sender-recover"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "gw-common",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "gw-replay-chain"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "async-jsonrpc-client",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-client"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-server"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "gw-store"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tests"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "async-jsonrpc-client",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tools"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "bech32 0.6.0",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "gw-traits"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "gw-common",
  "gw-db",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tx-filter"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "gw-common",
  "gw-config",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "gw-types"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "cfg-if 0.1.10",
  "ckb-fixed-hash",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "gw-utils"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "ckb-crypto",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "gw-version"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
 ]

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-benches"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 description = "Godwoken benchmarks."

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-block-producer"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-chain"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/challenge/Cargo.toml
+++ b/crates/challenge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-challenge"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-common"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-config"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-db"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/dynamic-config/Cargo.toml
+++ b/crates/dynamic-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-dynamic-config"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-generator"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/godwoken-bin/Cargo.toml
+++ b/crates/godwoken-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godwoken-bin"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-hash"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/jsonrpc-types/Cargo.toml
+++ b/crates/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-jsonrpc-types"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-mem-pool"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/p2p-network/Cargo.toml
+++ b/crates/p2p-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-p2p-network"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/polyjuice-sender-recover/Cargo.toml
+++ b/crates/polyjuice-sender-recover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-polyjuice-sender-recover"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/replay-chain/Cargo.toml
+++ b/crates/replay-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-replay-chain"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-client"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-server"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2018"
 

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-store"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tests"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2018"
 

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tools"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/traits/Cargo.toml
+++ b/crates/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-traits"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/tx-filter/Cargo.toml
+++ b/crates/tx-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tx-filter"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-types"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-utils"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-version"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Nervos Network"]
 edition = "2018"
 


### PR DESCRIPTION

## [v1.7.4] - 2022-11-27

- Fix community reported security issues. [#932](https://github.com/godwokenrises/godwoken/pull/932)  [#937](https://github.com/godwokenrises/godwoken/pull/937)