### PR TITLE
chore(CI): Remove setup-rust action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,11 +47,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-cargo-
         
-    # https://github.com/ATiltedTree/setup-rust
-    - uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: nightly
-        components: rustfmt clippy
+    - name: Install Rust components
+      run: rustup component add rustfmt && rustup component add clippy
+
     - name: Install moleculec 0.7.2
       run: |
         test "$(moleculec --version)" = "Moleculec 0.7.2" \
@@ -177,11 +175,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-${{ inputs.runner_type || 'ubuntu-20.04' }}-cargo-
     
-    # https://github.com/ATiltedTree/setup-rust
-    - uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: nightly
-        components: rustfmt clippy
+    - name: Install Rust components
+      run: rustup component add rustfmt && rustup component add clippy
+
     - name: Install moleculec 0.7.2
       run: |
         test "$(moleculec --version)" = "Moleculec 0.7.2" \

--- a/.github/workflows/web3-unit-tests.yml
+++ b/.github/workflows/web3-unit-tests.yml
@@ -31,11 +31,9 @@ jobs:
 
     steps:
 
-    # https://github.com/ATiltedTree/setup-rust
-    - uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: nightly
-        components: rustfmt clippy
+    - name: Install Rust components
+      run: rustup component add rustfmt && rustup component add clippy
+
     - name: Install moleculec 0.7.2
       run: |
         test "$(moleculec --version)" = "Moleculec 0.7.2" \


### PR DESCRIPTION
For remove following warnings:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: ATiltedTree/setup-rust@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```