### PR TITLE
chore: bump version to v1.12.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+## [v1.12.0-rc2] - 2023-02-21
+
+* config: add new fork for testnet at block#1916000 [#993](https://github.com/godwokenrises/godwoken/pull/993)
+* fix(withdrawal_unlocker): remove dry_run_transaction and fix error display [#992](https://github.com/godwokenrises/godwoken/pull/992)
+
 ## [v1.12.0-rc1] - 2023-02-08
 
 The `web3` and `web3-indexer` components have been added to the monorepo since this release, and we bumped the version from `v1.8.x` to `v1.12.x` to unify the version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "c-uint256-tests"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "cc",
  "cty",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "godwoken-bin"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-types",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "gw-benches"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "gw-block-producer"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "gw-builtin-binaries"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "gw-chain"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "gw-challenge"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "gw-common"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "gw-config"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "ckb-fixed-hash",
  "gw-builtin-binaries",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "gw-generator"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1912,14 +1912,14 @@ dependencies = [
 
 [[package]]
 name = "gw-hash"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "blake2b-ref 0.3.1",
 ]
 
 [[package]]
 name = "gw-jsonrpc-types"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "gw-mem-pool"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "gw-metrics"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "arc-swap",
  "gw-common",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "gw-p2p-network"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "gw-polyjuice-sender-recover"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "gw-common",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "gw-replay-chain"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-client"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-server"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "gw-smt"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "gw-store"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "gw-telemetry"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "chrono",
  "faster-hex 0.6.1",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tests"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tools"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "gw-traits"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "gw-common",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tx-filter"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "gw-common",
  "gw-config",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "gw-types"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "cfg-if 1.0.0",
  "ckb-fixed-hash",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "gw-utils"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-crypto",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "gw-version"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
 ]
@@ -2803,12 +2803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,7 +3090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3231,9 +3224,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.0+1.1.1t"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]
@@ -3754,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -3770,7 +3763,6 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
- "unarray",
 ]
 
 [[package]]
@@ -5188,12 +5180,6 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-benches"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 description = "Godwoken benchmarks."

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-block-producer"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/builtin-binaries/Cargo.toml
+++ b/crates/builtin-binaries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-builtin-binaries"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 edition = "2021"
 authors = ["Godwoken"]
 license = "MIT"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-chain"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/challenge/Cargo.toml
+++ b/crates/challenge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-challenge"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-config"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-generator"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/godwoken-bin/Cargo.toml
+++ b/crates/godwoken-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godwoken-bin"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/jsonrpc-types/Cargo.toml
+++ b/crates/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-jsonrpc-types"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-mem-pool"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-metrics"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/p2p-network/Cargo.toml
+++ b/crates/p2p-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-p2p-network"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/polyjuice-sender-recover/Cargo.toml
+++ b/crates/polyjuice-sender-recover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-polyjuice-sender-recover"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/replay-chain/Cargo.toml
+++ b/crates/replay-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-replay-chain"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-client"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-server"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2021"
 

--- a/crates/smt/Cargo.toml
+++ b/crates/smt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-smt"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-store"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-telemetry"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tests"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2021"
 

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tools"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/traits/Cargo.toml
+++ b/crates/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-traits"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/tx-filter/Cargo.toml
+++ b/crates/tx-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tx-filter"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-utils"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-version"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/gwos/crates/c-uint256-tests/Cargo.toml
+++ b/gwos/crates/c-uint256-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-uint256-tests"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/gwos/crates/common/Cargo.toml
+++ b/gwos/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-common"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/gwos/crates/hash/Cargo.toml
+++ b/gwos/crates/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-hash"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/gwos/crates/types/Cargo.toml
+++ b/gwos/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-types"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/web3/Cargo.lock
+++ b/web3/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "gw-common"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -1322,14 +1322,14 @@ dependencies = [
 
 [[package]]
 name = "gw-hash"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "blake2b-ref 0.3.1",
 ]
 
 [[package]]
 name = "gw-jsonrpc-types"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "gw-types"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "cfg-if 1.0.0",
  "ckb-fixed-hash",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "gw-web3-indexer"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "ckb-hash",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "gw-web3-rpc-client"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 dependencies = [
  "anyhow",
  "async-jsonrpc-client",

--- a/web3/crates/indexer/Cargo.toml
+++ b/web3/crates/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-web3-indexer"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/web3/crates/rpc-client/Cargo.toml
+++ b/web3/crates/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-web3-rpc-client"
-version = "1.12.0-rc1"
+version = "1.12.0-rc2"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/web3/package.json
+++ b/web3/package.json
@@ -30,6 +30,6 @@
     "eslint": "^8.5.0",
     "prettier": "^2.2.1"
   },
-  "version": "1.12.0-rc1",
+  "version": "1.12.0-rc2",
   "author": "hupeng <bitrocks.hu@gmail.com>"
 }

--- a/web3/packages/api-server/package.json
+++ b/web3/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@godwoken-web3/api-server",
-  "version": "1.12.0-rc1",
+  "version": "1.12.0-rc2",
   "private": true,
   "scripts": {
     "start": "concurrently \"tsc -w\" \"nodemon ./bin/cluster\"",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@ckb-lumos/base": "0.18.0-rc6",
     "@ckb-lumos/toolkit": "0.18.0-rc6",
-    "@godwoken-web3/godwoken": "1.12.0-rc1",
+    "@godwoken-web3/godwoken": "1.12.0-rc2",
     "@ethersproject/bignumber": "^5.7.0",
     "@newrelic/native-metrics": "^7.0.1",
     "@opentelemetry/api": "^1.3.0",

--- a/web3/packages/godwoken/package.json
+++ b/web3/packages/godwoken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@godwoken-web3/godwoken",
-  "version": "1.12.0-rc1",
+  "version": "1.12.0-rc2",
   "private": true,
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION

## [v1.12.0-rc2] - 2023-02-21

* config: add new fork for testnet at block#1916000 [#993](https://github.com/godwokenrises/godwoken/pull/993)
* fix(withdrawal_unlocker): remove dry_run_transaction and fix error display [#992](https://github.com/godwokenrises/godwoken/pull/992)