### PR TITLE
fix(web3): Topic includes null

### DIFF
--- a/web3/packages/api-server/src/base/filter.ts
+++ b/web3/packages/api-server/src/base/filter.ts
@@ -14,7 +14,7 @@ export enum FilterFlag {
   pendingTransaction = 2,
 }
 
-export type FilterTopic = null | HexString | HexString[];
+export type FilterTopic = null | HexString | (HexString | null)[];
 
 export interface FilterParams {
   fromBlock: bigint;

--- a/web3/packages/api-server/src/db/helpers.ts
+++ b/web3/packages/api-server/src/db/helpers.ts
@@ -282,10 +282,14 @@ export function buildQueryLogTopics(
       queryBuilder.where(`topics[${pgTopicIndex}]`, "=", hexToBuffer(topic));
     } else {
       const pgTopicIndex = index + 1;
-      queryBuilder.whereIn(
-        `topics[${pgTopicIndex}]`,
-        topic.map((subtopic) => hexToBuffer(subtopic))
-      );
+
+      // When topic includes null, this topic can be anything
+      if (!topic.includes(null)) {
+        queryBuilder.whereIn(
+          `topics[${pgTopicIndex}]`,
+          topic.map((subtopic) => hexToBuffer(subtopic as string))
+        );
+      }
     }
   });
 }


### PR DESCRIPTION
Related issue:
- The last item of https://github.com/godwokenrises/godwoken/issues/1025

```json
{
    "id": 2,
    "jsonrpc": "2.0",
    "method": "eth_newFilter",
    "params": [
       {
            "topics": [
                [
                    "0x0000000000000000000000000000000000000000000000000000000000000004",
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                ],
                [
                    null,
                    null,
                    "0x0000000000000000000000000000000000000000000000000000000000000003"
                ]
            ]
       }
    ]
}
```

`topics[1]` is an array includes `null` value, [in hardhat node, the `topics[1]` can match anything](https://github.com/NomicFoundation/hardhat/blob/8da0be187452cd00f47693773094dd6fe376f6e5/packages/hardhat-core/src/internal/hardhat-network/provider/filter.ts#L128), equals to `null`, and `infura` will reject this request with error

```json
{
    "jsonrpc": "2.0",
    "id": 2,
    "error": {
        "code": -32602,
        "message": "could not unmarshal parameter 0"
    }
}
```

Should we reject array includes null in `eth_newFilter` request such as `infura` or allow it such as `hardhat node` ? @Flouse 