### PR TITLE
Verify raw tx format when send raw transaction

### DIFF
--- a/web3/packages/api-server/src/methods/modules/eth.ts
+++ b/web3/packages/api-server/src/methods/modules/eth.ts
@@ -68,9 +68,9 @@ import {
   getSignature,
   polyTxToGwTx,
   polyjuiceRawTransactionToApiTransaction,
-  PolyjuiceTransaction,
   ethCallTxToGodwokenRawTx,
 } from "../../convert-tx";
+import { PolyjuiceTransaction } from "../../rlp";
 import { ethAddressToAccountId, EthRegistryAddress } from "../../base/address";
 import { keccakFromString } from "ethereumjs-util";
 import { DataCacheConstructor, RedisDataCache } from "../../cache/data";
@@ -212,7 +212,7 @@ export class Eth {
     this.sendRawTransaction = middleware(
       this.sendRawTransaction.bind(this),
       1,
-      [validators.hexString]
+      [validators.rawTransaction]
     );
 
     //

--- a/web3/packages/api-server/src/methods/modules/gw.ts
+++ b/web3/packages/api-server/src/methods/modules/gw.ts
@@ -34,10 +34,8 @@ import {
 import { InvalidParamsError } from "../error";
 import { gwConfig, readonlyPriceOracle } from "../../base";
 import { META_CONTRACT_ID } from "../constant";
-import {
-  PolyjuiceTransaction,
-  recoverEthAddressFromPolyjuiceTx,
-} from "../../convert-tx";
+import { PolyjuiceTransaction } from "../../rlp";
+import { recoverEthAddressFromPolyjuiceTx } from "../../convert-tx";
 import { isGaslessTransaction } from "../../gasless/utils";
 
 export class Gw {

--- a/web3/packages/api-server/src/rlp.ts
+++ b/web3/packages/api-server/src/rlp.ts
@@ -1,0 +1,59 @@
+import { HexNumber, HexString } from "@ckb-lumos/base";
+import { rlp } from "ethereumjs-util";
+
+export interface PolyjuiceTransaction {
+  nonce: HexNumber;
+  gasPrice: HexNumber;
+  gasLimit: HexNumber;
+  to: HexString;
+  value: HexNumber;
+  data: HexString;
+  v: HexNumber;
+  r: HexString;
+  s: HexString;
+}
+
+export function toRlpNumber(num: HexNumber): bigint {
+  return num === "0x" ? 0n : BigInt(num);
+}
+
+export function decodeEthRawTx(ethRawTx: HexString): PolyjuiceTransaction {
+  const result: Buffer[] = rlp.decode(ethRawTx) as Buffer[];
+  if (result.length !== 9) {
+    throw new Error("decode eth raw transaction data error");
+  }
+
+  // todo: r might be "0x" which cause inconvenient for down-stream
+  const resultHex = result.map((r) => "0x" + Buffer.from(r).toString("hex"));
+  const [nonce, gasPrice, gasLimit, to, value, data, v, r, s] = resultHex;
+  return {
+    nonce,
+    gasPrice,
+    gasLimit,
+    to,
+    value,
+    data,
+    v,
+    r,
+    s,
+  };
+}
+
+export function encodePolyjuiceTransaction(tx: PolyjuiceTransaction) {
+  const { nonce, gasPrice, gasLimit, to, value, data, v, r, s } = tx;
+
+  const beforeEncode = [
+    toRlpNumber(nonce),
+    toRlpNumber(gasPrice),
+    toRlpNumber(gasLimit),
+    to,
+    toRlpNumber(value),
+    data,
+    toRlpNumber(v),
+    toRlpNumber(r),
+    toRlpNumber(s),
+  ];
+
+  const result = rlp.encode(beforeEncode);
+  return "0x" + result.toString("hex");
+}

--- a/web3/packages/api-server/tests/methods/validators.test.ts
+++ b/web3/packages/api-server/tests/methods/validators.test.ts
@@ -1,0 +1,45 @@
+import test from "ava";
+
+import { validators } from "../../src/methods/validator";
+import { InvalidParamsError } from "../../src/methods/error";
+
+test("validators.rawTransaction's s with leading zeros", (t) => {
+  const originRawTx =
+    "0xf8680485174876e8008302f1c8940000000000000000000000000000000000000000808083022df4a0aa4567c44b378929018ebd3100716f288dd17f616ff9418d7ef0341f3aef4ca0a00013d2f7290ba5aff8911b28871c8e6b624117a711dea4f1484e0dc9d587d60a";
+
+  const params = [originRawTx];
+
+  const result = validators.rawTransaction(params, 0);
+
+  t.true(result instanceof InvalidParamsError);
+  t.is(
+    result?.message,
+    "invalid argument 0: rlp: non-canonical integer (leading zero bytes) for s, receive: 0x0013d2f7290ba5aff8911b28871c8e6b624117a711dea4f1484e0dc9d587d60a"
+  );
+});
+
+test("validators.rawTranaction's r with leading zeros", (t) => {
+  const originRawTx =
+    "0xf8680485174876e8008302f45b940000000000000000000000000000000000000000808083022df4a000330af14634c7d18125258707de6b115ff990743d5c5fac35089e54ea4dfd60a01a9186f9b620063219709aadb6857f88702aa03d94850199c80d39ec090897a2";
+
+  const params = [originRawTx];
+
+  const result = validators.rawTransaction(params, 0);
+
+  t.true(result instanceof InvalidParamsError);
+  t.is(
+    result?.message,
+    "invalid argument 0: rlp: non-canonical integer (leading zero bytes) for r, receive: 0x00330af14634c7d18125258707de6b115ff990743d5c5fac35089e54ea4dfd60"
+  );
+});
+
+test("validators.rawTransaction valid", (t) => {
+  const originRawTx =
+    "0xf8670485174876e8008302f45b940000000000000000000000000000000000000000808083022df49f330af14634c7d18125258707de6b115ff990743d5c5fac35089e54ea4dfd60a01a9186f9b620063219709aadb6857f88702aa03d94850199c80d39ec090897a2";
+
+  const params = [originRawTx];
+
+  const result = validators.rawTransaction(params, 0);
+
+  t.is(result, undefined);
+});


### PR DESCRIPTION
Will reject tx with invalid RLP format

```json
{
    "jsonrpc": "2.0",
    "id": 2,
    "error": {
        "code": -32602,
        "message": "invalid argument 0: rlp: non-canonical integer (leading zero bytes) for s, receive: 0x0013d2f7290ba5aff8911b28871c8e6b624117a711dea4f1484e0dc9d587d60a"
    }
}
```