### PR TITLE
chore: upgrade ckb crates to 0.106

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-chain-spec"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0f0606bce9ccbde520465890486807a0ac2fcba3e60d37df54a2d0be071725"
+checksum = "fccca15bb20b37f213bda1ff673fc25af8ee2e97f506ffc70de296d068034d63"
 dependencies = [
  "ckb-constant",
  "ckb-crypto",
@@ -605,24 +605,24 @@ dependencies = [
 
 [[package]]
 name = "ckb-channel"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0da1f4e474de48b05e30ad603da4da3b410344b619c7cf35d444e406c0bb6e"
+checksum = "5e718dfa7098b0bcce95c7fa573d96aad2f4c3ac886b6f35053f40c5e4894156"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "ckb-constant"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6df9fd997d58f1e5f12a683a00d98158a82c07a422e6f81ff390607f19c493"
+checksum = "5ddc317ee0521b2a176f7197bd1922ee5e757b1c454150cf392baec49c8f31f4"
 
 [[package]]
 name = "ckb-crypto"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1650275e0f5a59e8ebbd747d835e10b9179d8ab4941b96100d5b7e48fada695e"
+checksum = "105a3a011f3d29070d137ea1336d8761951281b39cb90db07b5b752c741b1d0f"
 dependencies = [
  "ckb-fixed-hash",
  "faster-hex 0.6.1",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao-utils"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b294c46e06c315900c9eb4e5719311902d68fcad6c802f43ebc658902715b5ea"
+checksum = "970872ecd2bfe4072051b020b78061c97dfc07e2e8797e73e7b17c238891b91e"
 dependencies = [
  "byteorder",
  "ckb-error",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-error"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51748ac5e08dce6c685cf4b43e27dcbcfc98e21442c4001c9f06509a04a400ed"
+checksum = "fd512b729186e6fa991b588647646e230db7728f71ba16087af21bded12ceb09"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d665013dbb8ff2df8e67c4add67db703ae3b642679f1a2962f76399703eee1"
+checksum = "8eba8f7006a63ad0945412012c89af6ad09d9b2b02962a869d0158a298fa8eca"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd92b9d691bbfd11a900ee17ad1010a553ae0b5d3a120e0c8094afcd30f9b15e"
+checksum = "44b15b464d37d8deeb66046011b3e01e642103b27d4752db4e74740ded732c73"
 dependencies = [
  "faster-hex 0.6.1",
  "serde",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24e42b82da4d891ac8b5b19de2807cae360c5377138a7cde377b60edc6ec953"
+checksum = "61e86358f6eb595a0e6a2a5ef96d54d4c56e0a4bf822934d7b1fe9904b7208e4"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b64eff869839aff45741515540e81a0447926d79262a439b5e9d0a5c98ac95"
+checksum = "038ad6840c4a89f4cd76b50621c4e6d82ca5f0d09fba707b1025016218d4a2d8"
 dependencies = [
  "blake2b-ref 0.2.1",
  "blake2b-rs",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82268ddea09f95324496d6def1b37d6bdc3a4841fecc185388e7a2bb6451687f"
+checksum = "eca123e0b725e487cd49f202097c38c73c2a4d7e1c80d89549c492f058e84f29"
 dependencies = [
  "ckb-types",
  "faster-hex 0.6.1",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-logger"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a312280df7ba55dc99cf8584ac4d3c9e3b85297a896202c76a21dfd43ffb0ea"
+checksum = "fe1d406dd67f086bb64d17af697a4d42c3d7d85e2a677bfd8c04aea4b48510cf"
 dependencies = [
  "log",
 ]
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-mock-tx-types"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73574949df81ecd84b5366992f1ab61d2a4e8dc905dabb58468b785fa90b22d"
+checksum = "67ac724a6c26076ea122129ed8428730e212a2166cbbe149e1b3112a88798401"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-traits",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11e010c034a98b734074a79655c738c40501e9113426173132856a35c6e71c6"
+checksum = "94f6c146d51b1b7f65511e6f16ef21b0d852aececc4ae87f78c3099c03e246a9"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -753,18 +753,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e48f0306a3fe072711e0342b71335898ac6d0a82b897ca3ae13e43770ce0e0"
+checksum = "507187824418c845b519c64521b34578570b5851d170ff0101bc477ed0cdee2b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656db5615c791b8d7b31a38e024f98fb497be5e2cb120b38be48eb4d9d1d0f6d"
+checksum = "17825cb1ec37c5ad2f2c6690aa4cbfeb9a6d2af02463a66b1fa013e4f9e762aa"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-pow"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9708f81c8c9058bf3dab834be2be68d14dcd9fa41bd793727428a2cf6b1ddf59"
+checksum = "a3ea66fa0ac3dc84cada2d2696903afb28dbea1211d05f04b0ed444874ee8623"
 dependencies = [
  "byteorder",
  "ckb-hash",
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rational"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444926bc5a9ad789b2b98e75f90330bcfe741bab517ca45d8f084449fe35efd8"
+checksum = "fa5edf5377138c9457015a450b1a263996d100a5b6e21566157f410e1a5b95b3"
 dependencies = [
  "numext-fixed-uint",
  "serde",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-resource"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95464c0e69e20553f34c132789f6275a1e06468362226cf5a986719f6da96161"
+checksum = "06cd89bd6c5bafeadc363cf0a479516355f16bd5758af4d7dace464d8756892b"
 dependencies = [
  "ckb-system-scripts",
  "ckb-types",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-script"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f06c44207d8e90b86f2b29f2341188a6d1a3520f6b657eb2ba662b3a772abfc"
+checksum = "b9da7feb35e8997b29f1c987d441a89fb13ba8e429b64e09e1d35dff7b9290a8"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -843,18 +843,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-traits"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d54a03a03af9857264cc252060f4274e11858956a4985793b04047117828329"
+checksum = "4697c0acbf62b2994f1c26868cfc005e0ec4fc506849acfb9dc52f10af2a6df2"
 dependencies = [
  "ckb-types",
 ]
 
 [[package]]
 name = "ckb-types"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06812497491fa58cea1c93dda2de074e0c5d51cf7d70d93dd50c862c661494c"
+checksum = "8f9f918d7f04fed733c528ec98ba8bdee31a885bd082e6ff263ca21d58e01378"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-util"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0f4f5647372cc1c2fdc7122e062984754e062edbcc654436a1af7f5b1382a0"
+checksum = "d60a55b4ad918828bdbf700f1b9949d74768b710c927e19f15282a2320a7ec71"
 dependencies = [
  "linked-hash-map",
  "once_cell",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1126bf0240d100234bc06efa7020f0d50ca35fe90e5ac7cac1b7721e1bacb7"
+checksum = "d8e8f7ba49aa55d08f8a575b69bc535cad65fdba75fea90856cee1fd3822a7a9"
 dependencies = [
  "byteorder",
  "bytes",
@@ -921,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14739bf59648c169de9257ec7dd6aba1aeb6a41725d636005f1c91853df58fcc"
+checksum = "5445b62604e7ab2bf5abb37bf6cca7ac26b2e4a76fddb27ceb61850f24864d58"
 
 [[package]]
 name = "clang-sys"

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -21,10 +21,10 @@ gw-utils = { path = "../utils" }
 gw-polyjuice-sender-recover = { path = "../polyjuice-sender-recover" }
 gw-telemetry = { path = "../telemetry" }
 gw-metrics = { path = "../metrics" }
-ckb-crypto = "0.105.1"
-ckb-fixed-hash = "0.105.1"
-ckb-types = "0.105.1"
-ckb-chain-spec = "0.105.1"
+ckb-crypto = "0.106"
+ckb-fixed-hash = "0.106"
+ckb-types = "0.106"
+ckb-chain-spec = "0.106"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 async-channel = "1.4.2"

--- a/crates/builtin-binaries/Cargo.toml
+++ b/crates/builtin-binaries/Cargo.toml
@@ -23,6 +23,6 @@ sha2 = "0.10.6"
 
 [build-dependencies]
 includedir_codegen = "0.6.0"
-ckb-fixed-hash = "0.105.1"
+ckb-fixed-hash = "0.106"
 anyhow = "1.0"
 sha2 = "0.10.6"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -20,7 +20,7 @@ gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-utils = { path = "../utils" }
 gw-telemetry = { path = "../telemetry" }
 gw-metrics = { path = "../metrics" }
-ckb-fixed-hash = "0.105.1"
+ckb-fixed-hash = "0.106"
 anyhow = "1.0"
 thiserror = "1.0"
 lazy_static = "1.4"

--- a/crates/challenge/Cargo.toml
+++ b/crates/challenge/Cargo.toml
@@ -17,11 +17,11 @@ gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-rpc-client = { path = "../rpc-client" }
 gw-traits = { path = "../traits" }
 gw-utils = { path = "../utils" }
-ckb-fixed-hash = "0.105.1"
-ckb-types = "0.105.1"
-ckb-script = "0.105.1"
-ckb-traits = "0.105.1"
-ckb-chain-spec = "0.105.1"
+ckb-fixed-hash = "0.106"
+ckb-types = "0.106"
+ckb-script = "0.106"
+ckb-traits = "0.106"
+ckb-chain-spec = "0.106"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -13,7 +13,7 @@ no-builtin = ["gw-builtin-binaries/no-builtin"]
 [dependencies]
 gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-builtin-binaries = { path = "../builtin-binaries" }
-ckb-fixed-hash = "0.105.1"
+ckb-fixed-hash = "0.106"
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4"
 lazy_static = "1.4"

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -20,11 +20,11 @@ gw-store = { path = "../store" }
 gw-traits = { path = "../traits" }
 gw-utils = { path = "../utils"}
 gw-jsonrpc-types = { path = "../jsonrpc-types" }
-ckb-types = "0.105.1"
+ckb-types = "0.106"
 anyhow = "1.0"
 blake2b-rs = "0.2"
-ckb-vm = { version = "=0.22.0", default-features = false }
-ckb-vm-aot = { version = "=0.22.0", optional = true }
+ckb-vm = { version = "=0.22.1", default-features = false }
+ckb-vm-aot = { version = "=0.22", optional = true }
 thiserror = "1.0"
 lazy_static = "1.4"
 rlp = "0.5.0"

--- a/crates/godwoken-bin/Cargo.toml
+++ b/crates/godwoken-bin/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-ckb-types = "0.105.1"
+ckb-types = "0.106"
 clap = { version = "3", features = ["derive"] }
 indicatif = "0.16"
 gw-block-producer = { path = "../block-producer" }

--- a/crates/jsonrpc-types/Cargo.toml
+++ b/crates/jsonrpc-types/Cargo.toml
@@ -11,8 +11,8 @@ serde = { version = "1.0", features = ["derive"] }
 faster-hex = "0.4"
 gw-types = { path = "../../gwos/crates/types" }
 gw-common = { path = "../../gwos/crates/common" }
-ckb-jsonrpc-types = "0.105.1"
-ckb-fixed-hash = "0.105.1"
+ckb-jsonrpc-types = "0.106"
+ckb-fixed-hash = "0.106"
 anyhow = "1.0"
 serde_repr = "0.1.10"
 serde_json = "1.0.94"

--- a/crates/replay-chain/Cargo.toml
+++ b/crates/replay-chain/Cargo.toml
@@ -19,8 +19,8 @@ gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-rpc-client = { path = "../rpc-client" }
 gw-utils = { path = "../utils" }
 clap = "3"
-ckb-fixed-hash = "0.105.1"
-ckb-types = "0.105.1"
+ckb-fixed-hash = "0.106"
+ckb-types = "0.106"
 anyhow = "1.0"
 thiserror = "1.0"
 lazy_static = "1.4"

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -11,8 +11,8 @@ gw-common = { path = "../../gwos/crates/common" }
 gw-config = { path = "../config" }
 gw-types = { path = "../../gwos/crates/types" }
 gw-jsonrpc-types = { path = "../jsonrpc-types" }
-ckb-fixed-hash = "0.105.1"
-ckb-types = "0.105.1"
+ckb-fixed-hash = "0.106"
+ckb-types = "0.106"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4.14"

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -25,9 +25,9 @@ gw-rpc-client = { path = "../rpc-client" }
 gw-telemetry = { path = "../telemetry" }
 gw-metrics = { path = "../metrics" }
 faster-hex = "0.4"
-ckb-crypto = "0.105.1"
-ckb-fixed-hash = "0.105.1"
-ckb-types = "0.105.1"
+ckb-crypto = "0.106"
+ckb-fixed-hash = "0.106"
+ckb-types = "0.106"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 futures = "0.3.13"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -29,19 +29,19 @@ gw-builtin-binaries = { path = "../builtin-binaries" }
 godwoken-bin = { path = "../godwoken-bin" }
 anyhow = "1.0"
 blake2b-rs = "0.2"
-ckb-vm = { version = "=0.22.0", default-features = false }
+ckb-vm = { version = "=0.22.1", default-features = false }
 thiserror = "1.0"
 lazy_static = "1.4"
 secp256k1 = { version = "0.24", features = ["recovery", "rand-std"] }
 sha3 = "0.10.6"
 hex = "0.4.2"
-ckb-script = "0.105.1"
-ckb-types = "0.105.1"
-ckb-error = "0.105.1"
-ckb-crypto = "0.105.1"
-ckb-hash = "0.105.1"
-ckb-traits = "0.105.1"
-ckb-fixed-hash = "0.105.1"
+ckb-script = "0.106"
+ckb-types = "0.106"
+ckb-error = "0.106"
+ckb-crypto = "0.106"
+ckb-hash = "0.106"
+ckb-traits = "0.106"
+ckb-fixed-hash = "0.106"
 rand = "0.8"
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -18,14 +18,14 @@ lazy_static = "1.4"
 secp256k1 = "0.24"
 sha3 = "0.10.6"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
-ckb-jsonrpc-types = "0.105.1"
-ckb-types = "0.105.1"
-ckb-resource = "0.105.1"
-ckb-hash = "0.105.1"
-ckb-fixed-hash = "0.105.1"
-ckb-crypto = "0.105.1"
-ckb-traits = "0.105.1"
-ckb-dao-utils = "0.105.1"
+ckb-jsonrpc-types = "0.106"
+ckb-types = "0.106"
+ckb-resource = "0.106"
+ckb-hash = "0.106"
+ckb-fixed-hash = "0.106"
+ckb-crypto = "0.106"
+ckb-traits = "0.106"
+ckb-dao-utils = "0.106"
 gw-types = { path = "../../gwos/crates/types" }
 gw-config = { path = "../config" }
 gw-common = { path = "../../gwos/crates/common" }
@@ -48,8 +48,8 @@ parking_lot = "0.12"
 toml = "0.7.1"
 
 [dev-dependencies]
-ckb-chain-spec = "0.105.1"
-ckb-script = "0.105.1"
-ckb-mock-tx-types = "0.105.1"
+ckb-chain-spec = "0.106"
+ckb-script = "0.106"
+ckb-mock-tx-types = "0.106"
 
 [features]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,14 +15,14 @@ gw-jsonrpc-types = { path = "../jsonrpc-types" }
 gw-store = { path = "../store" }
 anyhow = "1.0"
 faster-hex = "0.4"
-ckb-crypto = "0.105.1"
+ckb-crypto = "0.106"
 sha2 = "0.10.6"
 sha3 = "0.10.6"
 secp256k1 = "0.24"
 log = "0.4"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
-ckb-types = "0.105.1"
-ckb-chain-spec = "0.105.1"
+ckb-types = "0.106"
+ckb-chain-spec = "0.106"
 tokio = "1"
 zstd = "0.11.2"
 ethabi = { version = "18.0.0", default-features = false, features = ["thiserror", "std"] }

--- a/gwos-evm/polyjuice-tests/Cargo.toml
+++ b/gwos-evm/polyjuice-tests/Cargo.toml
@@ -22,8 +22,8 @@ gw-builtin-binaries = { path = "../../crates/builtin-binaries" }
 ####
 #Sync patch version with godwoken core.
 tracing = { version = "0.1.36", features = ["attributes"] } 
-ckb-vm = { version = "=0.22.0", default-features = false }
-ckb-vm-aot = { version = "=0.22.0" }
+ckb-vm = { version = "=0.22.1", default-features = false }
+ckb-vm-aot = { version = "=0.22" }
 ####
 
 lazy_static = "1.4"

--- a/gwos-evm/polyjuice-tests/fuzz/gw-syscall-simulator/Cargo.toml
+++ b/gwos-evm/polyjuice-tests/fuzz/gw-syscall-simulator/Cargo.toml
@@ -17,8 +17,8 @@ gw-utils     = { path = "../../../../crates/utils/" }
 gw-config    = { path = "../../../../crates/config/", features = ["no-builtin"] }
 gw-traits    = { path = "../../../../crates/traits/" }
 
-ckb-vm = { version = "=0.22.0", default-features = false }
-ckb-vm-aot = { version = "=0.22.0" }
+ckb-vm = { version = "=0.22.1", default-features = false }
+ckb-vm-aot = { version = "=0.22" }
 once_cell = "1.14.0"
 anyhow = "1.0"
 hex = "0.4"

--- a/gwos/crates/types/Cargo.toml
+++ b/gwos/crates/types/Cargo.toml
@@ -15,8 +15,8 @@ deprecated = []
 molecule = { version = "0.7.3", default-features = false }
 cfg-if = "1"
 gw-hash = { path = "../hash", default-features = false }
-ckb-fixed-hash = { version = "0.105.1", optional = true }
-ckb-types = { version = "0.105.1", default-features = false, optional = true }
+ckb-fixed-hash = { version = "0.106", optional = true }
+ckb-types = { version = "0.106", default-features = false, optional = true }
 primitive-types = { version = "0.12", default-features = false, features = [ "impl-serde", "impl-rlp" ] }
 
 [build-dependencies]

--- a/web3/Cargo.lock
+++ b/web3/Cargo.lock
@@ -535,18 +535,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-channel"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0da1f4e474de48b05e30ad603da4da3b410344b619c7cf35d444e406c0bb6e"
+checksum = "5e718dfa7098b0bcce95c7fa573d96aad2f4c3ac886b6f35053f40c5e4894156"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "ckb-error"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51748ac5e08dce6c685cf4b43e27dcbcfc98e21442c4001c9f06509a04a400ed"
+checksum = "fd512b729186e6fa991b588647646e230db7728f71ba16087af21bded12ceb09"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d665013dbb8ff2df8e67c4add67db703ae3b642679f1a2962f76399703eee1"
+checksum = "8eba8f7006a63ad0945412012c89af6ad09d9b2b02962a869d0158a298fa8eca"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd92b9d691bbfd11a900ee17ad1010a553ae0b5d3a120e0c8094afcd30f9b15e"
+checksum = "44b15b464d37d8deeb66046011b3e01e642103b27d4752db4e74740ded732c73"
 dependencies = [
  "faster-hex 0.6.1",
  "serde",
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24e42b82da4d891ac8b5b19de2807cae360c5377138a7cde377b60edc6ec953"
+checksum = "61e86358f6eb595a0e6a2a5ef96d54d4c56e0a4bf822934d7b1fe9904b7208e4"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b64eff869839aff45741515540e81a0447926d79262a439b5e9d0a5c98ac95"
+checksum = "038ad6840c4a89f4cd76b50621c4e6d82ca5f0d09fba707b1025016218d4a2d8"
 dependencies = [
  "blake2b-ref 0.2.1",
  "blake2b-rs",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82268ddea09f95324496d6def1b37d6bdc3a4841fecc185388e7a2bb6451687f"
+checksum = "eca123e0b725e487cd49f202097c38c73c2a4d7e1c80d89549c492f058e84f29"
 dependencies = [
  "ckb-types",
  "faster-hex 0.6.1",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11e010c034a98b734074a79655c738c40501e9113426173132856a35c6e71c6"
+checksum = "94f6c146d51b1b7f65511e6f16ef21b0d852aececc4ae87f78c3099c03e246a9"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -630,18 +630,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e48f0306a3fe072711e0342b71335898ac6d0a82b897ca3ae13e43770ce0e0"
+checksum = "507187824418c845b519c64521b34578570b5851d170ff0101bc477ed0cdee2b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656db5615c791b8d7b31a38e024f98fb497be5e2cb120b38be48eb4d9d1d0f6d"
+checksum = "17825cb1ec37c5ad2f2c6690aa4cbfeb9a6d2af02463a66b1fa013e4f9e762aa"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rational"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444926bc5a9ad789b2b98e75f90330bcfe741bab517ca45d8f084449fe35efd8"
+checksum = "fa5edf5377138c9457015a450b1a263996d100a5b6e21566157f410e1a5b95b3"
 dependencies = [
  "numext-fixed-uint",
  "serde",
@@ -660,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-types"
-version = "0.105.1"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06812497491fa58cea1c93dda2de074e0c5d51cf7d70d93dd50c862c661494c"
+checksum = "8f9f918d7f04fed733c528ec98ba8bdee31a885bd082e6ff263ca21d58e01378"
 dependencies = [
  "bit-vec",
  "bytes 1.1.0",

--- a/web3/crates/indexer/Cargo.toml
+++ b/web3/crates/indexer/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 gw-types = { path = "../../../gwos/crates/types" }
 gw-common = { path = "../../../gwos/crates/common" }
 gw-jsonrpc-types = { path = "../../../crates/jsonrpc-types" }
-ckb-hash = "0.105.1"
-ckb-types = "0.105.1"
+ckb-hash = "0.106"
+ckb-types = "0.106"
 anyhow = { version = "1.0", features = ["backtrace"] }
 smol = "1.2.5"
 thiserror = "1.0"

--- a/web3/crates/rpc-client/Cargo.toml
+++ b/web3/crates/rpc-client/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
-ckb-jsonrpc-types = "0.105.1"
-ckb-types = "0.105.1"
+ckb-jsonrpc-types = "0.106"
+ckb-types = "0.106"
 gw-types = { path = "../../../gwos/crates/types" }
 gw-common = { path = "../../../gwos/crates/common" }
 gw-jsonrpc-types = { path = "../../../crates/jsonrpc-types" }


### PR DESCRIPTION
upgrade ckb* crates to v0.106 because v0.105.1 has been yanked. For example: https://crates.io/crates/ckb-types/0.105.1
And ckb-vm should be upgraded as well.