### PR TITLE
hotfix: Remove `extra` from RPC error in response

### DIFF
--- a/web3/packages/api-server/src/methods/index.ts
+++ b/web3/packages/api-server/src/methods/index.ts
@@ -57,9 +57,9 @@ function getMethods(argsList: ModConstructorArgs = {}) {
                 error.data = err.data;
               }
 
-              if (err.extra) {
-                error.extra = err.extra;
-              }
+              // if (err.extra) {
+              //   error.extra = err.extra;
+              // }
 
               cb(error);
               // NOTE: Our error responses are not automatically collected by NewRelic because we use Jayson instead of


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/1297478/222494237-53e1fb45-1ddb-43ea-93dc-9829e67a6e62.png)


## After
![image](https://user-images.githubusercontent.com/1297478/222493664-46a4b60f-0b3e-4fc4-9886-6d5753f0a102.png)
