### PR TITLE
config: add new fork for testnet at block#2430000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,9 +3228,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.25.0+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
 dependencies = [
  "cc",
 ]

--- a/crates/builtin-binaries/build.rs
+++ b/crates/builtin-binaries/build.rs
@@ -34,13 +34,18 @@ fn main() {
 
 #[cfg(not(feature = "no-builtin"))]
 fn main() {
-    // Copy polyjuice v1.5.3 files
+    // Copy polyjuice v1.5.5 files
     {
-        let path = Path::new(BINARIES_DIR).join("godwoken-polyjuice-v1.5.3/generator");
-        if !path.exists() {
-            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let target_path = Path::new(BINARIES_DIR).join("godwoken-polyjuice-v1.5.5/generator");
+        if !target_path.exists() {
+            let dir = target_path.parent().unwrap();
+            std::fs::create_dir_all(dir).unwrap();
+
             let src = Path::new(GWOS_EVM_DIR).join("generator");
-            std::fs::copy(src, path).unwrap();
+            std::fs::copy(src, dir.join("generator")).unwrap();
+
+            let src = Path::new(GWOS_EVM_DIR).join("generator.debug");
+            std::fs::copy(src, dir.join("generator.debug")).unwrap();
         }
     }
 
@@ -94,6 +99,14 @@ fn main() {
         (
             "godwoken-polyjuice-v1.5.3/generator",
             h256!("0x342bac1659df8b1f12201ff952efc298b17d8875bda911ca059629486338604c"),
+        ),
+        (
+            "godwoken-polyjuice-v1.5.5/generator",
+            h256!("0xe4d2fed018645548204215413c13abd24ad94398ee28822c4f8f503268fefddb"),
+        ),
+        (
+            "godwoken-polyjuice-v1.5.5/generator.debug",
+            h256!("0x25e8f3889c890805bc4eaca0c564fc64c1ced7b85d4592147d679de2cdf56fd4"),
         ),
     ] {
         let path = Path::new(BINARIES_DIR).join(path);

--- a/crates/config/src/consensus/builtins/testnet.toml
+++ b/crates/config/src/consensus/builtins/testnet.toml
@@ -79,6 +79,15 @@ generator_checksum = '0x342bac1659df8b1f12201ff952efc298b17d8875bda911ca05962948
 validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
 backend_type = 'Polyjuice'
 
+[[backend_forks]]
+fork_height = 2430000
+# https://github.com/godwokenrises/godwoken/tree/57b9fc469f04fa7d5dadd6455a3217ffdde718da/gwos-evm
+[[backend_forks.backends]]
+generator = { bundled = 'builtin/godwoken-polyjuice-v1.5.5/generator' }
+generator_checksum = '0xe4d2fed018645548204215413c13abd24ad94398ee28822c4f8f503268fefddb'
+validator_script_type_hash = '0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736'
+backend_type = 'Polyjuice'
+
 
 [genesis]
 timestamp = 1651979802446

--- a/gwos-evm/polyjuice-tests/Cargo.toml
+++ b/gwos-evm/polyjuice-tests/Cargo.toml
@@ -19,6 +19,9 @@ gw-traits    = { path = "../../crates/traits/" }
 gw-generator = { path = "../../crates/generator/" }
 gw-builtin-binaries = { path = "../../crates/builtin-binaries" }
 
+jsonrpc-utils = { version = "=0.2.0-preview.4", features = ["client"] }
+jsonrpc-utils-macros = "=0.2.0-preview.4"
+
 ####
 #Sync patch version with godwoken core.
 tracing = { version = "0.1.36", features = ["attributes"] } 

--- a/gwos-evm/polyjuice-tests/fuzz/gw-syscall-simulator/Cargo.toml
+++ b/gwos-evm/polyjuice-tests/fuzz/gw-syscall-simulator/Cargo.toml
@@ -17,6 +17,8 @@ gw-utils     = { path = "../../../../crates/utils/" }
 gw-config    = { path = "../../../../crates/config/", features = ["no-builtin"] }
 gw-traits    = { path = "../../../../crates/traits/" }
 
+jsonrpc-utils = { version = "=0.2.0-preview.4", features = ["client"] }
+jsonrpc-utils-macros = "=0.2.0-preview.4"
 ckb-vm = { version = "=0.22.0", default-features = false }
 ckb-vm-aot = { version = "=0.22.0" }
 once_cell = "1.14.0"


### PR DESCRIPTION
## Changes
- https://github.com/godwokenrises/godwoken-builtin-binaries/pull/3

- [config: add new fork for testnet at block#2430000](https://github.com/godwokenrises/godwoken/commit/dc26f79994edf5e626c45fbfb30288393d70aa8d)  -> around 2023-04-13
  new backend fork: godwoken-polyjuice-v1.5.5

- cherry-pick 2 commits from develop branch
