### PR TITLE
feat(CI): print fuzz test cov report

### DIFF
--- a/.github/workflows/gwos-evm-fuzz.yml
+++ b/.github/workflows/gwos-evm-fuzz.yml
@@ -74,10 +74,15 @@ jobs:
         mkdir -p corpus
         ls corpus-cache
         make build/fuzzer && \
-        ./build/fuzzer corpus corpus-cache \
+        LLVM_PROFILE_FILE="build/fuzzer.profraw" ./build/fuzzer corpus corpus-cache \
           -max_total_time=$MAX_FUZZ_TIME -timeout=120 \
           -max_len=25000 -rss_limit_mb=0
       # Max data buffer size: 24KB < 25000 bytes
+    - name: Cov report
+      working-directory: gwos-evm/polyjuice-tests/fuzz
+      run: |
+        llvm-profdata merge -sparse build/fuzzer.profraw -o build/fuzzer.profdata
+        llvm-cov report ./build/fuzzer -instr-profile=build/fuzzer.profdata
         
     - name: merge corpus
       working-directory: gwos-evm/polyjuice-tests/fuzz


### PR DESCRIPTION
The coverage report looks like this: 
```txt
Run llvm-profdata merge -sparse build/fuzzer.profraw -o build/fuzzer.profdata
Filename                                                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
gwos-evm/c/contracts.h                                            333               333     0.00%          24                24     0.00%         748               748     0.00%
gwos-evm/c/generator/secp256k1_helper.h                            14                14     0.00%           3                 3     0.00%          34                34     0.00%
gwos-evm/c/other_contracts.h                                       43                43     0.00%           2                 2     0.00%          44                44     0.00%
gwos-evm/c/polyjuice.h                                           1182               702    40.61%          34                15    55.88%        1512               793    47.55%
gwos-evm/c/polyjuice_utils.h                                      156                77    50.64%          22                10    54.55%         227                87    61.67%
gwos-evm/c/sudt_contracts.h                                       136               136     0.00%           6                 6     0.00%         148               148     0.00%
gwos-evm/deps/ckb-c-stdlib/blake2b.h                              428                55    87.15%          18                 4    77.78%         227                72    68.28%
gwos-evm/deps/ckb-c-stdlib/molecule/molecule_builder.h             86                60    30.23%          20                11    45.00%         220               145    34.09%
gwos-evm/deps/ckb-c-stdlib/molecule/molecule_reader.h              67                28    58.21%          14                 5    64.29%         112                36    67.86%
gwos-evm/deps/ethash/include/ethash/keccak.hpp                      4                 3    25.00%           4                 3    25.00%          12                 9    25.00%
gwos-evm/deps/evmone/evmc/include/evmc/evmc.hpp                    80                79     1.25%          80                79     1.25%         275               274     0.36%
gwos-evm/deps/evmone/evmc/include/evmc/helpers.h                   12                12     0.00%          12                12     0.00%          60                60     0.00%
gwos-evm/deps/intx/include/intx/int128.hpp                        100               100     0.00%          71                71     0.00%         483               483     0.00%
gwos-evm/deps/intx/include/intx/intx.hpp                          106               106     0.00%          44                44     0.00%         360               360     0.00%
gwos-evm/polyjuice-tests/fuzz/build/blockchain.h                 1107              1046     5.51%          24                22     8.33%        1346              1258     6.54%
gwos-evm/polyjuice-tests/fuzz/build/godwoken.h                   3189              2972     6.80%          62                58     6.45%        4034              3788     6.10%
gwos-evm/polyjuice-tests/fuzz/ckb_syscalls.h                       43                18    58.14%           1                 0   100.00%          46                18    60.87%
gwos-evm/polyjuice-tests/fuzz/polyjuice_fuzzer.cc                  45                 3    93.33%           4                 1    75.00%         137                24    82.48%
gwos/c/common.h                                                   155                45    70.97%          17                 1    94.12%         263                81    69.20%
gwos/c/deps/sparse-merkle-tree/c/ckb_smt.h                        296               253    14.53%          22                20     9.09%         608               472    22.37%
gwos/c/generator_utils.h                                          281               136    51.60%          28                 9    67.86%         451               189    58.09%
gwos/c/gw_eth_addr_reg.h                                          112                56    50.00%           2                 0   100.00%         194                72    62.89%
gwos/c/gw_registry_addr.h                                          21                13    38.10%           3                 1    66.67%          31                16    48.39%
gwos/c/sudt_utils.h                                                86                58    32.56%          10                 5    50.00%         164               120    26.83%
gwos/c/uint256.h                                                   32                23    28.12%           6                 5    16.67%          57                46    19.30%

Files which contain no functions:
gwos-evm/c/polyjuice_errors.h                                       0                 0         -           0                 0         -           0                 0         -
gwos-evm/c/polyjuice_globals.h                                      0                 0         -           0                 0         -           0                 0         -
gwos-evm/polyjuice-tests/fuzz/build/secp256k1_data_info.h           0                 0         -           0                 0         -           0                 0         -
gwos/c/gw_def.h                                                     0                 0         -           0                 0         -           0                 0         -
gwos/c/gw_errors.h                                                  0                 0         -           0                 0         -           0                 0         -
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                            8114              6371    21.48%         533               411    22.89%       11793              9377    20.49%
```