### PR TITLE
fix: Cancel zero address as the default from address

### DIFF
--- a/web3/packages/api-server/src/base/gw-config.ts
+++ b/web3/packages/api-server/src/base/gw-config.ts
@@ -1,4 +1,4 @@
-import { utils, HexNumber, Script, HexString, Hash } from "@ckb-lumos/base";
+import { utils, HexNumber, Script, HexString } from "@ckb-lumos/base";
 import {
   BackendInfo,
   EoaScript,
@@ -15,11 +15,10 @@ import {
   GodwokenClient,
   NodeInfo as GwNodeInfo,
 } from "@godwoken-web3/godwoken";
-import { CKB_SUDT_ID, ZERO_ETH_ADDRESS } from "../methods/constant";
+import { CKB_SUDT_ID } from "../methods/constant";
 import { Uint32 } from "./types/uint";
 import { snakeToCamel } from "../util";
 import { EntryPointContract } from "../gasless/entrypoint";
-import { BaseEthRegistryAddress } from "./base-eth-registry-address";
 import { logger } from "./logger";
 
 // source: https://github.com/nervosnetwork/godwoken/commit/d6c98d8f8a199b6ec29bc77c5065c1108220bb0a#diff-c56fda2ca3b1366049c88e633389d9b6faa8366151369fd7314c81f6e389e5c7R5
@@ -430,33 +429,6 @@ function toConfigEoaScripts(nodeInfo: NodeInfo) {
 function toApiNodeInfo(nodeInfo: GwNodeInfo): NodeInfo {
   // todo: use determinable converting to replace snakeToCamel
   return snakeToCamel(nodeInfo, ["code_hash", "hash_type"]);
-}
-
-async function _zeroAddressAccount(
-  rpc: GodwokenClient,
-  registryId: number
-): Promise<AccountWithAddress | undefined> {
-  const registryAddress = new BaseEthRegistryAddress(
-    ZERO_ETH_ADDRESS,
-    registryId
-  );
-  const scriptHash: Hash | undefined = await rpc.getScriptHashByRegistryAddress(
-    registryAddress.serialize()
-  );
-  if (scriptHash == null) {
-    return undefined;
-  }
-
-  const id = await rpc.getAccountIdByScriptHash(scriptHash);
-  if (id == null) {
-    return undefined;
-  }
-
-  return {
-    id: "0x" + id.toString(16),
-    scriptHash,
-    address: ZERO_ETH_ADDRESS,
-  };
 }
 
 async function findFirstEoaAccountId(

--- a/web3/packages/api-server/src/base/gw-config.ts
+++ b/web3/packages/api-server/src/base/gw-config.ts
@@ -237,11 +237,6 @@ export class GwConfig {
   private async fetchDefaultFromAccount(
     registryId: number
   ): Promise<AccountWithAddress> {
-    const zeroAddressInfo = await zeroAddressAccount(this.rpc, registryId);
-    if (zeroAddressInfo != null) {
-      return zeroAddressInfo;
-    }
-
     const ethAccountLockTypeHash = this.nodeInfo.eoaScripts.find(
       (s) => s.eoaType === EoaScriptType.Eth
     )?.typeHash;
@@ -437,7 +432,7 @@ function toApiNodeInfo(nodeInfo: GwNodeInfo): NodeInfo {
   return snakeToCamel(nodeInfo, ["code_hash", "hash_type"]);
 }
 
-async function zeroAddressAccount(
+async function _zeroAddressAccount(
   rpc: GodwokenClient,
   registryId: number
 ): Promise<AccountWithAddress | undefined> {

--- a/web3/packages/api-server/src/base/gw-config.ts
+++ b/web3/packages/api-server/src/base/gw-config.ts
@@ -231,7 +231,6 @@ export class GwConfig {
     return new Account(regIdHex, scriptHash);
   }
 
-  // Using zero address firstly
   // we search the first account id = 3, if it is eoa account, use it, otherwise continue with id + 1;
   private async fetchDefaultFromAccount(
     registryId: number

--- a/web3/packages/api-server/tests/utils/config.test.ts
+++ b/web3/packages/api-server/tests/utils/config.test.ts
@@ -41,6 +41,24 @@ mockRpc.getAccountIdByScriptHash = async (scriptHash: HexString) => {
   }
 };
 
+mockRpc.getRegistryAddressByScriptHash = async (
+  scriptHash: HexString,
+  registryId: number
+) => {
+  switch (scriptHash) {
+    case "0x5df8df09ec23819836b888f575ca4154a2af1f1d4720bca91a5fc9f5f7d9921f":
+      return {
+        registry_id: "0x" + registryId.toString(16),
+        address: "0xFb2C72d3ffe10Ef7c9960272859a23D24db9e04A",
+      };
+
+    default:
+      throw new Error(
+        `getRegistryAddressByScriptHash not mock for script hash ${scriptHash}`
+      );
+  }
+};
+
 mockRpc.getScriptHash = async (accountId: number) => {
   switch (accountId) {
     case 4:
@@ -211,8 +229,7 @@ test("init gw config", async (t) => {
     },
   });
   t.is(config.accounts.polyjuiceCreator.id, "0x4");
-  // Using zero address as default address
-  t.is(config.accounts.defaultFrom.id, "0x5");
+  t.is(config.accounts.defaultFrom.id, "0x3");
   t.is(config.accounts.ethAddrReg.id, "0x2");
   t.is(config.nodeMode, NodeMode.FullNode);
   t.is(config.web3ChainId, "0x116e8");


### PR DESCRIPTION
Related:
- https://github.com/godwokenrises/godwoken/issues/1067

zero address deposited in godwoken block 372398, so when `eth_call` requires execute before this block and use zero address as default from will failed

So using first EOA account as default from address will resolve the problem