### PR TITLE
config: add new fork for mainnet at block#556000

### DIFF
--- a/crates/config/src/consensus/builtins/mainnet.toml
+++ b/crates/config/src/consensus/builtins/mainnet.toml
@@ -150,7 +150,7 @@ backend_type = 'Polyjuice'
 
 [[backend_forks]]
 fork_height = 556000
-https://github.com/godwokenrises/godwoken/tree/57b9fc469f04fa7d5dadd6455a3217ffdde718da/gwos-evm
+# https://github.com/godwokenrises/godwoken/tree/57b9fc469f04fa7d5dadd6455a3217ffdde718da/gwos-evm
 [[backend_forks.backends]]
 generator = { bundled = 'builtin/godwoken-polyjuice-v1.5.5/generator' }
 generator_checksum = '0xe4d2fed018645548204215413c13abd24ad94398ee28822c4f8f503268fefddb'

--- a/crates/config/src/consensus/builtins/mainnet.toml
+++ b/crates/config/src/consensus/builtins/mainnet.toml
@@ -148,6 +148,15 @@ generator_checksum = '0x342bac1659df8b1f12201ff952efc298b17d8875bda911ca05962948
 validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
 backend_type = 'Polyjuice'
 
+[[backend_forks]]
+fork_height = 556000
+https://github.com/godwokenrises/godwoken/tree/57b9fc469f04fa7d5dadd6455a3217ffdde718da/gwos-evm
+[[backend_forks.backends]]
+generator = { bundled = 'builtin/godwoken-polyjuice-v1.5.5/generator' }
+generator_checksum = '0xe4d2fed018645548204215413c13abd24ad94398ee28822c4f8f503268fefddb'
+validator_script_type_hash = '0x83d5d8841518e8db686909d27c821398491f475ed5f1cd392c36e83f4252c4ac'
+backend_type = 'Polyjuice'
+
 
 [genesis]
 timestamp = 1655830128000


### PR DESCRIPTION
New backend fork godwoken-polyjuice-v1.5.5 will be activated around 2023-05-05 (mainnet_v1 block#556000)

> mainnet_v1 blocks everyday: 1920 blocks

## References
- https://github.com/godwokenrises/godwoken/pull/1040
- https://v1.gwscan.com
