### PR TITLE
feat: disable resetting submission txs by default

### DIFF
--- a/crates/block-producer/src/psc.rs
+++ b/crates/block-producer/src/psc.rs
@@ -800,7 +800,10 @@ async fn confirm_block(
     drop(snap);
     // Use a timeout if there is room for fee rate bumping.
     let timeout = if context.psc_config.max_fee_rate > context.psc_config.min_fee_rate {
-        Some(Duration::from_secs(context.psc_config.confirm_timeout_secs))
+        context
+            .psc_config
+            .confirm_timeout_secs
+            .map(Duration::from_secs)
     } else {
         None
     };

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -187,8 +187,9 @@ pub struct PscConfig {
     pub max_fee_rate: u64,
     pub fee_rate_pid: Option<Pid<f64>>,
     pub fee_rate_pid_interval_secs: u64,
-    /// Bump fee rate if a transaction cannot be confirmed after the specified duration.
-    pub confirm_timeout_secs: u64,
+    /// Reset submission txs if a tx cannot be confirmed after the specified duration.
+    /// It's not very reliable. Don't use in prod.
+    pub confirm_timeout_secs: Option<u64>,
 }
 
 impl Default for PscConfig {
@@ -201,7 +202,7 @@ impl Default for PscConfig {
             min_fee_rate: 1000,
             max_fee_rate: 1100,
             fee_rate_pid_interval_secs: 10,
-            confirm_timeout_secs: 120,
+            confirm_timeout_secs: None,
         }
     }
 }


### PR DESCRIPTION
feat: Reset submission txs if a tx cannot be confirmed after the specified duration.

This feature is not very reliable. So we disable it by making confirm_timeout_secs optional and None.