### PR TITLE
Bump version to v1.14.0 rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [Unreleased]
 
+## [v1.14.0-rc1] - 2023-05-26
+
+Bug fixes:
+
+* fix: Cancel zero address as the default from address https://github.com/godwokenrises/godwoken/pull/1073
+* fix: fix re-syncing race condition https://github.com/godwokenrises/godwoken/pull/1066
+* feat: timeout for rpc serve https://github.com/godwokenrises/godwoken/pull/1060
+* fix: from > to should compare with number type, not string https://github.com/godwokenrises/godwoken/pull/1063
+
+Full Changelog: https://github.com/godwokenrises/godwoken/compare/v1.13.0…v1.14.0-rc1
+
 ## [v1.13.0] - 2023-04-25
 
 Upgrades:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [v1.14.0-rc1] - 2023-05-26
 
+Features:
+
+* feat: timeout for rpc serve https://github.com/godwokenrises/godwoken/pull/1060
+
 Bug fixes:
 
 * fix: Cancel zero address as the default from address https://github.com/godwokenrises/godwoken/pull/1073
 * fix: fix re-syncing race condition https://github.com/godwokenrises/godwoken/pull/1066
-* feat: timeout for rpc serve https://github.com/godwokenrises/godwoken/pull/1060
 * fix: from > to should compare with number type, not string https://github.com/godwokenrises/godwoken/pull/1063
 
 Full Changelog: https://github.com/godwokenrises/godwoken/compare/v1.13.0…v1.14.0-rc1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "c-uint256-tests"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "cc",
  "cty",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "godwoken-bin"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-types",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "gw-benches"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "gw-block-producer"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "gw-builtin-binaries"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "gw-chain"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "gw-challenge"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "gw-common"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "gw-config"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "ckb-fixed-hash",
  "gw-builtin-binaries",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "gw-generator"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1923,14 +1923,14 @@ dependencies = [
 
 [[package]]
 name = "gw-hash"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "blake2b-ref 0.3.1",
 ]
 
 [[package]]
 name = "gw-jsonrpc-types"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "gw-mem-pool"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "gw-metrics"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "arc-swap",
  "gw-common",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "gw-p2p-network"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "gw-polyjuice-sender-recover"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "gw-common",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "gw-replay-chain"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-client"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-server"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "gw-smt"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "gw-store"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "gw-telemetry"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "chrono",
  "faster-hex 0.6.1",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tests"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tools"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2270,7 +2270,7 @@ dependencies = [
 
 [[package]]
 name = "gw-traits"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "gw-common",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "gw-tx-filter"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "gw-common",
  "gw-config",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "gw-types"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "cfg-if 1.0.0",
  "ckb-fixed-hash",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "gw-utils"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-chain-spec",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "gw-version"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
 ]

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-benches"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 description = "Godwoken benchmarks."

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-block-producer"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/builtin-binaries/Cargo.toml
+++ b/crates/builtin-binaries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-builtin-binaries"
-version = "1.13.0"
+version = "1.14.0-rc1"
 edition = "2021"
 authors = ["Godwoken"]
 license = "MIT"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-chain"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/challenge/Cargo.toml
+++ b/crates/challenge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-challenge"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-config"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-generator"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/godwoken-bin/Cargo.toml
+++ b/crates/godwoken-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godwoken-bin"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/jsonrpc-types/Cargo.toml
+++ b/crates/jsonrpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-jsonrpc-types"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/mem-pool/Cargo.toml
+++ b/crates/mem-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-mem-pool"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-metrics"
-version = "1.13.0"
+version = "1.14.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/p2p-network/Cargo.toml
+++ b/crates/p2p-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-p2p-network"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/polyjuice-sender-recover/Cargo.toml
+++ b/crates/polyjuice-sender-recover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-polyjuice-sender-recover"
-version = "1.13.0"
+version = "1.14.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/replay-chain/Cargo.toml
+++ b/crates/replay-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-replay-chain"
-version = "1.13.0"
+version = "1.14.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-client"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-rpc-server"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2021"
 

--- a/crates/smt/Cargo.toml
+++ b/crates/smt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-smt"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-store"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-telemetry"
-version = "1.13.0"
+version = "1.14.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tests"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2021"
 

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tools"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/traits/Cargo.toml
+++ b/crates/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-traits"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/tx-filter/Cargo.toml
+++ b/crates/tx-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-tx-filter"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-utils"
-version = "1.13.0"
+version = "1.14.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-version"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/gwos/crates/c-uint256-tests/Cargo.toml
+++ b/gwos/crates/c-uint256-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-uint256-tests"
-version = "1.13.0"
+version = "1.14.0-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/gwos/crates/common/Cargo.toml
+++ b/gwos/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-common"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/gwos/crates/hash/Cargo.toml
+++ b/gwos/crates/hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-hash"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/gwos/crates/types/Cargo.toml
+++ b/gwos/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-types"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/web3/Cargo.lock
+++ b/web3/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "gw-common"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -1322,14 +1322,14 @@ dependencies = [
 
 [[package]]
 name = "gw-hash"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "blake2b-ref 0.3.1",
 ]
 
 [[package]]
 name = "gw-jsonrpc-types"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "gw-types"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "cfg-if 1.0.0",
  "ckb-fixed-hash",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "gw-web3-indexer"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-hash",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "gw-web3-rpc-client"
-version = "1.13.0"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "async-jsonrpc-client",

--- a/web3/crates/indexer/Cargo.toml
+++ b/web3/crates/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-web3-indexer"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/web3/crates/rpc-client/Cargo.toml
+++ b/web3/crates/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gw-web3-rpc-client"
-version = "1.13.0"
+version = "1.14.0-rc1"
 authors = ["Nervos Network"]
 edition = "2021"
 

--- a/web3/package.json
+++ b/web3/package.json
@@ -30,6 +30,6 @@
     "eslint": "^8.5.0",
     "prettier": "^2.2.1"
   },
-  "version": "1.13.0",
+  "version": "1.14.0-rc1",
   "author": "hupeng <bitrocks.hu@gmail.com>"
 }

--- a/web3/packages/api-server/package.json
+++ b/web3/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@godwoken-web3/api-server",
-  "version": "1.13.0",
+  "version": "1.14.0-rc1",
   "private": true,
   "scripts": {
     "start": "concurrently \"tsc -w\" \"nodemon ./bin/cluster\"",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@ckb-lumos/base": "0.18.0-rc6",
     "@ckb-lumos/toolkit": "0.18.0-rc6",
-    "@godwoken-web3/godwoken": "1.13.0",
+    "@godwoken-web3/godwoken": "1.14.0-rc1",
     "@ethersproject/bignumber": "^5.7.0",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/exporter-jaeger": "^1.8.0",

--- a/web3/packages/godwoken/package.json
+++ b/web3/packages/godwoken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@godwoken-web3/godwoken",
-  "version": "1.13.0",
+  "version": "1.14.0-rc1",
   "private": true,
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## [v1.14.0-rc1] - 2023-05-26

Bug fixes:

* fix: Cancel zero address as the default from address https://github.com/godwokenrises/godwoken/pull/1073
* fix: fix re-syncing race condition https://github.com/godwokenrises/godwoken/pull/1066
* feat: timeout for rpc serve https://github.com/godwokenrises/godwoken/pull/1060
* fix: from > to should compare with number type, not string https://github.com/godwokenrises/godwoken/pull/1063

Full Changelog: https://github.com/godwokenrises/godwoken/compare/v1.13.0…1.14-rc